### PR TITLE
feat(auth): add lazy token cipher and Valkey session core with absolute cap

### DIFF
--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:32b8bbd3429418d5b3f2eabe2d63d39773580fddf3d3fd31ce23e46dca0e0a23"
+content_hash = "sha256:e6ce894bf2ef7fa6fc4486c407c62701e0c4ea2df5ffa7ab1d66bd1575b69fd7"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -182,6 +182,107 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+requires_python = ">=3.10"
+summary = "Foreign Function Interface for Python calling C code."
+groups = ["default"]
+marker = "platform_python_implementation != \"PyPy\""
+dependencies = [
+    "pycparser; implementation_name != \"PyPy\"",
+]
+files = [
+    {file = "cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e"},
+    {file = "cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479"},
+    {file = "cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458"},
+    {file = "cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b"},
+    {file = "cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a"},
+    {file = "cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384"},
+    {file = "cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a"},
+    {file = "cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2"},
+    {file = "cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512"},
+    {file = "cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326"},
+    {file = "cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd"},
+    {file = "cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb"},
+    {file = "cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94"},
+    {file = "cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629"},
+    {file = "cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6"},
+    {file = "cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853"},
+    {file = "cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9"},
+    {file = "cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
+    {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 requires_python = ">=3.10"
@@ -205,6 +306,65 @@ marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+requires_python = "!=3.9.0,!=3.9.1,>=3.9"
+summary = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+groups = ["default"]
+dependencies = [
+    "cffi>=2.0.0; platform_python_implementation != \"PyPy\"",
+    "typing-extensions>=4.13.2; python_full_version < \"3.11\"",
+]
+files = [
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
 ]
 
 [[package]]
@@ -751,6 +911,18 @@ groups = ["dev"]
 files = [
     {file = "pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9"},
     {file = "pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"},
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+requires_python = ">=3.10"
+summary = "C parser in Python"
+groups = ["default"]
+marker = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
 
 [[package]]

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "Samuel Carson", email = "samuel.carson@gmail.com"},
 ]
-dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.115.12,<0.116", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=7.1.0"]
+dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.115.12,<0.116", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=7.1.0", "cryptography>=49.0.0"]
 requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}

--- a/app/backend/src/fastapi_app/core/session.py
+++ b/app/backend/src/fastapi_app/core/session.py
@@ -1,0 +1,76 @@
+# ABOUTME: Server-side Valkey sessions — sliding idle TTL + 30-day absolute cap (m2-eve-sso design spec §4.2; plan decision D4).
+# ABOUTME: get_current_session 401s on absence; get_optional_session returns None.
+import json
+import secrets
+import time
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request, status
+from redis.asyncio import Redis
+
+from .config import get_settings
+from .dependencies import get_cache
+
+
+def _session_key(sid: str) -> str:
+    return f"session:{sid}"
+
+
+async def create_session(
+    redis: Redis,
+    *,
+    user_id: int,
+    character_id: int,
+    character_name: str,
+    now: Optional[int] = None,
+) -> str:
+    s = get_settings()
+    now = int(time.time()) if now is None else now
+    sid = secrets.token_urlsafe(32)   # 256-bit, minted only post-auth (fixation defense)
+    payload = {
+        "user_id": user_id,
+        "character_id": character_id,
+        "character_name": character_name,
+        "created_at": now,   # int Unix epoch seconds (UTC)
+    }
+    await redis.set(_session_key(sid), json.dumps(payload), ex=s.SESSION_IDLE_TTL_SECONDS)
+    return sid
+
+
+async def read_session(redis: Redis, sid: str, *, now: Optional[int] = None) -> Optional[dict]:
+    s = get_settings()
+    now = int(time.time()) if now is None else now
+    key = _session_key(sid)
+    raw = await redis.getex(key, ex=s.SESSION_IDLE_TTL_SECONDS)  # atomic read + idle renew (D4)
+    if raw is None:
+        return None
+    payload = json.loads(raw)
+    deadline = payload["created_at"] + s.SESSION_ABSOLUTE_TTL_SECONDS
+    if now >= deadline:
+        await redis.delete(key)   # over the 30-day cap: delete in the same request
+        return None
+    remaining = deadline - now
+    if remaining < s.SESSION_IDLE_TTL_SECONDS:
+        await redis.expire(key, remaining)  # never outlive the absolute cap
+    return payload
+
+
+async def destroy_session(redis: Redis, sid: str) -> None:
+    await redis.delete(_session_key(sid))
+
+
+async def get_current_session(request: Request, redis: Redis = Depends(get_cache)) -> dict:
+    sid = request.cookies.get(get_settings().SESSION_COOKIE_NAME)
+    if not sid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    payload = await read_session(redis, sid)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    return payload
+
+
+async def get_optional_session(request: Request, redis: Redis = Depends(get_cache)) -> Optional[dict]:
+    sid = request.cookies.get(get_settings().SESSION_COOKIE_NAME)
+    if not sid:
+        return None
+    return await read_session(redis, sid)

--- a/app/backend/src/fastapi_app/core/token_cipher.py
+++ b/app/backend/src/fastapi_app/core/token_cipher.py
@@ -1,0 +1,34 @@
+# ABOUTME: Lazy Fernet/MultiFernet token encryption built from TOKEN_CIPHER_KEYS.
+# ABOUTME: Empty/whitespace-only key config surfaces as not-configured, never a boot crash (m2-eve-sso design spec §3.4).
+from typing import List
+
+from cryptography.fernet import Fernet, MultiFernet
+
+from .config import get_settings
+
+
+def parse_cipher_keys(raw: str) -> List[str]:
+    """Split on comma, strip each element, drop empties. Whitespace-only ⇒ []."""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def is_token_cipher_configured() -> bool:
+    raw = get_settings().TOKEN_CIPHER_KEYS.get_secret_value()
+    return bool(parse_cipher_keys(raw))
+
+
+def _build_cipher() -> MultiFernet:
+    # Rebuilt per call: construction is cheap, encrypt/decrypt run only at
+    # login/refresh frequency, and keys may rotate between calls — do not memoize.
+    keys = parse_cipher_keys(get_settings().TOKEN_CIPHER_KEYS.get_secret_value())
+    if not keys:
+        raise RuntimeError("TOKEN_CIPHER_KEYS is not configured")
+    return MultiFernet([Fernet(k) for k in keys])
+
+
+def encrypt_token(plaintext: str) -> str:
+    return _build_cipher().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_token(ciphertext: str) -> str:
+    return _build_cipher().decrypt(ciphertext.encode()).decode()

--- a/app/backend/src/fastapi_app/tests/core/test_session.py
+++ b/app/backend/src/fastapi_app/tests/core/test_session.py
@@ -1,0 +1,155 @@
+# ABOUTME: Session create/read/renew/cap/destroy against the fake Valkey with injected clocks.
+# ABOUTME: Covers both FastAPI deps: get_current_session (401s) and get_optional_session (None).
+import json
+
+import pytest
+
+from fastapi_app.core import session as sess
+from fastapi_app.core.config import settings
+from fastapi_app.tests.fake_redis import FakeRedis
+
+IDLE = settings.SESSION_IDLE_TTL_SECONDS       # 604800
+ABSOLUTE = settings.SESSION_ABSOLUTE_TTL_SECONDS  # 2592000
+
+
+@pytest.mark.asyncio
+async def test_create_then_read_renews_idle_window():
+    r = FakeRedis()
+    now = 1_000_000
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=now)
+    key = f"session:{sid}"
+    assert r.ttl_for(key) == IDLE
+    # Degrade the TTL first so the post-read IDLE assertion observes the renewal
+    # itself — straight after create it would hold even if read never renewed.
+    await r.expire(key, 123)
+    assert r.ttl_for(key) == 123
+    payload = await sess.read_session(r, sid, now=now + 100)
+    assert payload["character_id"] == 91
+    assert payload["created_at"] == now
+    assert r.ttl_for(key) == IDLE            # GETEX renewed the idle window
+
+
+@pytest.mark.asyncio
+async def test_read_caps_ttl_so_key_never_outlives_absolute_deadline():
+    r = FakeRedis()
+    created = 1_000_000
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
+    key = f"session:{sid}"
+    # 100s before the 30-day deadline: renewal must cap at 100, not idle (604800).
+    now = created + ABSOLUTE - 100
+    payload = await sess.read_session(r, sid, now=now)
+    assert payload is not None
+    assert r.ttl_for(key) == 100
+
+
+@pytest.mark.asyncio
+async def test_read_over_absolute_cap_deletes_and_returns_none():
+    r = FakeRedis()
+    created = 1_000_000
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
+    key = f"session:{sid}"
+    now = created + ABSOLUTE + 1     # one second past the hard cap
+    assert await sess.read_session(r, sid, now=now) is None
+    assert await r.exists(key) == 0  # over-cap session deleted in the same request
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_at_absolute_cap_deletes_and_returns_none():
+    r = FakeRedis()
+    created = 1_000_000
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
+    key = f"session:{sid}"
+    # Exactly at the deadline: session lifetime is [created, created+ABSOLUTE),
+    # so now == deadline is already expired (pins the >= boundary).
+    now = created + ABSOLUTE
+    assert await sess.read_session(r, sid, now=now) is None
+    assert await r.exists(key) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_missing_returns_none():
+    r = FakeRedis()
+    assert await sess.read_session(r, "nope", now=1) is None
+
+
+@pytest.mark.asyncio
+async def test_destroy_deletes_the_key():
+    r = FakeRedis()
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=1)
+    await sess.destroy_session(r, sid)
+    assert await r.exists(f"session:{sid}") == 0
+
+
+@pytest.mark.asyncio
+async def test_created_at_is_integer_epoch_seconds():
+    r = FakeRedis()
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=1_700_000_000)
+    stored = json.loads(r.store[f"session:{sid}"])
+    assert stored["created_at"] == 1_700_000_000
+    assert isinstance(stored["created_at"], int)
+
+
+@pytest.mark.asyncio
+async def test_get_current_session_401_without_cookie():
+    from types import SimpleNamespace
+    from fastapi import HTTPException
+    r = FakeRedis()
+    request = SimpleNamespace(cookies={}, app=SimpleNamespace(state=SimpleNamespace(redis=r)))
+    with pytest.raises(HTTPException) as exc:
+        await sess.get_current_session(request, redis=r)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_current_session_401_with_stale_cookie():
+    # Cookie present but no matching session in Valkey (expired or bogus sid):
+    # read_session returns None and the dependency must still 401.
+    from types import SimpleNamespace
+    from fastapi import HTTPException
+    r = FakeRedis()
+    request = SimpleNamespace(cookies={settings.SESSION_COOKIE_NAME: "bogus-sid"})
+    with pytest.raises(HTTPException) as exc:
+        await sess.get_current_session(request, redis=r)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_current_session_sources_redis_through_get_cache_which_503s():
+    # Wiring assertion first: the dependency seam must BE get_cache (the shared
+    # 503-when-cache-absent contract), not an ad-hoc redis source — asserting only
+    # get_cache's own behavior would pass even if the session dep dropped the seam.
+    import inspect
+    from types import SimpleNamespace
+    from fastapi import HTTPException
+    from fastapi import params as fastapi_params
+    from fastapi_app.core.dependencies import get_cache
+
+    redis_param = inspect.signature(sess.get_current_session).parameters["redis"]
+    assert isinstance(redis_param.default, fastapi_params.Depends)
+    assert redis_param.default.dependency is get_cache
+
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    with pytest.raises(HTTPException) as exc:
+        await get_cache(request)
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_get_optional_session_none_without_cookie():
+    from types import SimpleNamespace
+    r = FakeRedis()
+    request = SimpleNamespace(cookies={})
+    assert await sess.get_optional_session(request, redis=r) is None
+
+
+@pytest.mark.asyncio
+async def test_get_optional_session_returns_payload_for_valid_cookie():
+    import time
+    from types import SimpleNamespace
+    r = FakeRedis()
+    # Real-clock now is fine here: only "created within the last 30 days" matters,
+    # and expiry semantics are already pinned by read_session's injected-clock tests.
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=int(time.time()))
+    request = SimpleNamespace(cookies={settings.SESSION_COOKIE_NAME: sid})
+    payload = await sess.get_optional_session(request, redis=r)
+    assert payload is not None and payload["character_id"] == 91

--- a/app/backend/src/fastapi_app/tests/core/test_token_cipher.py
+++ b/app/backend/src/fastapi_app/tests/core/test_token_cipher.py
@@ -1,0 +1,72 @@
+# ABOUTME: Fernet/MultiFernet parse + round-trip + rotation + not-configured behavior.
+# ABOUTME: Wrong-key decrypt raises InvalidToken — the re-auth trigger — never a silent success.
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from fastapi_app.core import token_cipher as tc
+
+
+def test_parse_keys_rules():
+    assert tc.parse_cipher_keys("") == []
+    assert tc.parse_cipher_keys("   \n ") == []          # whitespace-only ⇒ not configured
+    assert tc.parse_cipher_keys("k1\n") == ["k1"]        # stray trailing newline stripped
+    assert tc.parse_cipher_keys("k1, k2 ,k3") == ["k1", "k2", "k3"]
+    assert tc.parse_cipher_keys("k1,,k2") == ["k1", "k2"]  # empty elements dropped
+
+
+def test_not_configured_when_empty(monkeypatch):
+    from fastapi_app.core.config import settings
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("  \n "))
+    assert tc.is_token_cipher_configured() is False
+    with pytest.raises(RuntimeError):
+        tc.encrypt_token("hello")   # lazy build raises, never a boot crash
+
+
+def test_round_trip_with_configured_key(monkeypatch):
+    from fastapi_app.core.config import settings
+    from pydantic import SecretStr
+    key = Fernet.generate_key().decode()
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(key))
+    assert tc.is_token_cipher_configured() is True
+    ct = tc.encrypt_token("refresh-token-abc")
+    assert ct != "refresh-token-abc"          # ciphertext != plaintext
+    assert tc.decrypt_token(ct) == "refresh-token-abc"
+
+
+def test_multifernet_rotation_decrypts_old_ciphertext(monkeypatch):
+    from fastapi_app.core.config import settings
+    from pydantic import SecretStr
+    old = Fernet.generate_key().decode()
+    new = Fernet.generate_key().decode()
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(old))
+    ct_old = tc.encrypt_token("token")
+    # rotate: new primary first, old kept for decrypt
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(f"{new}, {old}"))
+    assert tc.decrypt_token(ct_old) == "token"          # still decryptable
+    ct_new = tc.encrypt_token("token")
+    # Mechanism assertion: the NEW primary produced ct_new. (ct_new != ct_old would be
+    # vacuous — Fernet embeds a random IV, so any two encryptions differ regardless.)
+    assert Fernet(new).decrypt(ct_new.encode()) == b"token"
+    with pytest.raises(InvalidToken):
+        Fernet(old).decrypt(ct_new.encode())
+
+
+def test_wrong_key_decrypt_raises_invalid_token(monkeypatch):
+    from fastapi_app.core.config import settings
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    ct = tc.encrypt_token("token")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    with pytest.raises(InvalidToken):
+        tc.decrypt_token(ct)
+
+
+def test_malformed_key_is_configured_but_fails_loudly(monkeypatch):
+    from fastapi_app.core.config import settings
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("not-a-valid-fernet-key"))
+    assert tc.is_token_cipher_configured() is True   # non-empty config counts as configured
+    with pytest.raises(ValueError) as exc:
+        tc.encrypt_token("x")
+    assert "not-a-valid-fernet-key" not in str(exc.value)   # no key material in the error

--- a/app/backend/src/fastapi_app/tests/fake_redis.py
+++ b/app/backend/src/fastapi_app/tests/fake_redis.py
@@ -1,0 +1,64 @@
+# ABOUTME: In-memory async Valkey double for session + SSO-state tests (decode_responses=True).
+# ABOUTME: Extends the _FakeLockRedis precedent with get/set(ex)/getex/getdel/delete/exists + TTL.
+from typing import Dict, Optional
+
+
+class FakeRedis:
+    """Minimal async Valkey. Values are str (house pattern: decode_responses=True).
+
+    Deliberately mirrors real Redis semantics: SET without EX makes the key
+    persistent (any recorded TTL is cleared), and EXPIRE with ttl <= 0 deletes the key.
+    """
+
+    def __init__(self) -> None:
+        self.store: Dict[str, str] = {}
+        self.ttls: Dict[str, int] = {}   # last-set TTL per key, for test assertions
+
+    async def get(self, key: str) -> Optional[str]:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: Optional[int] = None, nx: bool = False):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        if ex is not None:
+            self.ttls[key] = ex
+        else:
+            self.ttls.pop(key, None)
+        return True
+
+    async def getex(self, key: str, ex: Optional[int] = None) -> Optional[str]:
+        value = self.store.get(key)
+        if value is not None and ex is not None:
+            self.ttls[key] = ex
+        return value
+
+    async def getdel(self, key: str) -> Optional[str]:
+        self.ttls.pop(key, None)
+        return self.store.pop(key, None)   # atomic single-use consume
+
+    async def expire(self, key: str, ttl: int) -> bool:
+        if key in self.store:
+            if ttl <= 0:
+                del self.store[key]
+                self.ttls.pop(key, None)
+                return True
+            self.ttls[key] = ttl
+            return True
+        return False
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                del self.store[key]
+                self.ttls.pop(key, None)
+                removed += 1
+        return removed
+
+    async def exists(self, key: str) -> int:
+        return 1 if key in self.store else 0
+
+    def ttl_for(self, key: str) -> Optional[int]:
+        """Test-only introspection of the last-applied TTL."""
+        return self.ttls.get(key)

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -68,8 +68,8 @@ notes and commit messages.
 |---|---|---|---|
 | 0 — CI workflow | ✅ CI GREEN — [PR #25](https://github.com/scarson/hangar-bay/pull/25) OPEN, awaiting Sam's codex gate + merge | `b5b2509`, `d23f243`, `6e45f6c`, `d1ae530` | first live run green; hardened per per-phase review; DISC-EXEC-1 flake fixed |
 | 1 — Settings consolidation | ✅ CI GREEN — [PR #26](https://github.com/scarson/hangar-bay/pull/26) OPEN (stacked on #25), awaiting Sam's codex gate | `eda6d08`, `e89158b` | spec review byte-exact; quality review APPROVED after 6 fixes; first CI attempt = transient GitHub startup failure (zero jobs), rerun green |
-| 2 — Data model | ✅ IMPLEMENTED — commit local on `claude/m2-phase2-model`, not pushed / no PR opened (dispatch instructions withheld push+PR) | `f382f8d` | stacked on `claude/m2-phase1-settings`; DISC-EXEC-3 comment fix |
-| 3 — Token cipher + session core | ⬜ Not started | — | — |
+| 2 — Data model | ✅ IMPLEMENTED — [PR #27](https://github.com/scarson/hangar-bay/pull/27) OPEN (stacked on #26), awaiting CI + codex gate | `f382f8d`, `0451750`, `7c7933d` | spec review byte-level clean (DISC-EXEC-3 adjudicated); quality APPROVED, 5 minors applied |
+| 3 — Token cipher + session core | 🚧 IN PROGRESS (claimed 2026-07-13T03:01Z, `claude/m2-phase3-cipher-session`) | — | stacked on `claude/m2-phase2-model` |
 | 4 — SSO service | ⬜ Not started | — | — |
 | 5 — Auth service + schemas | ⬜ Not started | — | — |
 | 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
@@ -631,7 +631,7 @@ git commit -m "refactor(config): consolidate the two Settings classes into core/
 
 ## Phase 2 — Data model
 
-**Execution Status:** ✅ IMPLEMENTED — commit `f382f8d` on `claude/m2-phase2-model` (stacked on `claude/m2-phase1-settings`), 2026-07-13. Not pushed, no PR opened (dispatch instructions withheld push/PR — Sam/coordinator to push and open the phase PR). Per-phase review, PR open, and CI still outstanding.
+**Execution Status:** ✅ IMPLEMENTED — PR #27 OPEN (stacked on #26; awaiting CI + codex gate). Shipped `f382f8d` (model + gate + tests), `0451750` (quality-review test strengthening), `7c7933d` (architecture-overview listing fix). Spec review byte-level clean (DISC-EXEC-3 adjudicated); quality review APPROVED, 2026-07-13.
 
 **Goal:** Replace the legacy `User` stub with the SSO `User` model (BigInteger `character_id` + token-vault columns), delete `common_models.py`, finish the `alembic/env.py` import swap (D1), and gate `create_db_tables()` to development-only (spec §4.5).
 
@@ -857,7 +857,7 @@ git commit -m "feat(auth): add SSO User model, delete legacy stub, gate dev-only
 
 ## Phase 3 — Token cipher + session core
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS — claimed 2026-07-13T03:01Z on `claude/m2-phase3-cipher-session` (stacked on `claude/m2-phase2-model`)
 
 **Goal:** Lazy Fernet/MultiFernet token cipher (spec §3.4) + Valkey session core with sliding idle TTL and 30-day absolute cap (§4.2), plus the in-memory fake Valkey test double the rest of M2 uses.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -69,7 +69,7 @@ notes and commit messages.
 | 0 — CI workflow | ✅ CI GREEN — [PR #25](https://github.com/scarson/hangar-bay/pull/25) OPEN, awaiting Sam's codex gate + merge | `b5b2509`, `d23f243`, `6e45f6c`, `d1ae530` | first live run green; hardened per per-phase review; DISC-EXEC-1 flake fixed |
 | 1 — Settings consolidation | ✅ CI GREEN — [PR #26](https://github.com/scarson/hangar-bay/pull/26) OPEN (stacked on #25), awaiting Sam's codex gate | `eda6d08`, `e89158b` | spec review byte-exact; quality review APPROVED after 6 fixes; first CI attempt = transient GitHub startup failure (zero jobs), rerun green |
 | 2 — Data model | ✅ IMPLEMENTED — [PR #27](https://github.com/scarson/hangar-bay/pull/27) OPEN (stacked on #26), awaiting CI + codex gate | `f382f8d`, `0451750`, `7c7933d` | spec review byte-level clean (DISC-EXEC-3 adjudicated); quality APPROVED, 5 minors applied |
-| 3 — Token cipher + session core | 🚧 IN PROGRESS (claimed 2026-07-13T03:01Z, `claude/m2-phase3-cipher-session`) | — | stacked on `claude/m2-phase2-model` |
+| 3 — Token cipher + session core | ✅ IMPLEMENTED — PR pending push (stacked on #27) | `d264cdd`, `755fb0c` | spec review byte-exact; quality ISSUES→APPROVED after 8 fixes incl. two mutation-proven test-pinning gaps |
 | 4 — SSO service | ⬜ Not started | — | — |
 | 5 — Auth service + schemas | ⬜ Not started | — | — |
 | 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
@@ -857,7 +857,7 @@ git commit -m "feat(auth): add SSO User model, delete legacy stub, gate dev-only
 
 ## Phase 3 — Token cipher + session core
 
-**Execution Status:** 🚧 IN PROGRESS — claimed 2026-07-13T03:01Z on `claude/m2-phase3-cipher-session` (stacked on `claude/m2-phase2-model`)
+**Execution Status:** ✅ IMPLEMENTED — shipped `d264cdd` (cryptography dep) + `755fb0c` (cipher, fake Valkey, session core; 85 tests). Spec review byte-exact; quality review ISSUES→APPROVED, 2026-07-13 — notable: mutation probes proved the sliding-renewal and exact-cap boundary were unpinned pre-fix; both now covered, and the fake's SET/EXPIRE semantics were tightened to real-Redis behavior before Phase 6 reuses it for the SSO state store.
 
 **Goal:** Lazy Fernet/MultiFernet token cipher (spec §3.4) + Valkey session core with sliding idle TTL and 30-day absolute cap (§4.2), plus the in-memory fake Valkey test double the rest of M2 uses.
 


### PR DESCRIPTION
Phase 3 of the M2 EVE SSO plan: the encryption and session heart of the login feature.

- `core/token_cipher.py`: lazy Fernet/MultiFernet keyring from `TOKEN_CIPHER_KEYS` — comma-split/strip/drop-empties parse, empty ⇒ not-configured (never a boot crash), first key encrypts, all keys decrypt (rotation-ready), rebuilt per call (documented no-memoize rationale). Errors carry no key material (test-pinned, including the malformed-key surface).
- `core/session.py`: opaque 256-bit sids minted only post-auth; sliding 7-day idle window via atomic `GETEX`, 30-day absolute cap enforced on the payload's `created_at` with same-request `DEL` at/past the deadline, and a conditional `EXPIRE` inside the final idle window so the key never outlives the cap (plan decision D4). `get_current_session` (401) / `get_optional_session` (None) both source Valkey through the shared `get_cache` 503 seam (wiring test-pinned).
- `tests/fake_redis.py`: in-memory async Valkey double with TTL bookkeeping; `GETDEL` atomic, and `SET`-without-ex / `EXPIRE<=0` semantics deliberately mirrored from real Redis — it gets reused for the SSO state store in Phase 6.
- 18 tests (85 total, pristine, deterministic across repeated runs), all on injected clocks — no timing-bound assertions.

Pipeline: implementer → spec review (all five files byte-identical to the plan) → quality review with MUTATION PROBES, which proved two silent pinning gaps (a renewal-free `read_session` and a `>`-flipped cap boundary both passed the original suite) — 8 fixes applied and both mutations re-run by implementer AND reviewer, each now failing at exactly its targeted test → re-review APPROVED.

**Stacked on #27** (Phase 2 data model). Per the merge-gate overlay: **leaving open** for the /codex gate.

## Merge classification

Review — domain (security: crypto/session core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)