### PR TITLE
feat(auth): add SSO login/callback/logout/me routes with state-binding and return-path guards

### DIFF
--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -1,0 +1,204 @@
+# ABOUTME: EVE SSO routes — login, callback, logout, /me — mounted bare (PROXY-1).
+# ABOUTME: state is single-use (GETDEL) AND browser-bound (hb_sso_state cookie) so the callback matches the login this browser started (§7).
+import asyncio
+import functools
+import json
+import secrets
+import time
+from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_settings
+from ..core.dependencies import get_cache, get_http_client
+from ..core.logging import get_logger, log_key_event
+from ..core.session import create_session, destroy_session, get_current_session
+from ..core.token_cipher import is_token_cipher_configured
+from ..db import get_db
+from ..schemas.auth import CurrentUserSchema
+from ..services import auth_service, sso
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/auth/sso", tags=["Auth"])   # bare; SPA reaches via /api/v1/auth/sso/*
+me_router = APIRouter(tags=["Auth"])                    # bare /me
+
+_STATE_TTL_SECONDS = 600
+_STATE_COOKIE = "hb_sso_state"
+
+
+# --- shared not-configured guard (login + callback only) ---
+async def require_sso_configured() -> None:
+    s = get_settings()
+    if not s.ESI_CLIENT_ID or not is_token_cipher_configured():
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="EVE SSO is not configured")
+
+
+# --- pure helpers (unit-tested in test_auth_helpers.py) ---
+def validate_next(value: Optional[str]) -> str:
+    if not value or not value.startswith("/"):
+        return "/"
+    if value.startswith("//"):
+        return "/"                          # protocol-relative
+    if len(value) > 1 and value[1] == "\\":
+        return "/"                          # /\evil.com
+    return value
+
+
+def build_redirect(frontend_origin: str, next_path: str, flag: Optional[str]) -> str:
+    split = urlsplit(next_path)
+    query = parse_qsl(split.query, keep_blank_values=True)
+    if flag is not None:
+        query.append(("sso", flag))
+    rebuilt = urlunsplit(("", "", split.path or "/", urlencode(query), split.fragment))
+    return frontend_origin + rebuilt
+
+
+def _cookie_secure() -> bool:
+    return get_settings().ENVIRONMENT != "development"
+
+
+def _clear_state_cookie(resp: Response) -> None:
+    resp.delete_cookie(_STATE_COOKIE, path="/")
+
+
+# --- routes ---
+@router.get("/login", dependencies=[Depends(require_sso_configured)])
+async def login(request: Request, next: str = "/", redis: Redis = Depends(get_cache)):
+    s = get_settings()
+    validated_next = validate_next(next)
+    state = secrets.token_urlsafe(24)   # 192-bit
+    await redis.set(f"sso_state:{state}", json.dumps({"next": validated_next}), ex=_STATE_TTL_SECONDS)
+    authorize_url = sso.build_authorize_url(
+        state=state, client_id=s.ESI_CLIENT_ID,
+        redirect_uri=s.ESI_SSO_CALLBACK_URL, authorize_url=s.ESI_SSO_AUTHORIZE_URL,
+    )
+    resp = RedirectResponse(authorize_url, status_code=status.HTTP_302_FOUND)
+    resp.set_cookie(
+        _STATE_COOKIE, state, max_age=_STATE_TTL_SECONDS, httponly=True,
+        samesite="lax", secure=_cookie_secure(), path="/",
+    )
+    return resp
+
+
+@functools.lru_cache(maxsize=1)
+def _signing_key_provider() -> jwt.PyJWKClient:
+    """Process-wide PyJWKClient: its JWKS cache (300 s TTL, kid-keyed) must persist
+    across logins — a per-request client would refetch the JWKS on every callback
+    (§3.2). Tests monkeypatch this module attribute, which shadows the cached
+    callable; a test that changes ESI_SSO_JWKS_URI must call
+    _signing_key_provider.cache_clear()."""
+    return jwt.PyJWKClient(get_settings().ESI_SSO_JWKS_URI)
+
+
+@router.get("/callback", dependencies=[Depends(require_sso_configured)])
+async def callback(
+    request: Request,
+    state: Optional[str] = None,
+    code: Optional[str] = None,
+    error: Optional[str] = None,
+    redis: Redis = Depends(get_cache),
+    http_client=Depends(get_http_client),
+    db: AsyncSession = Depends(get_db),
+):
+    s = get_settings()
+    started = time.perf_counter()
+    cookie_state = request.cookies.get(_STATE_COOKIE)
+    stored = None
+    if state:
+        raw = await redis.getdel(f"sso_state:{state}")   # single-use consume
+        if raw is not None:
+            stored = json.loads(raw)
+
+    # (A) EVE-side denial — no session, redirect with sso=denied.
+    # Sanctioned ordering (plan-review round 2): the denial exit precedes the binding
+    # check (C). No session is ever minted on denial, so innocent-user UX (a friendly
+    # redirect) wins over the hard 400; a pinning test covers denial+cookie-mismatch.
+    if error is not None:
+        nxt = validate_next(stored["next"]) if stored else "/"
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, nxt, "denied"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (B) State missing/expired (GETDEL miss) — innocent, redirect with sso=error.
+    if stored is None:
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, "/", "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (C) State live but browser binding fails — the only hard-400 exit (callback doesn't match this browser's login).
+    if cookie_state is None or cookie_state != state:
+        resp = JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"detail": "Invalid SSO state"})
+        _clear_state_cookie(resp)
+        return resp
+
+    validated_next = validate_next(stored["next"])
+
+    # (D) Exchange code — non-200 → sso=error redirect.
+    try:
+        tokens = await sso.exchange_code(
+            http_client, code=code or "", token_url=s.ESI_SSO_TOKEN_URL,
+            client_id=s.ESI_CLIENT_ID, client_secret=s.ESI_CLIENT_SECRET.get_secret_value(),
+        )
+    except sso.SsoTokenError:
+        # Structured failure log (§4.1 step 5) — status/outcome only, no token material (§7).
+        log_key_event(logger, "sso_callback", success=False,
+                      duration_ms=(time.perf_counter() - started) * 1000,
+                      outcome="token_exchange_failed")
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (E) Validate JWT — the JWKS fetch inside is synchronous urllib, so run the whole
+    # validation off the event loop (§3.2). Failure → sso=error redirect.
+    try:
+        provider = _signing_key_provider()
+        identity = await asyncio.to_thread(
+            sso.validate_access_token, tokens["access_token"], key_provider=provider, client_id=s.ESI_CLIENT_ID
+        )
+    except (sso.SsoJwtError, KeyError, jwt.exceptions.PyJWKClientError):
+        # Structured failure log (§4.1 step 6) — outcome only, never the JWT itself (§7).
+        log_key_event(logger, "sso_callback", success=False,
+                      duration_ms=(time.perf_counter() - started) * 1000,
+                      outcome="jwt_validation_failed")
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (F) Upsert + session.
+    user = await auth_service.upsert_user(db, identity, tokens)
+    sid = await create_session(redis, user_id=user.id, character_id=identity.character_id, character_name=identity.character_name)
+    log_key_event(logger, "sso_callback", success=True,
+                  duration_ms=(time.perf_counter() - started) * 1000,
+                  outcome="login", character_id=identity.character_id)
+
+    resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, None), status_code=status.HTTP_302_FOUND)
+    resp.set_cookie(
+        s.SESSION_COOKIE_NAME, sid, max_age=s.SESSION_ABSOLUTE_TTL_SECONDS, httponly=True,
+        samesite="lax", secure=_cookie_secure(), path="/",
+    )
+    _clear_state_cookie(resp)
+    return resp
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(request: Request, redis: Redis = Depends(get_cache)):
+    s = get_settings()
+    sid = request.cookies.get(s.SESSION_COOKIE_NAME)
+    if sid:
+        await destroy_session(redis, sid)   # no-op if already gone (idempotent)
+    resp = Response(status_code=status.HTTP_204_NO_CONTENT)
+    resp.delete_cookie(s.SESSION_COOKIE_NAME, path="/")
+    return resp
+
+
+@me_router.get("/me", response_model=CurrentUserSchema)
+async def me(session: dict = Depends(get_current_session)):
+    # get_current_session 401s when there is no valid session; /me serves from the
+    # session payload alone (no DB read — §4.2).
+    return CurrentUserSchema(character_id=session["character_id"], character_name=session["character_name"])

--- a/app/backend/src/fastapi_app/schemas/auth.py
+++ b/app/backend/src/fastapi_app/schemas/auth.py
@@ -1,0 +1,9 @@
+# ABOUTME: Pydantic response schema for GET /me — the SPA's only identity source.
+from pydantic import BaseModel, ConfigDict
+
+
+class CurrentUserSchema(BaseModel):
+    character_id: int
+    character_name: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -2,11 +2,14 @@
 # ABOUTME: Hangar Bay data follows the character on owner-hash change (F004 Criterion 1.6, §4.1).
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core import token_cipher
+from ..core.config import get_settings
 from ..models import User
+from . import sso
 from .sso import VerifiedIdentity
 
 
@@ -43,4 +46,44 @@ async def mark_for_reauth(db: AsyncSession, user: User) -> None:
     user.esi_access_token = None
     user.esi_refresh_token = None
     user.esi_access_token_expires_at = None
+    await db.flush()
+
+
+async def refresh_user_tokens(db: AsyncSession, http_client: "httpx.AsyncClient", user: User) -> None:
+    """Refresh a user's ESI tokens on demand (§4.3). Persists the returned refresh
+    token when the response carries one; keeps the stored one when it doesn't
+    (§2.7: rotation is optional). Only an invalid-grant-shaped 400 — or a vault
+    entry the current keyring cannot decrypt (§7) — marks the user for re-auth
+    (nulls the esi_* columns); 5xx and transport failures re-raise with the vault
+    untouched. No M2 endpoint calls this — M3's token-using caller does."""
+    from cryptography.fernet import InvalidToken
+
+    from ..core import token_cipher
+    s = get_settings()
+    if user.esi_refresh_token is None:
+        # Zero-scope logins bank no refresh token (D-DELTA-2): already the re-auth state.
+        await mark_for_reauth(db, user)
+        return
+    try:
+        refresh_token = token_cipher.decrypt_token(user.esi_refresh_token)
+    except InvalidToken:
+        # Rotated-away/wrong keyring: treated as missing tokens (§7), never a 500.
+        await mark_for_reauth(db, user)
+        return
+    try:
+        tokens = await sso.refresh_token_pair(
+            http_client, refresh_token=refresh_token, token_url=s.ESI_SSO_TOKEN_URL,
+            client_id=s.ESI_CLIENT_ID, client_secret=s.ESI_CLIENT_SECRET.get_secret_value(),
+        )
+    except sso.SsoTokenError as exc:
+        if exc.status_code == 400:   # invalid-grant shape: the grant itself is dead
+            await mark_for_reauth(db, user)
+            return
+        raise                        # outage (5xx/transport): surface it, keep the vault
+    now = datetime.now(timezone.utc)
+    user.esi_access_token = token_cipher.encrypt_token(tokens["access_token"])
+    returned_refresh = tokens.get("refresh_token")
+    if returned_refresh is not None:
+        user.esi_refresh_token = token_cipher.encrypt_token(returned_refresh)  # persist rotation
+    user.esi_access_token_expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
     await db.flush()

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -1,0 +1,46 @@
+# ABOUTME: User upsert (owner-hash transfer rule) + token encrypt/store + invalid-grant nulling.
+# ABOUTME: Hangar Bay data follows the character on owner-hash change (F004 Criterion 1.6, §4.1).
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core import token_cipher
+from ..models import User
+from .sso import VerifiedIdentity
+
+
+async def upsert_user(db: AsyncSession, identity: VerifiedIdentity, tokens: dict) -> User:
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
+    user = (
+        await db.execute(select(User).where(User.character_id == identity.character_id))
+    ).scalar_one_or_none()
+
+    if user is None:
+        user = User(character_id=identity.character_id)
+        db.add(user)
+
+    # Owner-hash transfer: on mismatch we update in place — data follows the character.
+    user.character_name = identity.character_name
+    user.owner_hash = identity.owner_hash
+    user.esi_access_token = token_cipher.encrypt_token(tokens["access_token"])
+    # Zero-scope logins carry no refresh_token key (D-DELTA-2); store NULL, never "".
+    refresh_token = tokens.get("refresh_token")
+    user.esi_refresh_token = (
+        token_cipher.encrypt_token(refresh_token) if refresh_token is not None else None
+    )
+    user.esi_access_token_expires_at = expires_at
+    user.last_login_at = now
+
+    await db.flush()
+    return user
+
+
+async def mark_for_reauth(db: AsyncSession, user: User) -> None:
+    """Invalid-grant handling (§4.3): null the esi_* columns only.
+    The session-invalidation half is deferred to M3's token-using caller."""
+    user.esi_access_token = None
+    user.esi_refresh_token = None
+    user.esi_access_token_expires_at = None
+    await db.flush()

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -340,3 +340,31 @@ async def test_callback_503_when_cipher_unconfigured_not_500(auth_client, monkey
     monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("   "))   # whitespace ⇒ not configured
     resp = await auth_client.get("/auth/sso/callback", params={"state": "X", "code": "C"}, follow_redirects=False)
     assert resp.status_code == 503     # guard fires before any cipher/exchange — never a 500 from MultiFernet([])
+
+
+@pytest.mark.asyncio
+async def test_logout_works_when_sso_not_configured(auth_client, monkeypatch):
+    # §4.4: logout is intentionally NOT behind the not-configured guard, so an existing
+    # session can always be cleared even when the SSO credentials are absent.
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="X")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    assert await auth_client.fake_redis.exists(f"session:{sid}") == 0
+
+
+@pytest.mark.asyncio
+async def test_me_works_when_sso_not_configured(auth_client, monkeypatch):
+    # §4.4: /me reads only the session payload and is NOT behind the not-configured guard,
+    # so an already-authenticated identity survives SSO being unconfigured.
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="Sesta Hound")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"character_id": 91000001, "character_name": "Sesta Hound"}

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -1,0 +1,342 @@
+# ABOUTME: HTTP-level EVE SSO flow — login params, callback exits, cookies, /me, 503-not-configured.
+# ABOUTME: Every callback exit is driven end-to-end over ASGITransport against the fake Valkey.
+# NOTE: cookies are set on the client JAR (httpx >= 0.28 deprecates per-request cookies=);
+# the auth_client fixture is function-scoped, so jar state cannot leak across tests.
+import json
+import time
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from fastapi_app.core import session as sess
+from fastapi_app.core.config import settings
+
+CLIENT_ID = "test-client"
+TOKEN_URL = settings.ESI_SSO_TOKEN_URL
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+def _sign_access_token(priv, **overrides):
+    now = int(time.time())
+    claims = {
+        "iss": "login.eveonline.com", "sub": "CHARACTER:EVE:91000001",
+        "aud": [CLIENT_ID, "EVE Online"], "name": "Sesta Hound", "owner": "OWN1",
+        "exp": now + 1200, "iat": now,
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, priv, algorithm="RS256", headers={"kid": "JWT-Signature-Key"})
+
+
+def _inject_jwks(monkeypatch, pub):
+    from fastapi_app.api import auth as auth_api
+    monkeypatch.setattr(auth_api, "_signing_key_provider", lambda: SimpleNamespace(
+        get_signing_key_from_jwt=lambda token: SimpleNamespace(key=pub)))
+
+
+async def _seed_state(client, state="STATE123", next_="/contracts?type=bpc&page=2"):
+    await client.fake_redis.set(f"sso_state:{state}", json.dumps({"next": next_}), ex=600)
+
+
+def _session_set_cookie(resp):
+    """The specific hb_session Set-Cookie header. Never assert on the JOINED header
+    string: the hb_sso_state DELETION cookie also carries samesite=lax, which would
+    mask a lost attribute on the session cookie."""
+    cookies = resp.headers.get_list("set-cookie")
+    return next(c for c in cookies if c.startswith(f"{settings.SESSION_COOKIE_NAME}="))
+
+
+# ---------- login ----------
+@pytest.mark.asyncio
+async def test_login_redirects_to_authorize_with_exact_params_and_sets_state(auth_client, configured_sso):
+    resp = await auth_client.get("/auth/sso/login", params={"next": "/contracts"}, follow_redirects=False)
+    assert resp.status_code == 302
+    loc = urlsplit(resp.headers["location"])
+    assert f"{loc.scheme}://{loc.netloc}{loc.path}" == settings.ESI_SSO_AUTHORIZE_URL
+    q = parse_qs(loc.query, keep_blank_values=True)   # parse_qs DROPS blank values by default
+    assert q["response_type"] == ["code"] and q["client_id"] == [CLIENT_ID]
+    assert q["redirect_uri"] == [settings.ESI_SSO_CALLBACK_URL]
+    assert q["scope"] == [""]   # KeyError if scope is missing; must be present AND empty (F004)
+    state = q["state"][0]
+    assert await auth_client.fake_redis.exists(f"sso_state:{state}") == 1
+    assert auth_client.fake_redis.ttl_for(f"sso_state:{state}") == 600
+    set_cookie = resp.headers["set-cookie"].lower()
+    assert "hb_sso_state=" in set_cookie and "httponly" in set_cookie and "max-age=600" in set_cookie
+
+
+@pytest.mark.parametrize("bad", ["//evil.com", "/\\evil.com", "https://evil.com", "javascript:alert(1)", "garbage"])
+@pytest.mark.asyncio
+async def test_login_open_redirect_next_falls_back_to_root(auth_client, configured_sso, bad):
+    resp = await auth_client.get("/auth/sso/login", params={"next": bad}, follow_redirects=False)
+    state = parse_qs(urlsplit(resp.headers["location"]).query)["state"][0]
+    stored = json.loads(await auth_client.fake_redis.get(f"sso_state:{state}"))
+    assert stored["next"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_login_without_next_param_stores_root(auth_client, configured_sso):
+    # Spec §6's "missing" case, pinned over HTTP: FastAPI's query binding of the
+    # `next: str = "/"` default is exactly the layer the pure-helper tests never touch.
+    resp = await auth_client.get("/auth/sso/login", follow_redirects=False)
+    state = parse_qs(urlsplit(resp.headers["location"]).query)["state"][0]
+    stored = json.loads(await auth_client.fake_redis.get(f"sso_state:{state}"))
+    assert stored["next"] == "/"
+
+
+# ---------- callback happy path ----------
+@pytest.mark.asyncio
+async def test_callback_happy_path_creates_user_sets_session_cookie(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session):
+    from sqlalchemy import select
+    from fastapi_app.core import token_cipher as tc
+    from fastapi_app.models import User
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    at = _sign_access_token(priv)
+    # Zero-scope (F004) wire shape: NO refresh_token key (D-DELTA-2).
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": at, "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts?type=bpc&page=2")
+
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?type=bpc&page=2"  # success: no sso flag, & merge
+    assert "hb_session=" in _session_set_cookie(resp)
+    state_clear = next(c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state="))
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()   # binding cookie cleared (§4.1 step 4)
+    user = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalar_one()
+    assert user.esi_access_token != at                       # ciphertext, not plaintext
+    assert tc.decrypt_token(user.esi_access_token) == at     # real Fernet round-trip under the fixture key
+    assert user.esi_refresh_token is None                    # zero scopes ⇒ no refresh token (D-DELTA-2)
+
+
+# ---------- callback binding / state exits ----------
+@pytest.mark.asyncio
+async def test_callback_binding_cookie_missing_hard_400(auth_client, configured_sso):
+    await _seed_state(auth_client)
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 400     # GETDEL hit but no hb_sso_state cookie → binding check fails
+    assert resp.json() == {"detail": "Invalid SSO state"}
+    state_clear = next(c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state="))
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()   # cleared even on the 400 exit
+
+
+@pytest.mark.asyncio
+async def test_callback_binding_cookie_mismatch_hard_400(auth_client, configured_sso):
+    await _seed_state(auth_client)
+    auth_client.cookies.set("hb_sso_state", "DIFFERENT")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_state_missing_redirects_sso_error_no_session(auth_client, configured_sso):
+    auth_client.cookies.set("hb_sso_state", "GONE")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "GONE", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_callback_eve_denial_redirects_sso_denied_merged(auth_client, configured_sso):
+    await _seed_state(auth_client, next_="/contracts?type=bpc&page=2")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?type=bpc&page=2&sso=denied"
+
+
+@pytest.mark.asyncio
+async def test_callback_denial_wins_over_binding_mismatch(auth_client, configured_sso):
+    # Pins the sanctioned ordering (Task 6.2 exit A): denial short-circuits BEFORE the
+    # binding check — no session is minted on denial, so the friendly redirect beats
+    # the hard 400 for an innocent user whose cookie went stale mid-flow.
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "SOMETHING-ELSE")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=denied"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_callback_token_non_200_redirects_sso_error_and_logs_outcome(auth_client, configured_sso, httpx_mock, caplog, capsys):
+    import logging
+    httpx_mock.add_response(url=TOKEN_URL, status_code=400, json={"error": "invalid_grant"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    with caplog.at_level(logging.INFO):
+        resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "BAD"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    # Structured failure log (§4.1 step 5). structlog's test-time sink depends on
+    # whether setup_logging ran (it does not under ASGITransport) — capture BOTH
+    # channels so the assertion is sink-agnostic.
+    combined = caplog.text + capsys.readouterr().out
+    assert "token_exchange_failed" in combined
+
+
+@pytest.mark.asyncio
+async def test_callback_jwt_failure_redirects_sso_error_and_never_logs_the_token(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, caplog, capsys):
+    import logging
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    bad_token = _sign_access_token(priv, iss="evil.example.com")
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": bad_token, "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    with caplog.at_level(logging.INFO):
+        resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    combined = caplog.text + capsys.readouterr().out
+    assert "jwt_validation_failed" in combined
+    assert bad_token not in combined     # §7: never token material in logs
+
+
+@pytest.mark.asyncio
+async def test_callback_unknown_kid_redirects_sso_error_not_500(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch):
+    # A kid miss surfaces as PyJWKClientError inside validation → mapped to SsoJwtError
+    # (Phase 4) → the callback's sso=error redirect, never an unhandled 500.
+    from jwt.exceptions import PyJWKClientError
+    from fastapi_app.api import auth as auth_api
+    priv, _pub = rsa_keypair
+
+    def _raise(token):
+        raise PyJWKClientError("Unable to find a signing key that matches")
+
+    monkeypatch.setattr(auth_api, "_signing_key_provider",
+                        lambda: SimpleNamespace(get_signing_key_from_jwt=_raise))
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302     # not a 500
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+
+
+@pytest.mark.parametrize("evil_next", ["//evil.com", "/\\evil.com"])
+@pytest.mark.asyncio
+async def test_callback_never_yields_protocol_relative_location(auth_client, configured_sso, evil_next):
+    # A malformed or externally-pointing next in Valkey is re-validated at the callback (§7).
+    await auth_client.fake_redis.set("sso_state:STATE123", json.dumps({"next": evil_next}), ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=denied"
+
+
+@pytest.mark.asyncio
+async def test_callback_owner_hash_transfer(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session):
+    from sqlalchemy import select
+    from fastapi_app.models import User
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    # first login
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv, owner="OWN1"), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="S1")
+    auth_client.cookies.set("hb_sso_state", "S1")
+    await auth_client.get("/auth/sso/callback", params={"state": "S1", "code": "C"}, follow_redirects=False)
+    # Second login, new owner hash. Re-set the jar cookie explicitly: the response's
+    # deletion Set-Cookie targets a host-scoped jar entry, NOT the domain-less entry
+    # cookies.set() created, so each callback must set its own binding cookie.
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv, owner="OWN2"), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="S2")
+    auth_client.cookies.set("hb_sso_state", "S2")
+    await auth_client.get("/auth/sso/callback", params={"state": "S2", "code": "C"}, follow_redirects=False)
+    rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
+    assert len(rows) == 1 and rows[0].owner_hash == "OWN2"
+
+
+# ---------- state single-use ([TIMING]) ----------
+@pytest.mark.asyncio
+async def test_state_is_single_use(auth_client, configured_sso):
+    await _seed_state(auth_client, state="ONCE")
+    # First callback: binding MISMATCH → hard 400 — but the GETDEL has already consumed
+    # the state. (A matching cookie here would reach the code exchange, exit (D) —
+    # blocked from the real network by the fixture's structural httpx_mock, but the
+    # test would then fail confusingly at teardown instead of pinning single-use.)
+    auth_client.cookies.set("hb_sso_state", "OTHER")
+    resp1 = await auth_client.get("/auth/sso/callback", params={"state": "ONCE", "code": "C"}, follow_redirects=False)
+    assert resp1.status_code == 400
+    assert await auth_client.fake_redis.exists("sso_state:ONCE") == 0     # consumed even on the 400 exit
+    # Second callback, now with a MATCHING cookie: GETDEL miss → innocent sso=error redirect, NOT a 400.
+    auth_client.cookies.set("hb_sso_state", "ONCE")
+    resp2 = await auth_client.get("/auth/sso/callback", params={"state": "ONCE", "code": "C"}, follow_redirects=False)
+    assert resp2.status_code == 302 and resp2.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+
+
+# ---------- cookie attributes ----------
+@pytest.mark.parametrize("env,expect_secure", [("production", True), ("test", True), ("development", False)])
+@pytest.mark.asyncio
+async def test_session_cookie_attributes_and_secure_flag(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, env, expect_secure):
+    monkeypatch.setattr(settings, "ENVIRONMENT", env)
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="ENVS")
+    auth_client.cookies.set("hb_sso_state", "ENVS")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "ENVS", "code": "C"}, follow_redirects=False)
+    sc = _session_set_cookie(resp).lower()   # ONLY the hb_session cookie — see helper docstring
+    assert "httponly" in sc and "samesite=lax" in sc
+    assert "path=/" in sc
+    assert f"max-age={settings.SESSION_ABSOLUTE_TTL_SECONDS}" in sc   # §4.2: Max-Age = 30-day absolute cap
+    assert ("secure" in sc) is expect_secure
+
+
+# ---------- logout ----------
+@pytest.mark.asyncio
+async def test_logout_is_idempotent_204_and_expires_cookie(auth_client, configured_sso):
+    # no session present → still 204 (not gated behind get_current_session)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    sc = resp.headers.get("set-cookie", "").lower()
+    assert "hb_session=" in sc
+    assert "max-age=0" in sc or "expires=" in sc   # actually EXPIRING, not (re)setting a live value
+
+
+@pytest.mark.asyncio
+async def test_logout_deletes_existing_session(auth_client, configured_sso):
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="X")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    assert await auth_client.fake_redis.exists(f"session:{sid}") == 0
+
+
+# ---------- /me ----------
+@pytest.mark.asyncio
+async def test_me_401_when_anonymous(auth_client, configured_sso):
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_me_200_from_session_payload(auth_client, configured_sso):
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="Sesta Hound")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"character_id": 91000001, "character_name": "Sesta Hound"}
+
+
+# ---------- not-configured (AC-4) ----------
+@pytest.mark.asyncio
+async def test_login_503_when_not_configured(auth_client, monkeypatch):
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    resp = await auth_client.get("/auth/sso/login", follow_redirects=False)
+    assert resp.status_code == 503 and resp.json() == {"detail": "EVE SSO is not configured"}
+
+
+@pytest.mark.asyncio
+async def test_callback_503_when_cipher_unconfigured_not_500(auth_client, monkeypatch):
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "test-client")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("   "))   # whitespace ⇒ not configured
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "X", "code": "C"}, follow_redirects=False)
+    assert resp.status_code == 503     # guard fires before any cipher/exchange — never a 500 from MultiFernet([])

--- a/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
@@ -1,0 +1,36 @@
+# ABOUTME: Unit coverage for the return-path next validator and the query-merge builder.
+# ABOUTME: Pure-function tests — no app or fixtures; redirect targets can never leave FRONTEND_ORIGIN.
+import pytest
+
+from fastapi_app.api.auth import build_redirect, validate_next
+
+
+@pytest.mark.parametrize("bad", ["//evil.com", "/\\evil.com", "https://evil.com", "javascript:alert(1)", "", None, "garbage"])
+def test_validate_next_rejects_dangerous_values(bad):
+    assert validate_next(bad) == "/"
+
+
+@pytest.mark.parametrize("ok", ["/", "/contracts", "/contracts?type=bpc&page=2"])
+def test_validate_next_accepts_safe_paths(ok):
+    assert validate_next(ok) == ok
+
+
+def test_build_redirect_merges_query_without_double_question_mark():
+    out = build_redirect("https://localhost:5173", "/contracts?type=bpc&page=2", flag="denied")
+    assert out == "https://localhost:5173/contracts?type=bpc&page=2&sso=denied"
+
+
+def test_build_redirect_adds_first_query_param():
+    out = build_redirect("https://localhost:5173", "/contracts", flag="error")
+    assert out == "https://localhost:5173/contracts?sso=error"
+
+
+def test_build_redirect_success_has_no_flag():
+    out = build_redirect("https://localhost:5173", "/contracts?page=2", flag=None)
+    assert out == "https://localhost:5173/contracts?page=2"
+
+
+def test_build_redirect_cannot_yield_protocol_relative_location():
+    # next was already validated to "/", so the Location stays under FRONTEND_ORIGIN.
+    out = build_redirect("https://localhost:5173", validate_next("//evil.com"), flag="error")
+    assert out == "https://localhost:5173/?sso=error"

--- a/app/backend/src/fastapi_app/tests/conftest.py
+++ b/app/backend/src/fastapi_app/tests/conftest.py
@@ -156,3 +156,58 @@ async def setup_contracts(db_session: AsyncSession):
     db_session.add_all(contracts_data)
     await db_session.flush()  # Use flush to send data within the test's transaction
     return contracts_data
+
+
+import httpx
+import pytest_asyncio
+from pydantic import SecretStr
+from cryptography.fernet import Fernet
+
+from fastapi_app.tests.fake_redis import FakeRedis
+
+
+@pytest_asyncio.fixture(scope="function")
+async def auth_client(db_session, httpx_mock):
+    """HTTP client over real_app with the auth routers mounted, app.state wired, and get_db overridden.
+    Does NOT configure SSO settings — use the `configured_sso` fixture for happy-path flow tests.
+    Depends on httpx_mock STRUCTURALLY: pytest-httpx patches the async transport class,
+    so app.state.http_client can never reach the real network in ANY auth test — an
+    un-mocked token POST fails loudly instead of leaving the process. (The outer
+    ASGITransport client is a different transport class and is unaffected.) Tests
+    that need token responses request httpx_mock themselves and get the same instance."""
+    from fastapi_app.main import app as real_app
+    from fastapi_app.api import auth as auth_api
+    from fastapi_app.db import get_db as get_db_dep
+
+    n_routes = len(real_app.router.routes)
+    real_app.include_router(auth_api.router)
+    real_app.include_router(auth_api.me_router)
+    real_app.openapi_schema = None
+
+    fake = FakeRedis()
+    real_app.state.redis = fake
+    real_app.state.http_client = httpx.AsyncClient(base_url="http://sso.test")  # pytest-httpx intercepts this
+    real_app.dependency_overrides[get_db_dep] = lambda: db_session
+
+    transport = httpx.ASGITransport(app=real_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        client.fake_redis = fake     # expose to tests for state/session assertions
+        yield client
+
+    await real_app.state.http_client.aclose()
+    del real_app.state.redis
+    del real_app.state.http_client
+    real_app.dependency_overrides.clear()
+    del real_app.router.routes[n_routes:]   # restore routes — main.py stays unmounted (D2)
+    real_app.openapi_schema = None
+
+
+@pytest.fixture
+def configured_sso(monkeypatch):
+    """Configure the settings singleton for a working SSO flow. (Plain pytest fixture —
+    it is synchronous; pytest_asyncio.fixture is reserved for the async auth_client.)"""
+    from fastapi_app.core.config import settings
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "test-client")
+    monkeypatch.setattr(settings, "ESI_CLIENT_SECRET", SecretStr("test-secret"))
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    return settings

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -1,0 +1,73 @@
+# ABOUTME: User upsert (create + owner-hash transfer), token encryption, invalid-grant nulling.
+# ABOUTME: Refresh-on-demand: rotation persistence, outages keep the vault, wrong-key/empty-vault re-auth.
+import pytest
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+from sqlalchemy import select
+
+from fastapi_app.core import token_cipher as tc
+from fastapi_app.core.config import settings
+from fastapi_app.models import User
+from fastapi_app.services import auth_service
+from fastapi_app.services.sso import VerifiedIdentity
+
+
+@pytest.fixture(autouse=True)
+def _configured_cipher(monkeypatch):
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+
+
+def _tokens():
+    # Zero-scope (F004/M2) wire shape: no refresh_token key at all (D-DELTA-2).
+    return {"access_token": "AT", "expires_in": 1200}
+
+
+def _tokens_with_refresh():
+    # M3-shaped response — scoped grants return refresh tokens; kept as tested foundation.
+    return {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200}
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_user_and_encrypts_tokens(db_session):
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    assert user.character_id == 91000001
+    assert user.character_name == "Sesta Hound"
+    assert user.owner_hash == "OWN1"
+    assert user.esi_access_token != "AT"                      # ciphertext, not plaintext
+    assert tc.decrypt_token(user.esi_access_token) == "AT"    # round-trips
+    assert user.esi_refresh_token is None                     # zero scopes ⇒ no refresh token stored
+    assert user.esi_access_token_expires_at is not None
+    assert user.last_login_at is not None
+
+
+@pytest.mark.asyncio
+async def test_upsert_encrypts_refresh_token_when_present(db_session):
+    # M3-shaped grant: when a refresh token IS returned, it is encrypted and round-trips.
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens_with_refresh())
+    assert user.esi_refresh_token != "RT"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"
+
+
+@pytest.mark.asyncio
+async def test_upsert_transfers_owner_hash_on_mismatch(db_session):
+    ident1 = VerifiedIdentity(character_id=91000001, character_name="Old Name", owner_hash="OWN1")
+    await auth_service.upsert_user(db_session, ident1, _tokens())
+    ident2 = VerifiedIdentity(character_id=91000001, character_name="New Name", owner_hash="OWN2")
+    user = await auth_service.upsert_user(db_session, ident2, {"access_token": "AT2", "expires_in": 1200})
+    rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
+    assert len(rows) == 1                          # updated in place, no duplicate row
+    assert user.owner_hash == "OWN2"               # ownership transferred
+    assert user.character_name == "New Name"
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+
+
+@pytest.mark.asyncio
+async def test_mark_for_reauth_nulls_esi_columns(db_session):
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    await auth_service.mark_for_reauth(db_session, user)
+    assert user.esi_access_token is None
+    assert user.esi_refresh_token is None
+    assert user.esi_access_token_expires_at is None

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -71,3 +71,103 @@ async def test_mark_for_reauth_nulls_esi_columns(db_session):
     assert user.esi_access_token is None
     assert user.esi_refresh_token is None
     assert user.esi_access_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, httpx_mock):
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1200})
+    httpx_mock.add_response(
+        url=settings.ESI_SSO_TOKEN_URL,
+        json={"access_token": "AT2", "refresh_token": "RT_ROTATED", "expires_in": 1200},
+    )
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT_ROTATED"   # rotation persisted
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_invalid_grant_nulls_columns(db_session, httpx_mock):
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, status_code=400, json={"error": "invalid_grant"})
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None
+    assert user.esi_refresh_token is None
+    assert user.esi_access_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_5xx_leaves_columns_and_raises(db_session, httpx_mock):
+    # §4.3: only an invalid-grant-shaped 400 nulls the vault. An EVE outage (5xx)
+    # surfaces to the caller with the encrypted tokens untouched.
+    import httpx
+    from fastapi_app.services import sso
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, status_code=502, json={"error": "bad_gateway"})
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # vault untouched
+    assert user.esi_access_token is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_transport_error_leaves_columns_and_raises(db_session, httpx_mock):
+    import httpx
+    from fastapi_app.services import sso
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_exception(httpx.ConnectError("connection refused"), url=settings.ESI_SSO_TOKEN_URL)
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # vault untouched
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_without_stored_refresh_token_marks_reauth(db_session, httpx_mock):
+    # M2 reality: zero-scope logins bank no refresh token (D-DELTA-2), so M3's caller
+    # will meet users with an empty vault — that IS the needs-re-auth state; no HTTP
+    # call is attempted. httpx_mock is requested WITH NO responses registered so an
+    # accidental request fails loudly and hermetically instead of reaching the network.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, _tokens())
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None and user.esi_refresh_token is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_user_tokens_wrong_key_vault_marks_reauth(db_session, httpx_mock, monkeypatch):
+    # §7: a vault entry the current keyring cannot decrypt is treated as missing
+    # tokens (re-auth path), never an exception. No responses registered — any
+    # accidental HTTP call fails loudly.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    # Swap the keyring so the stored ciphertexts no longer decrypt.
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert user.esi_access_token is None and user.esi_refresh_token is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_response_without_refresh_token_keeps_stored_one(db_session, httpx_mock):
+    # §2.7: rotation is optional — a refresh response with no refresh_token key
+    # updates the access token and keeps the stored refresh token unchanged.
+    import httpx
+    ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT", "expires_in": 1200})
+    httpx_mock.add_response(url=settings.ESI_SSO_TOKEN_URL, json={"access_token": "AT2", "expires_in": 1200})
+    async with httpx.AsyncClient() as client:
+        await auth_service.refresh_user_tokens(db_session, client, user)
+    assert tc.decrypt_token(user.esi_access_token) == "AT2"
+    assert tc.decrypt_token(user.esi_refresh_token) == "RT"   # unchanged, still decryptable

--- a/app/backend/src/fastapi_app/tests/services/test_auth_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_auth_service.py
@@ -1,5 +1,7 @@
 # ABOUTME: User upsert (create + owner-hash transfer), token encryption, invalid-grant nulling.
 # ABOUTME: Refresh-on-demand: rotation persistence, outages keep the vault, wrong-key/empty-vault re-auth.
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from cryptography.fernet import Fernet
 from pydantic import SecretStr
@@ -37,7 +39,9 @@ async def test_upsert_creates_user_and_encrypts_tokens(db_session):
     assert user.esi_access_token != "AT"                      # ciphertext, not plaintext
     assert tc.decrypt_token(user.esi_access_token) == "AT"    # round-trips
     assert user.esi_refresh_token is None                     # zero scopes ⇒ no refresh token stored
-    assert user.esi_access_token_expires_at is not None
+    # expires_at is now + expires_in (1200s), not a sign-flipped past instant.
+    assert user.esi_access_token_expires_at > datetime.now(timezone.utc) + timedelta(seconds=1000)
+    assert user.esi_access_token_expires_at < datetime.now(timezone.utc) + timedelta(seconds=1300)
     assert user.last_login_at is not None
 
 
@@ -53,13 +57,15 @@ async def test_upsert_encrypts_refresh_token_when_present(db_session):
 @pytest.mark.asyncio
 async def test_upsert_transfers_owner_hash_on_mismatch(db_session):
     ident1 = VerifiedIdentity(character_id=91000001, character_name="Old Name", owner_hash="OWN1")
-    await auth_service.upsert_user(db_session, ident1, _tokens())
+    first = await auth_service.upsert_user(db_session, ident1, _tokens())
+    first_login_at = first.last_login_at
     ident2 = VerifiedIdentity(character_id=91000001, character_name="New Name", owner_hash="OWN2")
     user = await auth_service.upsert_user(db_session, ident2, {"access_token": "AT2", "expires_in": 1200})
     rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
     assert len(rows) == 1                          # updated in place, no duplicate row
     assert user.owner_hash == "OWN2"               # ownership transferred
     assert user.character_name == "New Name"
+    assert user.last_login_at > first_login_at     # re-login refreshes the timestamp in place
     assert tc.decrypt_token(user.esi_access_token) == "AT2"
 
 
@@ -77,7 +83,9 @@ async def test_mark_for_reauth_nulls_esi_columns(db_session):
 async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, httpx_mock):
     import httpx
     ident = VerifiedIdentity(character_id=91000001, character_name="Sesta Hound", owner_hash="OWN1")
-    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1200})
+    # Seed a near-immediate expiry so the post-refresh assertion below can only pass
+    # if the REFRESH advanced it — not by inheriting a long upsert-time expiry.
+    user = await auth_service.upsert_user(db_session, ident, {"access_token": "AT", "refresh_token": "RT_OLD", "expires_in": 1})
     httpx_mock.add_response(
         url=settings.ESI_SSO_TOKEN_URL,
         json={"access_token": "AT2", "refresh_token": "RT_ROTATED", "expires_in": 1200},
@@ -86,6 +94,8 @@ async def test_refresh_user_tokens_persists_rotated_refresh_token(db_session, ht
         await auth_service.refresh_user_tokens(db_session, client, user)
     assert tc.decrypt_token(user.esi_access_token) == "AT2"
     assert tc.decrypt_token(user.esi_refresh_token) == "RT_ROTATED"   # rotation persisted
+    # the refreshed access token carries a forward expiry, so M3's caller won't re-hit EVE every request.
+    assert user.esi_access_token_expires_at > datetime.now(timezone.utc) + timedelta(seconds=1000)
 
 
 @pytest.mark.asyncio

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -2033,7 +2033,7 @@ git commit -m "feat(auth): add refresh-on-demand with rotation persistence and r
 
 ## Phase 6 — Auth API routes
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase6-auth-routes`)
 
 **Goal:** `api/auth.py` — login, callback, logout, `/me` — with the shared not-configured 503 guard, return-path `next` validator, query-merge redirect builder, `hb_sso_state` browser-binding cookie, and every callback exit (spec §4, §4.1, §4.2). Routes are **not** mounted in `main.py` yet (decision **D2**); the `auth_client` test fixture mounts them.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -72,7 +72,7 @@ notes and commit messages.
 | 3 — Token cipher + session core | ✅ IMPLEMENTED — [PR #28](https://github.com/scarson/hangar-bay/pull/28) OPEN (stacked on #27), awaiting CI + codex gate | `d264cdd`, `755fb0c` | spec review byte-exact; quality ISSUES→APPROVED after 8 fixes incl. two mutation-proven test-pinning gaps |
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
 | 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
-| 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
+| 6 — Auth API routes | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 5), awaiting CI + codex gate | `3394b15`, `8c9b9b5` | spec review byte-exact (conftest additive, main.py untouched per D2); quality APPROVED, mutation probes clean; fix round `8c9b9b5` pinned the §4.4 ungated-logout/`/me` boundary; findings 1+2 (500-vs-redirect via merged sso.py/session.py gaps) → hardening PR |
 | 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
 | 9 — Docs | ⬜ Not started | — | pitfalls entries for traps discovered |
@@ -2033,7 +2033,7 @@ git commit -m "feat(auth): add refresh-on-demand with rotation persistence and r
 
 ## Phase 6 — Auth API routes
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase6-auth-routes`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase6-auth-routes`, commits `3394b15`, `8c9b9b5`) — spec review byte-exact; quality review APPROVED (mutation probes confirmed the callback decision tree, single-use browser-bound state, return-path validation, cookie attributes, and log redaction are all non-vacuously tested); fix round `8c9b9b5` added two mutation-verified tests pinning the §4.4 ungated-logout/`/me` boundary. 165 pytest green, pristine. Two Minor findings (a token body missing `expires_in` surfacing as a callback 500 instead of `sso=error`; corrupt state-payload class) root-cause in already-merged sso.py/session.py and are tracked for the codex-findings hardening PR.
 
 **Goal:** `api/auth.py` — login, callback, logout, `/me` — with the shared not-configured 503 guard, return-path `next` validator, query-merge redirect builder, `hb_sso_state` browser-binding cookie, and every callback exit (spec §4, §4.1, §4.2). Routes are **not** mounted in `main.py` yet (decision **D2**); the `auth_client` test fixture mounts them.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -1695,7 +1695,7 @@ git commit -m "feat(auth): add EVE SSO service — code/refresh grants and JWT v
 
 ## Phase 5 — Auth service + schemas
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-12, branch `claude/m2-phase5-auth-service`)
 
 **Goal:** `services/auth_service.py` (user upsert with the owner-hash transfer rule, token encrypt/store) + `schemas/auth.py` (`CurrentUserSchema`) (spec §4, §4.3).
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -71,7 +71,7 @@ notes and commit messages.
 | 2 — Data model | ✅ IMPLEMENTED — [PR #27](https://github.com/scarson/hangar-bay/pull/27) OPEN (stacked on #26), awaiting CI + codex gate | `f382f8d`, `0451750`, `7c7933d` | spec review byte-level clean (DISC-EXEC-3 adjudicated); quality APPROVED, 5 minors applied |
 | 3 — Token cipher + session core | ✅ IMPLEMENTED — [PR #28](https://github.com/scarson/hangar-bay/pull/28) OPEN (stacked on #27), awaiting CI + codex gate | `d264cdd`, `755fb0c` | spec review byte-exact; quality ISSUES→APPROVED after 8 fixes incl. two mutation-proven test-pinning gaps |
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
-| 5 — Auth service + schemas | ⬜ Not started | — | — |
+| 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
 | 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
 | 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
@@ -1695,7 +1695,7 @@ git commit -m "feat(auth): add EVE SSO service — code/refresh grants and JWT v
 
 ## Phase 5 — Auth service + schemas
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-12, branch `claude/m2-phase5-auth-service`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase5-auth-service`, commits `f2886b3`, `35c73a7`, `ac3919e`) — spec review byte-exact; quality review APPROVED, mutation-proven expiry/last_login assertions added in fix round `ac3919e` (findings 3+5 deferred to the codex-findings hardening PR). 120 pytest green, pristine.
 
 **Goal:** `services/auth_service.py` (user upsert with the owner-hash transfer rule, token encrypt/store) + `schemas/auth.py` (`CurrentUserSchema`) (spec §4, §4.3).
 


### PR DESCRIPTION
## Phase 6 — Auth API routes (M2 EVE SSO)

Sixth phase of the M2 EVE SSO login work (F004). Adds `api/auth.py` — the login, callback, logout, and `/me` routes — plus their helpers, fixtures, and full HTTP-level flow tests. Sam's own app; standard defensive OAuth, described here in plain correctness terms.

**Stacked on #31 (Phase 5).** Base is `claude/m2-phase5-auth-service`; GitHub will retarget this to `dev` when #31 merges.

### What this adds
- `api/auth.py`, mounted **bare** (PROXY-1: `/auth/sso/*` and `/me`, no `/api/v1` prefix — the SPA reaches them through the Vite proxy):
  - `validate_next` — return-path validator: rejects `//`, `/\`, leading-backslash, and scheme/authority forms, collapsing them to `/` so a redirect target can never leave `FRONTEND_ORIGIN`.
  - `build_redirect` — query-merge builder that adds the `sso` flag via `urlencode` and reconstructs with `urlunsplit`, discarding any authority.
  - `require_sso_configured` — shared 503 guard on `login` + `callback` only.
  - `login` → authorize redirect, single-use `sso_state` in Valkey + browser-bound `hb_sso_state` cookie.
  - `callback` → the full decision tree: OAuth denial → `sso=denied`; GETDEL state-miss → `sso=error`; live state with a missing/mismatched binding cookie → hard 400; happy path mints a session. Every exit clears `hb_sso_state`. The state is single-use (GETDEL) **and** browser-bound, so the callback only completes the login this browser started.
  - `logout` → idempotent 204, expires the session cookie. `/me` → the `CurrentUserSchema` identity from the session, or 401 when anonymous. Both are intentionally ungated by the not-configured guard.
- `tests/conftest.py` — additive `auth_client` fixture (snapshots and restores `real_app.router.routes` so `main.py` stays unmounted per D2; depends on `httpx_mock` structurally so no auth test can reach the network) and `configured_sso`.

### Tests
`test_auth_helpers.py` (14) + `test_auth_flow.py` (35) — every callback exit driven end-to-end over ASGITransport against the fake Valkey, the `[TIMING]` single-use-state test, cookie attributes, logout idempotency, `/me`, and the 503 not-configured paths. Full backend suite: **165 passed, pristine**.

### Review trail
- **Spec-compliance review:** all four plan blocks byte-exact; conftest change purely additive; `main.py` untouched (D2); PROXY-1, the 503-guard placement, and log redaction all verified.
- **Quality review (mutation probes):** APPROVED. Probes confirmed the single-use/browser-binding state, the return-path defense (17 hostile `next` values, no escape), the Secure-outside-dev and 30-day Max-Age cookie attributes, and the token-not-in-logs guard are all non-vacuously tested. Fix round `8c9b9b5` adds two mutation-verified tests pinning the §4.4 boundary (logout and `/me` still function when SSO is unconfigured). Two Minor findings — a token body omitting `expires_in` surfacing as a callback 500 instead of an `sso=error` redirect, and the corrupt state-payload class — root-cause in already-merged `sso.py`/`session.py` and are tracked for the standalone codex-findings hardening PR.

## Merge classification
`Review — domain (security)` — auth routes with single-use browser-bound state and return-path validation.

Leaving open for the `/codex` gate per the M2 merge-gate overlay. Do not self-merge.
