### PR TITLE
feat(auth): add auth service — user upsert, token vault, refresh-on-demand

### DIFF
--- a/app/backend/src/fastapi_app/schemas/auth.py
+++ b/app/backend/src/fastapi_app/schemas/auth.py
@@ -1,0 +1,9 @@
+# ABOUTME: Pydantic response schema for GET /me — the SPA's only identity source.
+from pydantic import BaseModel, ConfigDict
+
+
+class CurrentUserSchema(BaseModel):
+    character_id: int
+    character_name: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -2,11 +2,14 @@
 # ABOUTME: Hangar Bay data follows the character on owner-hash change (F004 Criterion 1.6, §4.1).
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core import token_cipher
+from ..core.config import get_settings
 from ..models import User
+from . import sso
 from .sso import VerifiedIdentity
 
 
@@ -43,4 +46,44 @@ async def mark_for_reauth(db: AsyncSession, user: User) -> None:
     user.esi_access_token = None
     user.esi_refresh_token = None
     user.esi_access_token_expires_at = None
+    await db.flush()
+
+
+async def refresh_user_tokens(db: AsyncSession, http_client: "httpx.AsyncClient", user: User) -> None:
+    """Refresh a user's ESI tokens on demand (§4.3). Persists the returned refresh
+    token when the response carries one; keeps the stored one when it doesn't
+    (§2.7: rotation is optional). Only an invalid-grant-shaped 400 — or a vault
+    entry the current keyring cannot decrypt (§7) — marks the user for re-auth
+    (nulls the esi_* columns); 5xx and transport failures re-raise with the vault
+    untouched. No M2 endpoint calls this — M3's token-using caller does."""
+    from cryptography.fernet import InvalidToken
+
+    from ..core import token_cipher
+    s = get_settings()
+    if user.esi_refresh_token is None:
+        # Zero-scope logins bank no refresh token (D-DELTA-2): already the re-auth state.
+        await mark_for_reauth(db, user)
+        return
+    try:
+        refresh_token = token_cipher.decrypt_token(user.esi_refresh_token)
+    except InvalidToken:
+        # Rotated-away/wrong keyring: treated as missing tokens (§7), never a 500.
+        await mark_for_reauth(db, user)
+        return
+    try:
+        tokens = await sso.refresh_token_pair(
+            http_client, refresh_token=refresh_token, token_url=s.ESI_SSO_TOKEN_URL,
+            client_id=s.ESI_CLIENT_ID, client_secret=s.ESI_CLIENT_SECRET.get_secret_value(),
+        )
+    except sso.SsoTokenError as exc:
+        if exc.status_code == 400:   # invalid-grant shape: the grant itself is dead
+            await mark_for_reauth(db, user)
+            return
+        raise                        # outage (5xx/transport): surface it, keep the vault
+    now = datetime.now(timezone.utc)
+    user.esi_access_token = token_cipher.encrypt_token(tokens["access_token"])
+    returned_refresh = tokens.get("refresh_token")
+    if returned_refresh is not None:
+        user.esi_refresh_token = token_cipher.encrypt_token(returned_refresh)  # persist rotation
+    user.esi_access_token_expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
     await db.flush()

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -1,0 +1,46 @@
+# ABOUTME: User upsert (owner-hash transfer rule) + token encrypt/store + invalid-grant nulling.
+# ABOUTME: Hangar Bay data follows the character on owner-hash change (F004 Criterion 1.6, §4.1).
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core import token_cipher
+from ..models import User
+from .sso import VerifiedIdentity
+
+
+async def upsert_user(db: AsyncSession, identity: VerifiedIdentity, tokens: dict) -> User:
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
+    user = (
+        await db.execute(select(User).where(User.character_id == identity.character_id))
+    ).scalar_one_or_none()
+
+    if user is None:
+        user = User(character_id=identity.character_id)
+        db.add(user)
+
+    # Owner-hash transfer: on mismatch we update in place — data follows the character.
+    user.character_name = identity.character_name
+    user.owner_hash = identity.owner_hash
+    user.esi_access_token = token_cipher.encrypt_token(tokens["access_token"])
+    # Zero-scope logins carry no refresh_token key (D-DELTA-2); store NULL, never "".
+    refresh_token = tokens.get("refresh_token")
+    user.esi_refresh_token = (
+        token_cipher.encrypt_token(refresh_token) if refresh_token is not None else None
+    )
+    user.esi_access_token_expires_at = expires_at
+    user.last_login_at = now
+
+    await db.flush()
+    return user
+
+
+async def mark_for_reauth(db: AsyncSession, user: User) -> None:
+    """Invalid-grant handling (§4.3): null the esi_* columns only.
+    The session-invalidation half is deferred to M3's token-using caller."""
+    user.esi_access_token = None
+    user.esi_refresh_token = None
+    user.esi_access_token_expires_at = None
+    await db.flush()

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -1,0 +1,73 @@
+# ABOUTME: User upsert (create + owner-hash transfer), token encryption, invalid-grant nulling.
+# ABOUTME: Refresh-on-demand: rotation persistence, outages keep the vault, wrong-key/empty-vault re-auth.
+import pytest
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+from sqlalchemy import select
+
+from fastapi_app.core import token_cipher as tc
+from fastapi_app.core.config import settings
+from fastapi_app.models import User
+from fastapi_app.services import auth_service
+from fastapi_app.services.sso import VerifiedIdentity
+
+
+@pytest.fixture(autouse=True)
+def _configured_cipher(monkeypatch):
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+
+
+def _tokens():
+    # Zero-scope (F004/M2) wire shape: no refresh_token key at all (D-DELTA-2).
+    return {"access_token": "AT", "expires_in": 1200}
+
+
+def _tokens_with_refresh():
+    # M3-shaped response — scoped grants return refresh tokens; kept as tested foundation.
+    return {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200}
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_user_and_encrypts_tokens(db_session):
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    assert user.character_id == 91000001
+    assert user.character_name == "Sesta Hound"
+    assert user.owner_hash == "OWN1"
+    assert user.esi_access_token != "AT"                      # ciphertext, not plaintext
+    assert tc.decrypt_token(user.esi_access_token) == "AT"    # round-trips
+    assert user.esi_refresh_token is None                     # zero scopes ⇒ no refresh token stored
+    assert user.esi_access_token_expires_at is not None
+    assert user.last_login_at is not None
+
+
+@pytest.mark.asyncio
+async def test_upsert_encrypts_refresh_token_when_present(db_session):
+    # M3-shaped grant: when a refresh token IS returned, it is encrypted and round-trips.
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens_with_refresh())
+    assert user.esi_refresh_token != "RT"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"
+
+
+@pytest.mark.asyncio
+async def test_upsert_transfers_owner_hash_on_mismatch(db_session):
+    ident1 = VerifiedIdentity(character_id=91000001, character_name="Old Name", owner_hash="OWN1")
+    await auth_service.upsert_user(db_session, ident1, _tokens())
+    ident2 = VerifiedIdentity(character_id=91000001, character_name="New Name", owner_hash="OWN2")
+    user = await auth_service.upsert_user(db_session, ident2, {"access_token": "AT2", "expires_in": 1200})
+    rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
+    assert len(rows) == 1                          # updated in place, no duplicate row
+    assert user.owner_hash == "OWN2"               # ownership transferred
+    assert user.character_name == "New Name"
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+
+
+@pytest.mark.asyncio
+async def test_mark_for_reauth_nulls_esi_columns(db_session):
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    await auth_service.mark_for_reauth(db_session, user)
+    assert user.esi_access_token is None
+    assert user.esi_refresh_token is None
+    assert user.esi_access_token_expires_at is None

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -71,3 +71,103 @@ async def test_mark_for_reauth_nulls_esi_columns(db_session):
     assert user.esi_access_token is None
     assert user.esi_refresh_token is None
     assert user.esi_access_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, httpx_mock):
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1200})
+    httpx_mock.add_response(
+        url=settings.ESI_SSO_TOKEN_URL,
+        json={"access_token": "AT2", "refresh_token": "RT_ROTATED", "expires_in": 1200},
+    )
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT_ROTATED"   # rotation persisted
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_invalid_grant_nulls_columns(db_session, httpx_mock):
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, status_code=400, json={"error": "invalid_grant"})
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None
+    assert user.esi_refresh_token is None
+    assert user.esi_access_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_5xx_leaves_columns_and_raises(db_session, httpx_mock):
+    # §4.3: only an invalid-grant-shaped 400 nulls the vault. An EVE outage (5xx)
+    # surfaces to the caller with the encrypted tokens untouched.
+    import httpx
+    from fastapi_app.services import sso
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, status_code=502, json={"error": "bad_gateway"})
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # vault untouched
+    assert user.esi_access_token is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_transport_error_leaves_columns_and_raises(db_session, httpx_mock):
+    import httpx
+    from fastapi_app.services import sso
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_exception(httpx.ConnectError("connection refused"), url=settings.ESI_SSO_TOKEN_URL)
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # vault untouched
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_without_stored_refresh_token_marks_reauth(db_session, httpx_mock):
+    # M2 reality: zero-scope logins bank no refresh token (D-DELTA-2), so M3's caller
+    # will meet users with an empty vault — that IS the needs-re-auth state; no HTTP
+    # call is attempted. httpx_mock is requested WITH NO responses registered so an
+    # accidental request fails loudly and hermetically instead of reaching the network.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None and user.esi_refresh_token is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_wrong_key_vault_marks_reauth(db_session, httpx_mock, monkeypatch):
+    # §7: a vault entry the current keyring cannot decrypt is treated as missing
+    # tokens (re-auth path), never an exception. No responses registered — any
+    # accidental HTTP call fails loudly.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    # Swap the keyring so the stored ciphertexts no longer decrypt.
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None and user.esi_refresh_token is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_response_without_refresh_token_keeps_stored_one(db_session, httpx_mock):
+    # §2.7: rotation is optional — a refresh response with no refresh_token key
+    # updates the access token and keeps the stored refresh token unchanged.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, json={"access_token": "AT2", "expires_in": 1200})
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # unchanged, still decryptable

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -1,5 +1,7 @@
 # ABOUTME: User upsert (create + owner-hash transfer), token encryption, invalid-grant nulling.
 # ABOUTME: Refresh-on-demand: rotation persistence, outages keep the vault, wrong-key/empty-vault re-auth.
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from cryptography.fernet import Fernet
 from pydantic import SecretStr
@@ -37,7 +39,9 @@ async def test_upsert_creates_user_and_encrypts_tokens(db_session):
     assert user.esi_access_token != "AT"                      # ciphertext, not plaintext
     assert tc.decrypt_token(user.esi_access_token) == "AT"    # round-trips
     assert user.esi_refresh_token is None                     # zero scopes ⇒ no refresh token stored
-    assert user.esi_access_token_expires_at is not None
+    # expires_at is now + expires_in (1200s), not a sign-flipped past instant.
+    assert user.esi_access_token_expires_at > datetime.now(timezone.utc) + timedelta(seconds=1000)
+    assert user.esi_access_token_expires_at < datetime.now(timezone.utc) + timedelta(seconds=1300)
     assert user.last_login_at is not None
 
 
@@ -53,13 +57,15 @@ async def test_upsert_encrypts_refresh_token_when_present(db_session):
 @pytest.mark.asyncio
 async def test_upsert_transfers_owner_hash_on_mismatch(db_session):
     ident1 = VerifiedIdentity(character_id=91000001, character_name="Old Name", owner_hash="OWN1")
-    await auth_service.upsert_user(db_session, ident1, _tokens())
+    first = await auth_service.upsert_user(db_session, ident1, _tokens())
+    first_login_at = first.last_login_at
     ident2 = VerifiedIdentity(character_id=91000001, character_name="New Name", owner_hash="OWN2")
     user = await auth_service.upsert_user(db_session, ident2, {"access_token": "AT2", "expires_in": 1200})
     rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
     assert len(rows) == 1                          # updated in place, no duplicate row
     assert user.owner_hash == "OWN2"               # ownership transferred
     assert user.character_name == "New Name"
+    assert user.last_login_at > first_login_at     # re-login refreshes the timestamp in place
     assert tc.decrypt_token(user.esi_access_token) == "AT2"
 
 
@@ -77,7 +83,9 @@ async def test_mark_for_reauth_nulls_esi_columns(db_session):
 async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, httpx_mock):
     import httpx
     ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
-    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1200})
+    # Seed a near-immediate expiry so the post-refresh assertion below can only pass
+    # if the REFRESH advanced it — not by inheriting a long upsert-time expiry.
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1})
     httpx_mock.add_response(
         url=settings.ESI_SSO_TOKEN_URL,
         json={"access_token": "AT2", "refresh_token": "RT_ROTATED", "expires_in": 1200},
@@ -86,6 +94,8 @@ async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, ht
         await auth_service.refresh_user_tokens(db_session, client, user)
     assert tc.decrypt_token(user.esi_access_token) == "AT2"
     assert tc.decrypt_token(user.esi_refresh_token) == "RT_ROTATED"   # rotation persisted
+    # the refreshed access token carries a forward expiry, so M3's caller won't re-hit EVE every request.
+    assert user.esi_access_token_expires_at > datetime.now(timezone.utc) + timedelta(seconds=1000)
 
 
 @pytest.mark.asyncio

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -1695,7 +1695,7 @@ git commit -m "feat(auth): add EVE SSO service — code/refresh grants and JWT v
 
 ## Phase 5 — Auth service + schemas
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-12, branch `claude/m2-phase5-auth-service`)
 
 **Goal:** `services/auth_service.py` (user upsert with the owner-hash transfer rule, token encrypt/store) + `schemas/auth.py` (`CurrentUserSchema`) (spec §4, §4.3).
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -71,7 +71,7 @@ notes and commit messages.
 | 2 — Data model | ✅ IMPLEMENTED — [PR #27](https://github.com/scarson/hangar-bay/pull/27) OPEN (stacked on #26), awaiting CI + codex gate | `f382f8d`, `0451750`, `7c7933d` | spec review byte-level clean (DISC-EXEC-3 adjudicated); quality APPROVED, 5 minors applied |
 | 3 — Token cipher + session core | ✅ IMPLEMENTED — [PR #28](https://github.com/scarson/hangar-bay/pull/28) OPEN (stacked on #27), awaiting CI + codex gate | `d264cdd`, `755fb0c` | spec review byte-exact; quality ISSUES→APPROVED after 8 fixes incl. two mutation-proven test-pinning gaps |
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
-| 5 — Auth service + schemas | ⬜ Not started | — | — |
+| 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
 | 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
 | 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
@@ -1695,7 +1695,7 @@ git commit -m "feat(auth): add EVE SSO service — code/refresh grants and JWT v
 
 ## Phase 5 — Auth service + schemas
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-12, branch `claude/m2-phase5-auth-service`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase5-auth-service`, commits `f2886b3`, `35c73a7`, `ac3919e`) — spec review byte-exact; quality review APPROVED, mutation-proven expiry/last_login assertions added in fix round `ac3919e` (findings 3+5 deferred to the codex-findings hardening PR). 120 pytest green, pristine.
 
 **Goal:** `services/auth_service.py` (user upsert with the owner-hash transfer rule, token encrypt/store) + `schemas/auth.py` (`CurrentUserSchema`) (spec §4, §4.3).
 


### PR DESCRIPTION
## Phase 5 — Auth service + schemas (M2 EVE SSO)

Fifth phase of the M2 EVE SSO login work (F004). Adds the auth-service write path plus the `/me` response schema. This is Sam's own app; standard defensive OAuth — described here in plain correctness terms.

**Stacked position:** base is `dev` (Phases 0–4 merged as #25, #26, #27, #28, #30). No stacked parent open.

### What this adds
- `schemas/auth.py` — `CurrentUserSchema` (`{character_id, character_name}`), the SPA's only identity source (consumed by Phase 6 `/me` and Phase 8's `CurrentUser` alias).
- `services/auth_service.py`:
  - `upsert_user` — create-or-update keyed on `character_id`, with the owner-hash transfer rule (on owner-hash change the row updates in place — Hangar Bay data follows the character, F004 Criterion 1.6). Encrypts the ESI access token into the vault; stores NULL (never `""`) for the refresh token on zero-scope M2 logins (D-DELTA-2).
  - `mark_for_reauth` — nulls the `esi_*` columns only (session-invalidation deferred to M3).
  - `refresh_user_tokens` — refresh-on-demand: persists a returned rotated refresh token, keeps the stored one when the response omits it (rotation is optional), marks re-auth only on an invalid-grant-shaped 400 or an undecryptable vault entry, and re-raises on outage (5xx/transport) with the vault untouched. No M2 endpoint calls it yet — it exists tested as the M3 foundation.

### Tests
`tests/services/test_auth_service.py` — 11 tests (upsert/owner-hash transfer/encryption, invalid-grant nulling, and the full refresh matrix: rotation persistence, optional-rotation, 5xx and transport outages keep the vault, empty-vault and wrong-keyring paths mark re-auth without any HTTP call). Full backend suite: **120 passed, pristine** (zero warnings).

### Review trail
- **Spec-compliance review:** byte-exact against the plan's verbatim Phase 5 blocks; commit structure and trailers verified.
- **Quality review (mutation probes):** APPROVED. Its probes showed the token-expiry arithmetic was unasserted — a sign-flipped upsert expiry, a dropped refresh-expiry advance, and a frozen `last_login_at` all passed the original suite. Fix round `ac3919e` adds three assertions that each provably kill their mutant (verified by re-running the mutants). Two Minor findings (identity-map-only persistence assertion; an `expires_in`-read ordering that pairs with a known `_post_token` field-validation gap in already-merged `sso.py`) are tracked for the standalone codex-findings hardening PR rather than reopening this phase.

## Merge classification
`Review — domain (security: token vault/auth service)` — encrypted ESI token vault and the auth-service write path.

Leaving open for the `/codex` gate per the M2 merge-gate overlay. Do not self-merge.
