### PR TITLE
feat(api): mount SSO routes, regenerate typed client, add dev-unconfigured startup warning

### DIFF
--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -1,0 +1,204 @@
+# ABOUTME: EVE SSO routes — login, callback, logout, /me — mounted bare (PROXY-1).
+# ABOUTME: state is single-use (GETDEL) AND browser-bound (hb_sso_state cookie) so the callback matches the login this browser started (§7).
+import asyncio
+import functools
+import json
+import secrets
+import time
+from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.config import get_settings
+from ..core.dependencies import get_cache, get_http_client
+from ..core.logging import get_logger, log_key_event
+from ..core.session import create_session, destroy_session, get_current_session
+from ..core.token_cipher import is_token_cipher_configured
+from ..db import get_db
+from ..schemas.auth import CurrentUserSchema
+from ..services import auth_service, sso
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/auth/sso", tags=["Auth"])   # bare; SPA reaches via /api/v1/auth/sso/*
+me_router = APIRouter(tags=["Auth"])                    # bare /me
+
+_STATE_TTL_SECONDS = 600
+_STATE_COOKIE = "hb_sso_state"
+
+
+# --- shared not-configured guard (login + callback only) ---
+async def require_sso_configured() -> None:
+    s = get_settings()
+    if not s.ESI_CLIENT_ID or not is_token_cipher_configured():
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="EVE SSO is not configured")
+
+
+# --- pure helpers (unit-tested in test_auth_helpers.py) ---
+def validate_next(value: Optional[str]) -> str:
+    if not value or not value.startswith("/"):
+        return "/"
+    if value.startswith("//"):
+        return "/"                          # protocol-relative
+    if len(value) > 1 and value[1] == "\\":
+        return "/"                          # /\evil.com
+    return value
+
+
+def build_redirect(frontend_origin: str, next_path: str, flag: Optional[str]) -> str:
+    split = urlsplit(next_path)
+    query = parse_qsl(split.query, keep_blank_values=True)
+    if flag is not None:
+        query.append(("sso", flag))
+    rebuilt = urlunsplit(("", "", split.path or "/", urlencode(query), split.fragment))
+    return frontend_origin + rebuilt
+
+
+def _cookie_secure() -> bool:
+    return get_settings().ENVIRONMENT != "development"
+
+
+def _clear_state_cookie(resp: Response) -> None:
+    resp.delete_cookie(_STATE_COOKIE, path="/")
+
+
+# --- routes ---
+@router.get("/login", dependencies=[Depends(require_sso_configured)])
+async def login(request: Request, next: str = "/", redis: Redis = Depends(get_cache)):
+    s = get_settings()
+    validated_next = validate_next(next)
+    state = secrets.token_urlsafe(24)   # 192-bit
+    await redis.set(f"sso_state:{state}", json.dumps({"next": validated_next}), ex=_STATE_TTL_SECONDS)
+    authorize_url = sso.build_authorize_url(
+        state=state, client_id=s.ESI_CLIENT_ID,
+        redirect_uri=s.ESI_SSO_CALLBACK_URL, authorize_url=s.ESI_SSO_AUTHORIZE_URL,
+    )
+    resp = RedirectResponse(authorize_url, status_code=status.HTTP_302_FOUND)
+    resp.set_cookie(
+        _STATE_COOKIE, state, max_age=_STATE_TTL_SECONDS, httponly=True,
+        samesite="lax", secure=_cookie_secure(), path="/",
+    )
+    return resp
+
+
+@functools.lru_cache(maxsize=1)
+def _signing_key_provider() -> jwt.PyJWKClient:
+    """Process-wide PyJWKClient: its JWKS cache (300 s TTL, kid-keyed) must persist
+    across logins — a per-request client would refetch the JWKS on every callback
+    (§3.2). Tests monkeypatch this module attribute, which shadows the cached
+    callable; a test that changes ESI_SSO_JWKS_URI must call
+    _signing_key_provider.cache_clear()."""
+    return jwt.PyJWKClient(get_settings().ESI_SSO_JWKS_URI)
+
+
+@router.get("/callback", dependencies=[Depends(require_sso_configured)])
+async def callback(
+    request: Request,
+    state: Optional[str] = None,
+    code: Optional[str] = None,
+    error: Optional[str] = None,
+    redis: Redis = Depends(get_cache),
+    http_client=Depends(get_http_client),
+    db: AsyncSession = Depends(get_db),
+):
+    s = get_settings()
+    started = time.perf_counter()
+    cookie_state = request.cookies.get(_STATE_COOKIE)
+    stored = None
+    if state:
+        raw = await redis.getdel(f"sso_state:{state}")   # single-use consume
+        if raw is not None:
+            stored = json.loads(raw)
+
+    # (A) EVE-side denial — no session, redirect with sso=denied.
+    # Sanctioned ordering (plan-review round 2): the denial exit precedes the binding
+    # check (C). No session is ever minted on denial, so innocent-user UX (a friendly
+    # redirect) wins over the hard 400; a pinning test covers denial+cookie-mismatch.
+    if error is not None:
+        nxt = validate_next(stored["next"]) if stored else "/"
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, nxt, "denied"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (B) State missing/expired (GETDEL miss) — innocent, redirect with sso=error.
+    if stored is None:
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, "/", "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (C) State live but browser binding fails — the only hard-400 exit (callback doesn't match this browser's login).
+    if cookie_state is None or cookie_state != state:
+        resp = JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content={"detail": "Invalid SSO state"})
+        _clear_state_cookie(resp)
+        return resp
+
+    validated_next = validate_next(stored["next"])
+
+    # (D) Exchange code — non-200 → sso=error redirect.
+    try:
+        tokens = await sso.exchange_code(
+            http_client, code=code or "", token_url=s.ESI_SSO_TOKEN_URL,
+            client_id=s.ESI_CLIENT_ID, client_secret=s.ESI_CLIENT_SECRET.get_secret_value(),
+        )
+    except sso.SsoTokenError:
+        # Structured failure log (§4.1 step 5) — status/outcome only, no token material (§7).
+        log_key_event(logger, "sso_callback", success=False,
+                      duration_ms=(time.perf_counter() - started) * 1000,
+                      outcome="token_exchange_failed")
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (E) Validate JWT — the JWKS fetch inside is synchronous urllib, so run the whole
+    # validation off the event loop (§3.2). Failure → sso=error redirect.
+    try:
+        provider = _signing_key_provider()
+        identity = await asyncio.to_thread(
+            sso.validate_access_token, tokens["access_token"], key_provider=provider, client_id=s.ESI_CLIENT_ID
+        )
+    except (sso.SsoJwtError, KeyError, jwt.exceptions.PyJWKClientError):
+        # Structured failure log (§4.1 step 6) — outcome only, never the JWT itself (§7).
+        log_key_event(logger, "sso_callback", success=False,
+                      duration_ms=(time.perf_counter() - started) * 1000,
+                      outcome="jwt_validation_failed")
+        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
+        _clear_state_cookie(resp)
+        return resp
+
+    # (F) Upsert + session.
+    user = await auth_service.upsert_user(db, identity, tokens)
+    sid = await create_session(redis, user_id=user.id, character_id=identity.character_id, character_name=identity.character_name)
+    log_key_event(logger, "sso_callback", success=True,
+                  duration_ms=(time.perf_counter() - started) * 1000,
+                  outcome="login", character_id=identity.character_id)
+
+    resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, None), status_code=status.HTTP_302_FOUND)
+    resp.set_cookie(
+        s.SESSION_COOKIE_NAME, sid, max_age=s.SESSION_ABSOLUTE_TTL_SECONDS, httponly=True,
+        samesite="lax", secure=_cookie_secure(), path="/",
+    )
+    _clear_state_cookie(resp)
+    return resp
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(request: Request, redis: Redis = Depends(get_cache)):
+    s = get_settings()
+    sid = request.cookies.get(s.SESSION_COOKIE_NAME)
+    if sid:
+        await destroy_session(redis, sid)   # no-op if already gone (idempotent)
+    resp = Response(status_code=status.HTTP_204_NO_CONTENT)
+    resp.delete_cookie(s.SESSION_COOKIE_NAME, path="/")
+    return resp
+
+
+@me_router.get("/me", response_model=CurrentUserSchema)
+async def me(session: dict = Depends(get_current_session)):
+    # get_current_session 401s when there is no valid session; /me serves from the
+    # session payload alone (no DB read — §4.2).
+    return CurrentUserSchema(character_id=session["character_id"], character_name=session["character_name"])

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -18,6 +18,7 @@ from .core.http_client import init_http_client, close_http_client
 from .core.scheduler import add_aggregation_job, create_scheduler
 from .core.dependencies import get_cache
 from .core.logging import setup_logging, RequestIDMiddleware
+from .core.token_cipher import is_token_cipher_configured
 from .db import AsyncSessionLocal, async_engine, Base
 from .core.esi_client_class import ESIClient # For manual ESI client creation
 from .services.background_aggregation import ContractAggregationService # For manual service creation
@@ -39,7 +40,8 @@ async def lifespan(app: FastAPI):
     # Startup logic
     # Setup structured logging first
     setup_logging(settings)
-    
+    warn_if_sso_unconfigured()
+
     await create_db_tables()
     init_http_client(app)
     await init_cache(app)
@@ -138,6 +140,14 @@ async def create_db_tables():
     logger.info("Database tables successfully recreated.")
 
 
+def warn_if_sso_unconfigured() -> None:
+    """Development-only startup notice (spec §4.4): SSO routes 503 until .env is filled."""
+    if settings.ENVIRONMENT != "development":
+        return
+    if not settings.ESI_CLIENT_ID or not is_token_cipher_configured():
+        logger.warning(
+            "EVE SSO is not configured (ESI_CLIENT_ID/TOKEN_CIPHER_KEYS empty); /auth/sso/* returns 503."
+        )
 
 
 

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -22,6 +22,7 @@ from .db import AsyncSessionLocal, async_engine, Base
 from .core.esi_client_class import ESIClient # For manual ESI client creation
 from .services.background_aggregation import ContractAggregationService # For manual service creation
 from .api import contracts as contracts_router
+from .api import auth as auth_router
 from .models import contracts # This import is crucial for Base.metadata to find the tables.
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -165,5 +166,7 @@ async def cache_test(rd: Optional[Redis] = Depends(get_cache)):
 # The /api/v1 prefix is handled by the frontend proxy configuration.
 # The router is included here without a prefix to match the incoming requests.
 app.include_router(contracts_router.router)
+app.include_router(auth_router.router)      # /auth/sso/login|callback|logout (bare, PROXY-1)
+app.include_router(auth_router.me_router)   # /me (bare)
 
 # Further application setup, routers, middleware, etc., will go here

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -340,3 +340,31 @@ async def test_callback_503_when_cipher_unconfigured_not_500(auth_client, monkey
     monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("   "))   # whitespace ⇒ not configured
     resp = await auth_client.get("/auth/sso/callback", params={"state": "X", "code": "C"}, follow_redirects=False)
     assert resp.status_code == 503     # guard fires before any cipher/exchange — never a 500 from MultiFernet([])
+
+
+@pytest.mark.asyncio
+async def test_logout_works_when_sso_not_configured(auth_client, monkeypatch):
+    # §4.4: logout is intentionally NOT behind the not-configured guard, so an existing
+    # session can always be cleared even when the SSO credentials are absent.
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="X")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    assert await auth_client.fake_redis.exists(f"session:{sid}") == 0
+
+
+@pytest.mark.asyncio
+async def test_me_works_when_sso_not_configured(auth_client, monkeypatch):
+    # §4.4: /me reads only the session payload and is NOT behind the not-configured guard,
+    # so an already-authenticated identity survives SSO being unconfigured.
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="Sesta Hound")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"character_id": 91000001, "character_name": "Sesta Hound"}

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -1,0 +1,342 @@
+# ABOUTME: HTTP-level EVE SSO flow — login params, callback exits, cookies, /me, 503-not-configured.
+# ABOUTME: Every callback exit is driven end-to-end over ASGITransport against the fake Valkey.
+# NOTE: cookies are set on the client JAR (httpx >= 0.28 deprecates per-request cookies=);
+# the auth_client fixture is function-scoped, so jar state cannot leak across tests.
+import json
+import time
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlsplit
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from fastapi_app.core import session as sess
+from fastapi_app.core.config import settings
+
+CLIENT_ID = "test-client"
+TOKEN_URL = settings.ESI_SSO_TOKEN_URL
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+def _sign_access_token(priv, **overrides):
+    now = int(time.time())
+    claims = {
+        "iss": "login.eveonline.com", "sub": "CHARACTER:EVE:91000001",
+        "aud": [CLIENT_ID, "EVE Online"], "name": "Sesta Hound", "owner": "OWN1",
+        "exp": now + 1200, "iat": now,
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, priv, algorithm="RS256", headers={"kid": "JWT-Signature-Key"})
+
+
+def _inject_jwks(monkeypatch, pub):
+    from fastapi_app.api import auth as auth_api
+    monkeypatch.setattr(auth_api, "_signing_key_provider", lambda: SimpleNamespace(
+        get_signing_key_from_jwt=lambda token: SimpleNamespace(key=pub)))
+
+
+async def _seed_state(client, state="STATE123", next_="/contracts?type=bpc&page=2"):
+    await client.fake_redis.set(f"sso_state:{state}", json.dumps({"next": next_}), ex=600)
+
+
+def _session_set_cookie(resp):
+    """The specific hb_session Set-Cookie header. Never assert on the JOINED header
+    string: the hb_sso_state DELETION cookie also carries samesite=lax, which would
+    mask a lost attribute on the session cookie."""
+    cookies = resp.headers.get_list("set-cookie")
+    return next(c for c in cookies if c.startswith(f"{settings.SESSION_COOKIE_NAME}="))
+
+
+# ---------- login ----------
+@pytest.mark.asyncio
+async def test_login_redirects_to_authorize_with_exact_params_and_sets_state(auth_client, configured_sso):
+    resp = await auth_client.get("/auth/sso/login", params={"next": "/contracts"}, follow_redirects=False)
+    assert resp.status_code == 302
+    loc = urlsplit(resp.headers["location"])
+    assert f"{loc.scheme}://{loc.netloc}{loc.path}" == settings.ESI_SSO_AUTHORIZE_URL
+    q = parse_qs(loc.query, keep_blank_values=True)   # parse_qs DROPS blank values by default
+    assert q["response_type"] == ["code"] and q["client_id"] == [CLIENT_ID]
+    assert q["redirect_uri"] == [settings.ESI_SSO_CALLBACK_URL]
+    assert q["scope"] == [""]   # KeyError if scope is missing; must be present AND empty (F004)
+    state = q["state"][0]
+    assert await auth_client.fake_redis.exists(f"sso_state:{state}") == 1
+    assert auth_client.fake_redis.ttl_for(f"sso_state:{state}") == 600
+    set_cookie = resp.headers["set-cookie"].lower()
+    assert "hb_sso_state=" in set_cookie and "httponly" in set_cookie and "max-age=600" in set_cookie
+
+
+@pytest.mark.parametrize("bad", ["//evil.com", "/\\evil.com", "https://evil.com", "javascript:alert(1)", "garbage"])
+@pytest.mark.asyncio
+async def test_login_open_redirect_next_falls_back_to_root(auth_client, configured_sso, bad):
+    resp = await auth_client.get("/auth/sso/login", params={"next": bad}, follow_redirects=False)
+    state = parse_qs(urlsplit(resp.headers["location"]).query)["state"][0]
+    stored = json.loads(await auth_client.fake_redis.get(f"sso_state:{state}"))
+    assert stored["next"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_login_without_next_param_stores_root(auth_client, configured_sso):
+    # Spec §6's "missing" case, pinned over HTTP: FastAPI's query binding of the
+    # `next: str = "/"` default is exactly the layer the pure-helper tests never touch.
+    resp = await auth_client.get("/auth/sso/login", follow_redirects=False)
+    state = parse_qs(urlsplit(resp.headers["location"]).query)["state"][0]
+    stored = json.loads(await auth_client.fake_redis.get(f"sso_state:{state}"))
+    assert stored["next"] == "/"
+
+
+# ---------- callback happy path ----------
+@pytest.mark.asyncio
+async def test_callback_happy_path_creates_user_sets_session_cookie(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session):
+    from sqlalchemy import select
+    from fastapi_app.core import token_cipher as tc
+    from fastapi_app.models import User
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    at = _sign_access_token(priv)
+    # Zero-scope (F004) wire shape: NO refresh_token key (D-DELTA-2).
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": at, "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts?type=bpc&page=2")
+
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?type=bpc&page=2"  # success: no sso flag, & merge
+    assert "hb_session=" in _session_set_cookie(resp)
+    state_clear = next(c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state="))
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()   # binding cookie cleared (§4.1 step 4)
+    user = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalar_one()
+    assert user.esi_access_token != at                       # ciphertext, not plaintext
+    assert tc.decrypt_token(user.esi_access_token) == at     # real Fernet round-trip under the fixture key
+    assert user.esi_refresh_token is None                    # zero scopes ⇒ no refresh token (D-DELTA-2)
+
+
+# ---------- callback binding / state exits ----------
+@pytest.mark.asyncio
+async def test_callback_binding_cookie_missing_hard_400(auth_client, configured_sso):
+    await _seed_state(auth_client)
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 400     # GETDEL hit but no hb_sso_state cookie → binding check fails
+    assert resp.json() == {"detail": "Invalid SSO state"}
+    state_clear = next(c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state="))
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()   # cleared even on the 400 exit
+
+
+@pytest.mark.asyncio
+async def test_callback_binding_cookie_mismatch_hard_400(auth_client, configured_sso):
+    await _seed_state(auth_client)
+    auth_client.cookies.set("hb_sso_state", "DIFFERENT")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_state_missing_redirects_sso_error_no_session(auth_client, configured_sso):
+    auth_client.cookies.set("hb_sso_state", "GONE")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "GONE", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_callback_eve_denial_redirects_sso_denied_merged(auth_client, configured_sso):
+    await _seed_state(auth_client, next_="/contracts?type=bpc&page=2")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?type=bpc&page=2&sso=denied"
+
+
+@pytest.mark.asyncio
+async def test_callback_denial_wins_over_binding_mismatch(auth_client, configured_sso):
+    # Pins the sanctioned ordering (Task 6.2 exit A): denial short-circuits BEFORE the
+    # binding check — no session is minted on denial, so the friendly redirect beats
+    # the hard 400 for an innocent user whose cookie went stale mid-flow.
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "SOMETHING-ELSE")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=denied"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_callback_token_non_200_redirects_sso_error_and_logs_outcome(auth_client, configured_sso, httpx_mock, caplog, capsys):
+    import logging
+    httpx_mock.add_response(url=TOKEN_URL, status_code=400, json={"error": "invalid_grant"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    with caplog.at_level(logging.INFO):
+        resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "BAD"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    # Structured failure log (§4.1 step 5). structlog's test-time sink depends on
+    # whether setup_logging ran (it does not under ASGITransport) — capture BOTH
+    # channels so the assertion is sink-agnostic.
+    combined = caplog.text + capsys.readouterr().out
+    assert "token_exchange_failed" in combined
+
+
+@pytest.mark.asyncio
+async def test_callback_jwt_failure_redirects_sso_error_and_never_logs_the_token(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, caplog, capsys):
+    import logging
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    bad_token = _sign_access_token(priv, iss="evil.example.com")
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": bad_token, "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    with caplog.at_level(logging.INFO):
+        resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    combined = caplog.text + capsys.readouterr().out
+    assert "jwt_validation_failed" in combined
+    assert bad_token not in combined     # §7: never token material in logs
+
+
+@pytest.mark.asyncio
+async def test_callback_unknown_kid_redirects_sso_error_not_500(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch):
+    # A kid miss surfaces as PyJWKClientError inside validation → mapped to SsoJwtError
+    # (Phase 4) → the callback's sso=error redirect, never an unhandled 500.
+    from jwt.exceptions import PyJWKClientError
+    from fastapi_app.api import auth as auth_api
+    priv, _pub = rsa_keypair
+
+    def _raise(token):
+        raise PyJWKClientError("Unable to find a signing key that matches")
+
+    monkeypatch.setattr(auth_api, "_signing_key_provider",
+                        lambda: SimpleNamespace(get_signing_key_from_jwt=_raise))
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302     # not a 500
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+
+
+@pytest.mark.parametrize("evil_next", ["//evil.com", "/\\evil.com"])
+@pytest.mark.asyncio
+async def test_callback_never_yields_protocol_relative_location(auth_client, configured_sso, evil_next):
+    # A malformed or externally-pointing next in Valkey is re-validated at the callback (§7).
+    await auth_client.fake_redis.set("sso_state:STATE123", json.dumps({"next": evil_next}), ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=denied"
+
+
+@pytest.mark.asyncio
+async def test_callback_owner_hash_transfer(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session):
+    from sqlalchemy import select
+    from fastapi_app.models import User
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    # first login
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv, owner="OWN1"), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="S1")
+    auth_client.cookies.set("hb_sso_state", "S1")
+    await auth_client.get("/auth/sso/callback", params={"state": "S1", "code": "C"}, follow_redirects=False)
+    # Second login, new owner hash. Re-set the jar cookie explicitly: the response's
+    # deletion Set-Cookie targets a host-scoped jar entry, NOT the domain-less entry
+    # cookies.set() created, so each callback must set its own binding cookie.
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv, owner="OWN2"), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="S2")
+    auth_client.cookies.set("hb_sso_state", "S2")
+    await auth_client.get("/auth/sso/callback", params={"state": "S2", "code": "C"}, follow_redirects=False)
+    rows = (await db_session.execute(select(User).where(User.character_id == 91000001))).scalars().all()
+    assert len(rows) == 1 and rows[0].owner_hash == "OWN2"
+
+
+# ---------- state single-use ([TIMING]) ----------
+@pytest.mark.asyncio
+async def test_state_is_single_use(auth_client, configured_sso):
+    await _seed_state(auth_client, state="ONCE")
+    # First callback: binding MISMATCH → hard 400 — but the GETDEL has already consumed
+    # the state. (A matching cookie here would reach the code exchange, exit (D) —
+    # blocked from the real network by the fixture's structural httpx_mock, but the
+    # test would then fail confusingly at teardown instead of pinning single-use.)
+    auth_client.cookies.set("hb_sso_state", "OTHER")
+    resp1 = await auth_client.get("/auth/sso/callback", params={"state": "ONCE", "code": "C"}, follow_redirects=False)
+    assert resp1.status_code == 400
+    assert await auth_client.fake_redis.exists("sso_state:ONCE") == 0     # consumed even on the 400 exit
+    # Second callback, now with a MATCHING cookie: GETDEL miss → innocent sso=error redirect, NOT a 400.
+    auth_client.cookies.set("hb_sso_state", "ONCE")
+    resp2 = await auth_client.get("/auth/sso/callback", params={"state": "ONCE", "code": "C"}, follow_redirects=False)
+    assert resp2.status_code == 302 and resp2.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+
+
+# ---------- cookie attributes ----------
+@pytest.mark.parametrize("env,expect_secure", [("production", True), ("test", True), ("development", False)])
+@pytest.mark.asyncio
+async def test_session_cookie_attributes_and_secure_flag(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, env, expect_secure):
+    monkeypatch.setattr(settings, "ENVIRONMENT", env)
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    httpx_mock.add_response(url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"})
+    await _seed_state(auth_client, state="ENVS")
+    auth_client.cookies.set("hb_sso_state", "ENVS")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "ENVS", "code": "C"}, follow_redirects=False)
+    sc = _session_set_cookie(resp).lower()   # ONLY the hb_session cookie — see helper docstring
+    assert "httponly" in sc and "samesite=lax" in sc
+    assert "path=/" in sc
+    assert f"max-age={settings.SESSION_ABSOLUTE_TTL_SECONDS}" in sc   # §4.2: Max-Age = 30-day absolute cap
+    assert ("secure" in sc) is expect_secure
+
+
+# ---------- logout ----------
+@pytest.mark.asyncio
+async def test_logout_is_idempotent_204_and_expires_cookie(auth_client, configured_sso):
+    # no session present → still 204 (not gated behind get_current_session)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    sc = resp.headers.get("set-cookie", "").lower()
+    assert "hb_session=" in sc
+    assert "max-age=0" in sc or "expires=" in sc   # actually EXPIRING, not (re)setting a live value
+
+
+@pytest.mark.asyncio
+async def test_logout_deletes_existing_session(auth_client, configured_sso):
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="X")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.post("/auth/sso/logout")
+    assert resp.status_code == 204
+    assert await auth_client.fake_redis.exists(f"session:{sid}") == 0
+
+
+# ---------- /me ----------
+@pytest.mark.asyncio
+async def test_me_401_when_anonymous(auth_client, configured_sso):
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_me_200_from_session_payload(auth_client, configured_sso):
+    sid = await sess.create_session(auth_client.fake_redis, user_id=1, character_id=91000001, character_name="Sesta Hound")
+    auth_client.cookies.set(settings.SESSION_COOKIE_NAME, sid)
+    resp = await auth_client.get("/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"character_id": 91000001, "character_name": "Sesta Hound"}
+
+
+# ---------- not-configured (AC-4) ----------
+@pytest.mark.asyncio
+async def test_login_503_when_not_configured(auth_client, monkeypatch):
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    resp = await auth_client.get("/auth/sso/login", follow_redirects=False)
+    assert resp.status_code == 503 and resp.json() == {"detail": "EVE SSO is not configured"}
+
+
+@pytest.mark.asyncio
+async def test_callback_503_when_cipher_unconfigured_not_500(auth_client, monkeypatch):
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "test-client")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("   "))   # whitespace ⇒ not configured
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "X", "code": "C"}, follow_redirects=False)
+    assert resp.status_code == 503     # guard fires before any cipher/exchange — never a 500 from MultiFernet([])

--- a/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
@@ -1,0 +1,36 @@
+# ABOUTME: Unit coverage for the return-path next validator and the query-merge builder.
+# ABOUTME: Pure-function tests — no app or fixtures; redirect targets can never leave FRONTEND_ORIGIN.
+import pytest
+
+from fastapi_app.api.auth import build_redirect, validate_next
+
+
+@pytest.mark.parametrize("bad", ["//evil.com", "/\\evil.com", "https://evil.com", "javascript:alert(1)", "", None, "garbage"])
+def test_validate_next_rejects_dangerous_values(bad):
+    assert validate_next(bad) == "/"
+
+
+@pytest.mark.parametrize("ok", ["/", "/contracts", "/contracts?type=bpc&page=2"])
+def test_validate_next_accepts_safe_paths(ok):
+    assert validate_next(ok) == ok
+
+
+def test_build_redirect_merges_query_without_double_question_mark():
+    out = build_redirect("https://localhost:5173", "/contracts?type=bpc&page=2", flag="denied")
+    assert out == "https://localhost:5173/contracts?type=bpc&page=2&sso=denied"
+
+
+def test_build_redirect_adds_first_query_param():
+    out = build_redirect("https://localhost:5173", "/contracts", flag="error")
+    assert out == "https://localhost:5173/contracts?sso=error"
+
+
+def test_build_redirect_success_has_no_flag():
+    out = build_redirect("https://localhost:5173", "/contracts?page=2", flag=None)
+    assert out == "https://localhost:5173/contracts?page=2"
+
+
+def test_build_redirect_cannot_yield_protocol_relative_location():
+    # next was already validated to "/", so the Location stays under FRONTEND_ORIGIN.
+    out = build_redirect("https://localhost:5173", validate_next("//evil.com"), flag="error")
+    assert out == "https://localhost:5173/?sso=error"

--- a/app/backend/src/fastapi_app/tests/api/test_me_schema.py
+++ b/app/backend/src/fastapi_app/tests/api/test_me_schema.py
@@ -1,0 +1,23 @@
+# ABOUTME: Schema-level guard that /me and the SSO routes are mounted bare with the right shape (TEST-1).
+# ABOUTME: PROXY-1 sentinel: no /api/v1 prefix may ever appear in the backend-owned OpenAPI paths.
+from fastapi_app.main import app
+
+
+def test_me_and_sso_routes_mounted_bare():
+    schema = app.openapi()
+    assert "/me" in schema["paths"]
+    assert "/auth/sso/login" in schema["paths"]
+    assert "/auth/sso/callback" in schema["paths"]
+    assert "/auth/sso/logout" in schema["paths"]
+    # PROXY-1: never an /api/v1 prefix on the backend
+    assert not any(p.startswith("/api/v1") for p in schema["paths"])
+
+
+def test_me_response_schema_shape():
+    schema = app.openapi()
+    ref = schema["paths"]["/me"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+    name = ref.rsplit("/", 1)[-1]
+    props = schema["components"]["schemas"][name]["properties"]
+    assert set(props) == {"character_id", "character_name"}
+    assert props["character_id"]["type"] == "integer"
+    assert props["character_name"]["type"] == "string"

--- a/app/backend/src/fastapi_app/tests/conftest.py
+++ b/app/backend/src/fastapi_app/tests/conftest.py
@@ -156,3 +156,58 @@ async def setup_contracts(db_session: AsyncSession):
     db_session.add_all(contracts_data)
     await db_session.flush()  # Use flush to send data within the test's transaction
     return contracts_data
+
+
+import httpx
+import pytest_asyncio
+from pydantic import SecretStr
+from cryptography.fernet import Fernet
+
+from fastapi_app.tests.fake_redis import FakeRedis
+
+
+@pytest_asyncio.fixture(scope="function")
+async def auth_client(db_session, httpx_mock):
+    """HTTP client over real_app with the auth routers mounted, app.state wired, and get_db overridden.
+    Does NOT configure SSO settings — use the `configured_sso` fixture for happy-path flow tests.
+    Depends on httpx_mock STRUCTURALLY: pytest-httpx patches the async transport class,
+    so app.state.http_client can never reach the real network in ANY auth test — an
+    un-mocked token POST fails loudly instead of leaving the process. (The outer
+    ASGITransport client is a different transport class and is unaffected.) Tests
+    that need token responses request httpx_mock themselves and get the same instance."""
+    from fastapi_app.main import app as real_app
+    from fastapi_app.api import auth as auth_api
+    from fastapi_app.db import get_db as get_db_dep
+
+    n_routes = len(real_app.router.routes)
+    real_app.include_router(auth_api.router)
+    real_app.include_router(auth_api.me_router)
+    real_app.openapi_schema = None
+
+    fake = FakeRedis()
+    real_app.state.redis = fake
+    real_app.state.http_client = httpx.AsyncClient(base_url="http://sso.test")  # pytest-httpx intercepts this
+    real_app.dependency_overrides[get_db_dep] = lambda: db_session
+
+    transport = httpx.ASGITransport(app=real_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        client.fake_redis = fake     # expose to tests for state/session assertions
+        yield client
+
+    await real_app.state.http_client.aclose()
+    del real_app.state.redis
+    del real_app.state.http_client
+    real_app.dependency_overrides.clear()
+    del real_app.router.routes[n_routes:]   # restore routes — main.py stays unmounted (D2)
+    real_app.openapi_schema = None
+
+
+@pytest.fixture
+def configured_sso(monkeypatch):
+    """Configure the settings singleton for a working SSO flow. (Plain pytest fixture —
+    it is synchronous; pytest_asyncio.fixture is reserved for the async auth_client.)"""
+    from fastapi_app.core.config import settings
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "test-client")
+    monkeypatch.setattr(settings, "ESI_CLIENT_SECRET", SecretStr("test-secret"))
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr(Fernet.generate_key().decode()))
+    return settings

--- a/app/backend/src/fastapi_app/tests/conftest.py
+++ b/app/backend/src/fastapi_app/tests/conftest.py
@@ -176,13 +176,7 @@ async def auth_client(db_session, httpx_mock):
     ASGITransport client is a different transport class and is unaffected.) Tests
     that need token responses request httpx_mock themselves and get the same instance."""
     from fastapi_app.main import app as real_app
-    from fastapi_app.api import auth as auth_api
     from fastapi_app.db import get_db as get_db_dep
-
-    n_routes = len(real_app.router.routes)
-    real_app.include_router(auth_api.router)
-    real_app.include_router(auth_api.me_router)
-    real_app.openapi_schema = None
 
     fake = FakeRedis()
     real_app.state.redis = fake
@@ -198,8 +192,6 @@ async def auth_client(db_session, httpx_mock):
     del real_app.state.redis
     del real_app.state.http_client
     real_app.dependency_overrides.clear()
-    del real_app.router.routes[n_routes:]   # restore routes — main.py stays unmounted (D2)
-    real_app.openapi_schema = None
 
 
 @pytest.fixture

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -65,6 +65,8 @@ async def test_create_db_tables_runs_in_development(monkeypatch):
     [
         ("development", "", "", True),        # unconfigured in dev → exactly one warning
         ("development", "cid", "some-key", False),  # configured in dev → silent
+        ("development", "cid", "", True),     # client id set, cipher unset → still warns (pins the OR)
+        ("development", "", "some-key", True),  # cipher set, client id unset → still warns (pins the OR)
         ("production", "", "", False),        # never warns outside development
     ],
 )

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -58,3 +58,23 @@ async def test_create_db_tables_runs_in_development(monkeypatch):
     await main_mod.create_db_tables()
     assert entered["value"] is True
     assert synced == [Base.metadata.drop_all, Base.metadata.create_all]
+
+
+@pytest.mark.parametrize(
+    "env,client_id,keys,expect_warning",
+    [
+        ("development", "", "", True),        # unconfigured in dev → exactly one warning
+        ("development", "cid", "some-key", False),  # configured in dev → silent
+        ("production", "", "", False),        # never warns outside development
+    ],
+)
+def test_sso_unconfigured_startup_warning(monkeypatch, caplog, env, client_id, keys, expect_warning):
+    from pydantic import SecretStr
+
+    monkeypatch.setattr(main_mod.settings, "ENVIRONMENT", env)
+    monkeypatch.setattr(main_mod.settings, "ESI_CLIENT_ID", client_id)
+    monkeypatch.setattr(main_mod.settings, "TOKEN_CIPHER_KEYS", SecretStr(keys))
+    with caplog.at_level(logging.WARNING):
+        main_mod.warn_if_sso_unconfigured()
+    warnings = [r for r in caplog.records if "EVE SSO is not configured" in r.getMessage()]
+    assert len(warnings) == (1 if expect_warning else 0)

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -259,6 +259,24 @@
         "title": "ContractSchema",
         "type": "object"
       },
+      "CurrentUserSchema": {
+        "properties": {
+          "character_id": {
+            "title": "Character Id",
+            "type": "integer"
+          },
+          "character_name": {
+            "title": "Character Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "character_id",
+          "character_name"
+        ],
+        "title": "CurrentUserSchema",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -384,6 +402,140 @@
           }
         },
         "summary": "Read Root"
+      }
+    },
+    "/auth/sso/callback": {
+      "get": {
+        "operationId": "callback_auth_sso_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "State"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Error"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Callback",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/auth/sso/login": {
+      "get": {
+        "operationId": "login_auth_sso_login_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "next",
+            "required": false,
+            "schema": {
+              "default": "/",
+              "title": "Next",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/auth/sso/logout": {
+      "post": {
+        "operationId": "logout_auth_sso_logout_post",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Logout",
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/cache-test": {
@@ -875,6 +1027,27 @@
           }
         },
         "summary": "Health Check"
+      }
+    },
+    "/me": {
+      "get": {
+        "operationId": "me_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Me",
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/metrics": {

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -21,6 +21,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/sso/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Callback */
+        get: operations["callback_auth_sso_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Login */
+        get: operations["login_auth_sso_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Logout */
+        post: operations["logout_auth_sso_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/cache-test": {
         parameters: {
             query?: never;
@@ -93,6 +144,23 @@ export interface paths {
         };
         /** Health Check */
         get: operations["health_check_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Me */
+        get: operations["me_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -206,6 +274,13 @@ export interface components {
             /** Volume */
             volume?: number | null;
         };
+        /** CurrentUserSchema */
+        CurrentUserSchema: {
+            /** Character Id */
+            character_id: number;
+            /** Character Name */
+            character_name: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -280,6 +355,88 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
+            };
+        };
+    };
+    callback_auth_sso_callback_get: {
+        parameters: {
+            query?: {
+                state?: string | null;
+                code?: string | null;
+                error?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    login_auth_sso_login_get: {
+        parameters: {
+            query?: {
+                next?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    logout_auth_sso_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -422,6 +579,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    me_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurrentUserSchema"];
                 };
             };
         };

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -2732,7 +2732,7 @@ git commit -m "feat(auth): add SSO login/callback/logout/me routes with state-bi
 
 ## Phase 7 — Backend wiring + codegen
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase7-wiring-codegen`)
 
 **Goal:** Mount the auth routers in `main.py` (the real schema change, D2), strip the Phase 6 fixture's temporary mount, regenerate `openapi.json` + `schema.d.ts`, commit both, add the `/me` `app.openapi()` schema assertion (TEST-1 schema check), and add the spec §4.4 development startup warning.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -2033,7 +2033,7 @@ git commit -m "feat(auth): add refresh-on-demand with rotation persistence and r
 
 ## Phase 6 — Auth API routes
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase6-auth-routes`)
 
 **Goal:** `api/auth.py` — login, callback, logout, `/me` — with the shared not-configured 503 guard, return-path `next` validator, query-merge redirect builder, `hb_sso_state` browser-binding cookie, and every callback exit (spec §4, §4.1, §4.2). Routes are **not** mounted in `main.py` yet (decision **D2**); the `auth_client` test fixture mounts them.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -72,7 +72,7 @@ notes and commit messages.
 | 3 — Token cipher + session core | ✅ IMPLEMENTED — [PR #28](https://github.com/scarson/hangar-bay/pull/28) OPEN (stacked on #27), awaiting CI + codex gate | `d264cdd`, `755fb0c` | spec review byte-exact; quality ISSUES→APPROVED after 8 fixes incl. two mutation-proven test-pinning gaps |
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
 | 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
-| 6 — Auth API routes | ⬜ Not started | — | routes NOT yet mounted in main.py (see decision D2) |
+| 6 — Auth API routes | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 5), awaiting CI + codex gate | `3394b15`, `8c9b9b5` | spec review byte-exact (conftest additive, main.py untouched per D2); quality APPROVED, mutation probes clean; fix round `8c9b9b5` pinned the §4.4 ungated-logout/`/me` boundary; findings 1+2 (500-vs-redirect via merged sso.py/session.py gaps) → hardening PR |
 | 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
 | 9 — Docs | ⬜ Not started | — | pitfalls entries for traps discovered |
@@ -2033,7 +2033,7 @@ git commit -m "feat(auth): add refresh-on-demand with rotation persistence and r
 
 ## Phase 6 — Auth API routes
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase6-auth-routes`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase6-auth-routes`, commits `3394b15`, `8c9b9b5`) — spec review byte-exact; quality review APPROVED (mutation probes confirmed the callback decision tree, single-use browser-bound state, return-path validation, cookie attributes, and log redaction are all non-vacuously tested); fix round `8c9b9b5` added two mutation-verified tests pinning the §4.4 ungated-logout/`/me` boundary. 165 pytest green, pristine. Two Minor findings (a token body missing `expires_in` surfacing as a callback 500 instead of `sso=error`; corrupt state-payload class) root-cause in already-merged sso.py/session.py and are tracked for the codex-findings hardening PR.
 
 **Goal:** `api/auth.py` — login, callback, logout, `/me` — with the shared not-configured 503 guard, return-path `next` validator, query-merge redirect builder, `hb_sso_state` browser-binding cookie, and every callback exit (spec §4, §4.1, §4.2). Routes are **not** mounted in `main.py` yet (decision **D2**); the `auth_client` test fixture mounts them.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -73,7 +73,7 @@ notes and commit messages.
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
 | 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
 | 6 — Auth API routes | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 5), awaiting CI + codex gate | `3394b15`, `8c9b9b5` | spec review byte-exact (conftest additive, main.py untouched per D2); quality APPROVED, mutation probes clean; fix round `8c9b9b5` pinned the §4.4 ungated-logout/`/me` boundary; findings 1+2 (500-vs-redirect via merged sso.py/session.py gaps) → hardening PR |
-| 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
+| 7 — Backend wiring + codegen | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 6), awaiting CI + codex gate | `5ce0b9a`, `2cdaa53`, a829fe9 | spec review byte-exact; quality ISSUES→fixed (mixed-config rows pin the OR mutant); codegen artifacts regeneration-verified byte-current; path count 6→10, no `/api/v1`; 172 green, tsc clean |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
 | 9 — Docs | ⬜ Not started | — | pitfalls entries for traps discovered |
 
@@ -2732,7 +2732,7 @@ git commit -m "feat(auth): add SSO login/callback/logout/me routes with state-bi
 
 ## Phase 7 — Backend wiring + codegen
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase7-wiring-codegen`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase7-wiring-codegen`, commits `5ce0b9a`, `2cdaa53`, `a829fe9`) — spec review byte-exact (mount verbatim, conftest cleanup exactly prescribed, codegen artifacts committed with the schema change per CLAUDE.md, D3 preserved); quality review ISSUES→fixed: openapi.json/schema.d.ts confirmed byte-current by regeneration, no duplicate-operation-id warnings after the fixture-mount strip, schema assertions non-vacuous (mutation-checked), and the fix round added two mixed-config parametrize rows that pin the OR in `warn_if_sso_unconfigured` (an `or→and` mutant previously survived). Path count 6→10 (+4 bare SSO routes, no `/api/v1`). 172 pytest green, pristine; `tsc -b` clean.
 
 **Goal:** Mount the auth routers in `main.py` (the real schema change, D2), strip the Phase 6 fixture's temporary mount, regenerate `openapi.json` + `schema.d.ts`, commit both, add the `/me` `app.openapi()` schema assertion (TEST-1 schema check), and add the spec §4.4 development startup warning.
 


### PR DESCRIPTION
## Phase 7 — Backend wiring + codegen (M2 EVE SSO)

Seventh phase of the M2 EVE SSO login work (F004). Mounts the auth routers in `main.py` — the real OpenAPI schema change — strips the Phase 6 test fixture's temporary mount, regenerates the typed client, and adds a dev-startup notice. Sam's own app; standard defensive OAuth, described in plain correctness terms.

**Stacked on #32 (Phase 6).** Base is `claude/m2-phase6-auth-routes`; GitHub retargets as the stack merges.

### What this adds
- `main.py`: mounts `auth_router.router` (`/auth/sso/login|callback|logout`) and `auth_router.me_router` (`/me`) bare next to the contracts router (PROXY-1: no `/api/v1` prefix). Phase 1's import-time print removal and Phase 2's `create_db_tables` dev-gate are preserved (D3).
- `warn_if_sso_unconfigured()` — a development-only, once-per-startup notice (spec §4.4) when `ESI_CLIENT_ID` or the token cipher is unset; reuses `is_token_cipher_configured()` (no duplicated key-parse rule). Called in `lifespan` right after `setup_logging`.
- `tests/conftest.py`: the `auth_client` fixture's temporary mount machinery is removed now that `main.py` mounts the routers for real — the auth tests exercise the production-mounted routes, and no route double-mounts.
- Regenerated **`openapi.json`** (6→10 paths) and **`schema.d.ts`** (now carries `CurrentUserSchema`), committed together with the schema change per CLAUDE.md.

### Tests
- `tests/api/test_me_schema.py` — schema-level `app.openapi()` assertions that `/me` and the SSO routes are mounted bare with the right `CurrentUserSchema` shape (TEST-1), plus a PROXY-1 sentinel that no `/api/v1` path exists.
- `tests/test_create_db_tables_gate.py` — parametrized startup-warning tests (dev-unconfigured warns once, dev-configured silent, prod never, plus the two mixed-config rows added in the fix round).
- Full backend suite: **172 passed, pristine** (no duplicate-operation-id warnings). Frontend `npx tsc -b` clean.

### Review trail
- **Spec-compliance review:** all blocks byte-exact; conftest cleanup exactly as prescribed; codegen artifacts committed with the schema change; D3 preserved; the E402 17→19 in `main.py` is the same pervasive class already in that file (plan-dictated import placement), not a new violation.
- **Quality review (empirical):** regenerated `openapi.json` and `schema.d.ts` and confirmed the committed artifacts are byte-current (a stale generated client is the classic codegen bug — not present here); confirmed no duplicate-operation-id warnings after the fixture strip; mutation-checked that the schema assertions have teeth. It found one Important test gap — the startup-warning parametrization couldn't tell `or` from `and`, so an `or→and` regression (which would suppress the §4.4 warning in exactly the partial-`.env` cases) survived. Fix round adds two mixed-config rows, mutation-verified to fail under `and` and pass under the shipped `or`.

## Merge classification
`Review — domain (public interface: OpenAPI/serialization contract)` — mounts the public API surface and commits the generated typed client.

Leaving open for the `/codex` gate per the M2 merge-gate overlay. Do not self-merge.
