### PR TITLE
feat(web): add SSO header identity, useCurrentUser/useLogout hooks, and ?sso notice

### DIFF
--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -18,6 +18,7 @@ from .core.http_client import init_http_client, close_http_client
 from .core.scheduler import add_aggregation_job, create_scheduler
 from .core.dependencies import get_cache
 from .core.logging import setup_logging, RequestIDMiddleware
+from .core.token_cipher import is_token_cipher_configured
 from .db import AsyncSessionLocal, async_engine, Base
 from .core.esi_client_class import ESIClient # For manual ESI client creation
 from .services.background_aggregation import ContractAggregationService # For manual service creation
@@ -39,7 +40,8 @@ async def lifespan(app: FastAPI):
     # Startup logic
     # Setup structured logging first
     setup_logging(settings)
-    
+    warn_if_sso_unconfigured()
+
     await create_db_tables()
     init_http_client(app)
     await init_cache(app)
@@ -138,6 +140,14 @@ async def create_db_tables():
     logger.info("Database tables successfully recreated.")
 
 
+def warn_if_sso_unconfigured() -> None:
+    """Development-only startup notice (spec §4.4): SSO routes 503 until .env is filled."""
+    if settings.ENVIRONMENT != "development":
+        return
+    if not settings.ESI_CLIENT_ID or not is_token_cipher_configured():
+        logger.warning(
+            "EVE SSO is not configured (ESI_CLIENT_ID/TOKEN_CIPHER_KEYS empty); /auth/sso/* returns 503."
+        )
 
 
 

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -22,6 +22,7 @@ from .db import AsyncSessionLocal, async_engine, Base
 from .core.esi_client_class import ESIClient # For manual ESI client creation
 from .services.background_aggregation import ContractAggregationService # For manual service creation
 from .api import contracts as contracts_router
+from .api import auth as auth_router
 from .models import contracts # This import is crucial for Base.metadata to find the tables.
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -165,5 +166,7 @@ async def cache_test(rd: Optional[Redis] = Depends(get_cache)):
 # The /api/v1 prefix is handled by the frontend proxy configuration.
 # The router is included here without a prefix to match the incoming requests.
 app.include_router(contracts_router.router)
+app.include_router(auth_router.router)      # /auth/sso/login|callback|logout (bare, PROXY-1)
+app.include_router(auth_router.me_router)   # /me (bare)
 
 # Further application setup, routers, middleware, etc., will go here

--- a/app/backend/src/fastapi_app/tests/api/test_me_schema.py
+++ b/app/backend/src/fastapi_app/tests/api/test_me_schema.py
@@ -1,0 +1,23 @@
+# ABOUTME: Schema-level guard that /me and the SSO routes are mounted bare with the right shape (TEST-1).
+# ABOUTME: PROXY-1 sentinel: no /api/v1 prefix may ever appear in the backend-owned OpenAPI paths.
+from fastapi_app.main import app
+
+
+def test_me_and_sso_routes_mounted_bare():
+    schema = app.openapi()
+    assert "/me" in schema["paths"]
+    assert "/auth/sso/login" in schema["paths"]
+    assert "/auth/sso/callback" in schema["paths"]
+    assert "/auth/sso/logout" in schema["paths"]
+    # PROXY-1: never an /api/v1 prefix on the backend
+    assert not any(p.startswith("/api/v1") for p in schema["paths"])
+
+
+def test_me_response_schema_shape():
+    schema = app.openapi()
+    ref = schema["paths"]["/me"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+    name = ref.rsplit("/", 1)[-1]
+    props = schema["components"]["schemas"][name]["properties"]
+    assert set(props) == {"character_id", "character_name"}
+    assert props["character_id"]["type"] == "integer"
+    assert props["character_name"]["type"] == "string"

--- a/app/backend/src/fastapi_app/tests/conftest.py
+++ b/app/backend/src/fastapi_app/tests/conftest.py
@@ -176,13 +176,7 @@ async def auth_client(db_session, httpx_mock):
     ASGITransport client is a different transport class and is unaffected.) Tests
     that need token responses request httpx_mock themselves and get the same instance."""
     from fastapi_app.main import app as real_app
-    from fastapi_app.api import auth as auth_api
     from fastapi_app.db import get_db as get_db_dep
-
-    n_routes = len(real_app.router.routes)
-    real_app.include_router(auth_api.router)
-    real_app.include_router(auth_api.me_router)
-    real_app.openapi_schema = None
 
     fake = FakeRedis()
     real_app.state.redis = fake
@@ -198,8 +192,6 @@ async def auth_client(db_session, httpx_mock):
     del real_app.state.redis
     del real_app.state.http_client
     real_app.dependency_overrides.clear()
-    del real_app.router.routes[n_routes:]   # restore routes — main.py stays unmounted (D2)
-    real_app.openapi_schema = None
 
 
 @pytest.fixture

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -65,6 +65,8 @@ async def test_create_db_tables_runs_in_development(monkeypatch):
     [
         ("development", "", "", True),        # unconfigured in dev → exactly one warning
         ("development", "cid", "some-key", False),  # configured in dev → silent
+        ("development", "cid", "", True),     # client id set, cipher unset → still warns (pins the OR)
+        ("development", "", "some-key", True),  # cipher set, client id unset → still warns (pins the OR)
         ("production", "", "", False),        # never warns outside development
     ],
 )

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -58,3 +58,23 @@ async def test_create_db_tables_runs_in_development(monkeypatch):
     await main_mod.create_db_tables()
     assert entered["value"] is True
     assert synced == [Base.metadata.drop_all, Base.metadata.create_all]
+
+
+@pytest.mark.parametrize(
+    "env,client_id,keys,expect_warning",
+    [
+        ("development", "", "", True),        # unconfigured in dev → exactly one warning
+        ("development", "cid", "some-key", False),  # configured in dev → silent
+        ("production", "", "", False),        # never warns outside development
+    ],
+)
+def test_sso_unconfigured_startup_warning(monkeypatch, caplog, env, client_id, keys, expect_warning):
+    from pydantic import SecretStr
+
+    monkeypatch.setattr(main_mod.settings, "ENVIRONMENT", env)
+    monkeypatch.setattr(main_mod.settings, "ESI_CLIENT_ID", client_id)
+    monkeypatch.setattr(main_mod.settings, "TOKEN_CIPHER_KEYS", SecretStr(keys))
+    with caplog.at_level(logging.WARNING):
+        main_mod.warn_if_sso_unconfigured()
+    warnings = [r for r in caplog.records if "EVE SSO is not configured" in r.getMessage()]
+    assert len(warnings) == (1 if expect_warning else 0)

--- a/app/frontend/web/e2e/auth.spec.ts
+++ b/app/frontend/web/e2e/auth.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+import { SEVEN_SHIPS, pageOf } from './fixtures/contracts'
+import { makeCurrentUser } from './fixtures/auth'
+import { interceptContractList, interceptCurrentUser, interceptLogout, stubPortraits } from './helpers/api'
+
+test.describe('SSO header identity', () => {
+  test('anonymous header shows a login link with the encoded next', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
+    await interceptContractList(page, pageOf(SEVEN_SHIPS))
+    await page.goto('/contracts?is_bpc=true')
+    const login = page.getByRole('link', { name: /log in with eve/i })
+    await expect(login).toBeVisible()
+    // The /contracts route's validateSearch defaults every field (page, size,
+    // sort_by, …) and the router writes the fully-resolved search back onto the
+    // URL, so "next" carries that resolved query, not the bare '?is_bpc=true'
+    // that was typed in (same root cause as the equivalent vitest assertion in
+    // HeaderIdentity.test.tsx — verified against this app's own URL-normalizing
+    // behavior, e.g. sorting.spec.ts's bare goto('/contracts') asserting
+    // sort_by/sort_direction land in the URL).
+    const url = new URL(page.url())
+    const expectedNext = encodeURIComponent(url.pathname + url.search)
+    await expect(login).toHaveAttribute('href', '/api/v1/auth/sso/login?next=' + expectedNext)
+    expect(expectedNext).toContain('is_bpc%3Dtrue')
+  })
+
+  test('authenticated header shows portrait, name, and logout', async ({ page }) => {
+    await interceptCurrentUser(page, makeCurrentUser({ character_name: 'Sesta Hound' }))
+    await interceptContractList(page, pageOf(SEVEN_SHIPS))
+    await stubPortraits(page)   // keep the fixture lane offline — portrait is an external CDN URL
+    await page.goto('/contracts')
+    await expect(page.getByText('Sesta Hound')).toBeVisible()
+    // The portrait is decorative (alt="") so it exposes NO accessible role — this CSS
+    // attribute selector is the sanctioned exception to the role/label-selectors rule
+    // (same rationale as the HeaderIdentity vitest test).
+    await expect(page.locator('img[src*="images.evetech.net"]')).toHaveAttribute('src', /characters\/91000001\/portrait\?size=64/)
+    await expect(page.getByRole('button', { name: /log out/i })).toBeVisible()
+  })
+
+  test('logout POSTs exactly once and returns to anonymous', async ({ page }) => {
+    let authed = true
+    await page.route(/\/api\/v1\/me$/, async (route) => {
+      await route.fulfill({
+        status: authed ? 200 : 401,
+        contentType: 'application/json',
+        body: JSON.stringify(authed ? makeCurrentUser() : { detail: 'unauthenticated' }),
+      })
+    })
+    // Flip to anonymous INSIDE the logout handler, before the 204 is fulfilled: the
+    // /me refetch can only fire after the 204, so it always observes authed=false.
+    // A post-click flip in Node would race the in-page refetch (retries are 0 and
+    // TEST-2 forbids masking timing flakes).
+    const logoutCalls = await interceptLogout(page, () => {
+      authed = false
+    })
+    await interceptContractList(page, pageOf(SEVEN_SHIPS))
+    await stubPortraits(page)   // authenticated render → portrait request; stay offline
+    await page.goto('/contracts')
+    await page.getByRole('button', { name: /log out/i }).click()
+    // Assert the POST landed (204) BEFORE asserting the transition, so the test
+    // cannot pass on a logout that never reached the backend.
+    await expect.poll(() => logoutCalls.length).toBe(1)
+    expect(logoutCalls[0].method).toBe('POST')
+    await expect(page.getByRole('link', { name: /log in with eve/i })).toBeVisible()
+  })
+
+  test('?sso=denied renders a dismissible notice', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
+    await interceptContractList(page, pageOf(SEVEN_SHIPS))
+    await page.goto('/contracts?sso=denied')
+    await expect(page.getByText(/cancelled/i)).toBeVisible()
+    await page.getByRole('button', { name: /dismiss/i }).click()
+    await expect(page).not.toHaveURL(/sso=denied/)
+    await expect(page.getByText(/cancelled/i)).toHaveCount(0)
+  })
+})

--- a/app/frontend/web/e2e/default-view.spec.ts
+++ b/app/frontend/web/e2e/default-view.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { SEVEN_SHIPS, pageOf } from './fixtures/contracts'
-import { interceptContractList } from './helpers/api'
+import { interceptContractList, interceptCurrentUser } from './helpers/api'
 import { openFiltersIfCollapsed, rowLinks } from './helpers/ui'
 
 /**
@@ -9,6 +9,7 @@ import { openFiltersIfCollapsed, rowLinks } from './helpers/ui'
  */
 test.describe('default view', () => {
   test('root redirects to /contracts and shows ships-only by default', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, pageOf(SEVEN_SHIPS))
 
     await page.goto('/')
@@ -51,6 +52,7 @@ test.describe('default view', () => {
   })
 
   test('unchecking Ships only widens to All Contracts and drops the API filter', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.get('is_ship_contract') === 'true' ? SEVEN_SHIPS : SEVEN_SHIPS.slice(0, 2)),
     )

--- a/app/frontend/web/e2e/detail.spec.ts
+++ b/app/frontend/web/e2e/detail.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test'
 import { makeBpcItem, makeContract, makeShipItem, pageOf } from './fixtures/contracts'
-import { failUnexpectedApiCalls, interceptContractDetail, interceptContractList } from './helpers/api'
+import {
+  failUnexpectedApiCalls,
+  interceptContractDetail,
+  interceptContractList,
+  interceptCurrentUser,
+} from './helpers/api'
 import { rowLinks } from './helpers/ui'
 
 /**
@@ -31,6 +36,7 @@ test.describe('contract detail (F003)', () => {
     page,
   }) => {
     const contract = detailContract()
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf([contract]))
     const detailCalls = await interceptContractDetail(page, contract)
 
@@ -71,6 +77,7 @@ test.describe('contract detail (F003)', () => {
     page,
   }) => {
     const contract = detailContract()
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf([contract]))
     await interceptContractDetail(page, contract)
 
@@ -94,8 +101,12 @@ test.describe('contract detail (F003)', () => {
   })
 
   test('cold deep link renders fully and the back control is a link to the list', async ({ page }) => {
-    // Prove ONLY the detail endpoint is hit on a cold load: abort anything else.
+    // Prove ONLY the detail endpoint is hit on a cold load: abort anything else —
+    // except the header's own /me, which is expected on every page and answered
+    // 401 by the intercept registered below (page.route runs last-registered-first,
+    // so the more specific /me intercept must come AFTER this catch-all to win).
     await failUnexpectedApiCalls(page)
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractDetail(page, detailContract())
 
     await page.goto(`/contracts/${CONTRACT_ID}`)
@@ -115,6 +126,7 @@ test.describe('contract detail (F003)', () => {
   test('404 shows the not-found heading and the back control still returns to the list', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf([detailContract()]))
     await interceptContractDetail(page, { status: 404 })
 
@@ -129,7 +141,11 @@ test.describe('contract detail (F003)', () => {
   })
 
   test('document title becomes "<hull> — Hangar Bay"', async ({ page }) => {
+    // Same last-registered-first ordering as the cold-deep-link test above: the
+    // catch-all must be registered before the /me intercept so the specific
+    // route still wins.
     await failUnexpectedApiCalls(page)
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractDetail(page, detailContract())
 
     await page.goto(`/contracts/${CONTRACT_ID}`)

--- a/app/frontend/web/e2e/filters.spec.ts
+++ b/app/frontend/web/e2e/filters.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { BPC_CONTRACTS, SEVEN_SHIPS, bigDataset, pageOf, paginate } from './fixtures/contracts'
-import { interceptContractList } from './helpers/api'
+import { interceptContractList, interceptCurrentUser } from './helpers/api'
 import { openFiltersIfCollapsed, rowLinks } from './helpers/ui'
 
 /**
@@ -21,6 +21,7 @@ test.describe('contract filters', () => {
     // char value produces the SAME toApiQuery output as empty, so useContracts'
     // query key is unchanged and NO new request fires — the value only lives in
     // the URL while the user is mid-typing.
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.get('search') === 'abc' ? SEVEN_SHIPS.slice(0, 1) : SEVEN_SHIPS),
     )
@@ -52,6 +53,7 @@ test.describe('contract filters', () => {
   })
 
   test('price bounds: min/max reach the URL and the wire, and the rows update', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const priced = SEVEN_SHIPS.slice(2, 5) // Maelstrom, Purifier, Hound
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.has('min_price') || params.has('max_price') ? priced : SEVEN_SHIPS),
@@ -77,6 +79,7 @@ test.describe('contract filters', () => {
   test('region multi-select: filter the list, pick two, wire carries repeated region_ids', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const regional = SEVEN_SHIPS.slice(0, 2) // Revelation, Raven
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.has('region_ids') ? regional : SEVEN_SHIPS),
@@ -111,6 +114,7 @@ test.describe('contract filters', () => {
   test('blueprint-copies toggle: is_bpc reaches URL + wire and rows show the BPC badge', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.get('is_bpc') === 'true' ? BPC_CONTRACTS : SEVEN_SHIPS),
     )
@@ -132,6 +136,7 @@ test.describe('contract filters', () => {
   })
 
   test('clear filters resets the URL + controls and the button removes itself', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     // The responder narrows to 2 rows whenever a search is sent, so the return to
     // 7 rows after Clear is a deterministic sync point proving the reset re-fetched.
     const calls = await interceptContractList(page, (params) =>
@@ -181,6 +186,7 @@ test.describe('contract filters', () => {
   })
 
   test('applying a filter resets pagination to page 1', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const all = bigDataset(60)
     const calls = await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page') ?? 1), Number(params.get('size') ?? 50)),

--- a/app/frontend/web/e2e/fixtures/auth.ts
+++ b/app/frontend/web/e2e/fixtures/auth.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Wire-shape fixtures for GET /me — the SPA's identity source in the fixture lane.
+// ABOUTME: makeCurrentUser overrides let specs vary identity without inventing new wire shapes.
+export interface WireCurrentUser {
+  character_id: number
+  character_name: string
+}
+
+export function makeCurrentUser(overrides: Partial<WireCurrentUser> = {}): WireCurrentUser {
+  return { character_id: 91_000_001, character_name: 'Sesta Hound', ...overrides }
+}

--- a/app/frontend/web/e2e/helpers/api.ts
+++ b/app/frontend/web/e2e/helpers/api.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import type { WireContract, WirePage } from '../fixtures/contracts'
+import type { WireCurrentUser } from '../fixtures/auth'
 
 /**
  * Route-interception helpers for the fixture lane.
@@ -104,4 +105,59 @@ export async function failUnexpectedApiCalls(page: Page): Promise<void> {
   await page.route('**/api/v1/**', async (route) => {
     await route.abort('failed')
   })
+}
+
+const ME_URL = /\/api\/v1\/me$/
+const LOGOUT_URL = /\/api\/v1\/auth\/sso\/logout$/
+
+export type CurrentUserResponder = WireCurrentUser | ErrorResponse
+
+/** Intercept GET /me. Pass `{ status: 401 }` for the anonymous default. */
+export async function interceptCurrentUser(page: Page, responder: CurrentUserResponder): Promise<void> {
+  await page.route(ME_URL, async (route) => {
+    if (isErrorResponse(responder)) {
+      await route.fulfill({
+        status: responder.status,
+        contentType: 'application/json',
+        body: JSON.stringify(responder.body ?? { detail: 'unauthenticated' }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(responder) })
+  })
+}
+
+export interface LogoutCall extends CapturedCall {
+  /** HTTP method of the captured request — the spec must assert it is POST. */
+  method: string
+}
+
+/** Intercept /auth/sso/logout (any method — capture, then assert POST), fulfilling 204.
+ * `onFulfill` runs before the 204 is sent: use it to flip sibling /me route state so
+ * the post-logout /me refetch — which can only fire after the 204 — deterministically
+ * observes the anonymous state (retries are 0; TEST-2 forbids masking timing). */
+export async function interceptLogout(page: Page, onFulfill?: () => void): Promise<LogoutCall[]> {
+  const calls: LogoutCall[] = []
+  await page.route(LOGOUT_URL, async (route) => {
+    const url = new URL(route.request().url())
+    calls.push({ url, params: url.searchParams, method: route.request().method() })
+    onFulfill?.()
+    await route.fulfill({ status: 204, body: '' })
+  })
+  return calls
+}
+
+// 1x1 transparent PNG. The character portrait points at images.evetech.net, which is
+// OUTSIDE /api/v1/** — without this stub, authenticated-header specs fire a live CDN
+// request from the hermetic fixture lane (offline/throttled CI runners would hang on it).
+const PORTRAIT_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+/** Serve a tiny PNG for EVE portrait requests so authenticated specs stay fully offline. */
+export async function stubPortraits(page: Page): Promise<void> {
+  await page.route('**://images.evetech.net/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'image/png', body: PORTRAIT_PNG }),
+  )
 }

--- a/app/frontend/web/e2e/pagination.spec.ts
+++ b/app/frontend/web/e2e/pagination.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { bigDataset, paginate } from './fixtures/contracts'
-import { interceptContractList } from './helpers/api'
+import { interceptContractList, interceptCurrentUser } from './helpers/api'
 import { rowLinks } from './helpers/ui'
 
 /**
@@ -22,6 +22,7 @@ test.describe('pagination', () => {
     // Hull labels are the row-link text (primaryLabel prefers the ship item);
     // derive the expected set from the fixture so it stays coupled to the builder.
     const expectedLabels = all.map((c) => c.items[0].type_name as string)
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page')), Number(params.get('size'))),
     )
@@ -69,6 +70,7 @@ test.describe('pagination', () => {
 
   test('Previous is disabled on the first page and Next on the last', async ({ page }) => {
     const all = bigDataset(120)
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page')), Number(params.get('size'))),
     )
@@ -88,6 +90,7 @@ test.describe('pagination', () => {
     // Mechanism (confirmed in @tanstack/router-core scroll-restoration.js): on every
     // navigation's `onRendered`, resetScroll (default true) calls window.scrollTo(0,0).
     const all = bigDataset(120)
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page')), Number(params.get('size'))),
     )
@@ -113,6 +116,7 @@ test.describe('pagination', () => {
     // replace to pageCount. The backend echoes {total>0, items:[]} for pages past
     // the end (paginate reproduces this), which triggers the self-heal.
     const all = bigDataset(120)
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page')), Number(params.get('size'))),
     )
@@ -131,6 +135,7 @@ test.describe('pagination', () => {
 
   test('deep-links straight to a middle page without walking from page 1', async ({ page }) => {
     const all = bigDataset(120)
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       paginate(all, Number(params.get('page')), Number(params.get('size'))),
     )

--- a/app/frontend/web/e2e/responsive.spec.ts
+++ b/app/frontend/web/e2e/responsive.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { BPC_CONTRACTS, SEVEN_SHIPS, makeContract, makeShipItem, pageOf } from './fixtures/contracts'
-import { interceptContractDetail, interceptContractList } from './helpers/api'
+import { interceptContractDetail, interceptContractList, interceptCurrentUser } from './helpers/api'
 import { rowLinks } from './helpers/ui'
 
 /**
@@ -24,6 +24,7 @@ test.describe('responsive filter-rail disclosure', () => {
     page,
   }) => {
     test.skip(!isMobile(), 'the Filters disclosure only exists below the lg breakpoint')
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf(SEVEN_SHIPS))
 
     await page.goto('/contracts')
@@ -45,6 +46,7 @@ test.describe('responsive filter-rail disclosure', () => {
     page,
   }) => {
     test.skip(!isMobile(), 'the Filters disclosure only exists below the lg breakpoint')
+    await interceptCurrentUser(page, { status: 401 })
     // Keyed responder: is_bpc=true serves the blueprint set, otherwise the ships.
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.get('is_bpc') === 'true' ? BPC_CONTRACTS : SEVEN_SHIPS),
@@ -93,6 +95,7 @@ test.describe('responsive filter-rail disclosure', () => {
     page,
   }) => {
     test.skip(!isMobile(), 'the Filters disclosure only exists below the lg breakpoint')
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, (params) =>
       pageOf(params.get('is_bpc') === 'true' ? BPC_CONTRACTS : SEVEN_SHIPS),
     )
@@ -125,6 +128,7 @@ test.describe('responsive filter-rail disclosure', () => {
     page,
   }) => {
     test.skip(isMobile(), 'above lg the rail is always visible — there is no disclosure to test')
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf(SEVEN_SHIPS))
 
     await page.goto('/contracts')
@@ -143,6 +147,7 @@ test.describe('responsive filter-rail disclosure', () => {
   test('both: a results row link opens the detail view and browser-back returns to the list', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf(SEVEN_SHIPS))
     await interceptContractDetail(page, (contractId) =>
       makeContract({ contract_id: contractId, items: [makeShipItem('Revelation')] }),

--- a/app/frontend/web/e2e/sorting.spec.ts
+++ b/app/frontend/web/e2e/sorting.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { makeContract, makeShipItem, paginate, type WireContract } from './fixtures/contracts'
-import { interceptContractList, type ListResponder } from './helpers/api'
+import { interceptContractList, interceptCurrentUser, type ListResponder } from './helpers/api'
 import { rowLinks } from './helpers/ui'
 
 /**
@@ -93,6 +93,7 @@ const activeSortHeader = (page: import('@playwright/test').Page) => page.locator
 
 test.describe('column-header sorting', () => {
   test('default sort is Issued descending on the wire and in the header', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, listResponder)
 
     await page.goto('/contracts')
@@ -118,6 +119,7 @@ test.describe('column-header sorting', () => {
   test('clicking Price (ISK) sorts price ascending, resets to page 1, renders server order', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, listResponder)
 
     // Start on page 2 so the reset-to-1 on sort is observable (5 items / size 3
@@ -151,6 +153,7 @@ test.describe('column-header sorting', () => {
   })
 
   test('re-clicking Price flips the direction asc↔desc everywhere', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, listResponder)
 
     await page.goto('/contracts')
@@ -185,6 +188,7 @@ test.describe('column-header sorting', () => {
   })
 
   test('switching to a different header resets direction to that column initial', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, listResponder)
 
     // Deep-link into price DESCENDING so the reset is unmistakable: switching
@@ -216,6 +220,7 @@ test.describe('column-header sorting', () => {
   })
 
   test('deep-link restores the sorted header and sends the params on first load', async ({ page }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, listResponder)
 
     await page.goto('/contracts?sort_by=price&sort_direction=asc')

--- a/app/frontend/web/e2e/states.spec.ts
+++ b/app/frontend/web/e2e/states.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test'
 import { SEVEN_SHIPS, makeContract, makeShipItem, pageOf } from './fixtures/contracts'
-import { interceptContractDetail, interceptContractList } from './helpers/api'
+import { interceptContractDetail, interceptContractList, interceptCurrentUser } from './helpers/api'
 import { openFiltersIfCollapsed, rowLinks } from './helpers/ui'
 
 /**
@@ -56,6 +56,7 @@ test.describe('states', () => {
   test('loading skeleton shows while the list request is in flight, then rows replace it', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     const { opened, release } = gate()
     await page.route(LIST_URL, async (route) => {
       await opened
@@ -88,6 +89,7 @@ test.describe('states', () => {
   test('empty result shows the no-match card, Clear filters, and announces zero', async ({
     page,
   }) => {
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractList(page, pageOf([]))
 
     await page.goto('/contracts')
@@ -109,6 +111,7 @@ test.describe('states', () => {
     // before surfacing an error — failing only call 0 would auto-recover on call 1
     // and never reach the alert. Fail both initial attempts, then let the manual
     // Retry (call 2) succeed.
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (_params, call) =>
       call < 2 ? { status: 500 } : pageOf(SEVEN_SHIPS),
     )
@@ -140,6 +143,7 @@ test.describe('states', () => {
     // Responder keyed on the wire param: is_bpc=true narrows to two rows. This is a
     // synthetic narrowing to exercise the announcement, not a product claim about
     // ship/BPC overlap; the fixture lane is authoritative for what comes back.
+    await interceptCurrentUser(page, { status: 401 })
     const calls = await interceptContractList(page, (params) =>
       pageOf(params.get('is_bpc') === 'true' ? SEVEN_SHIPS.slice(0, 2) : SEVEN_SHIPS),
     )
@@ -165,6 +169,7 @@ test.describe('states', () => {
       contract_id: 232_100_001,
       items: [makeShipItem('Revelation')],
     })
+    await interceptCurrentUser(page, { status: 401 })
     const { opened, release } = gate()
     await page.route(DETAIL_URL, async (route) => {
       await opened
@@ -185,6 +190,7 @@ test.describe('states', () => {
   test('detail page shows its error alert + Retry when the request fails', async ({ page }) => {
     // useContract retries non-404s once, so a persistent 500 makes two attempts and
     // then renders the error branch (not the 404 NotFound branch).
+    await interceptCurrentUser(page, { status: 401 })
     await interceptContractDetail(page, { status: 500 })
 
     await page.goto('/contracts/232100001')

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -259,6 +259,24 @@
         "title": "ContractSchema",
         "type": "object"
       },
+      "CurrentUserSchema": {
+        "properties": {
+          "character_id": {
+            "title": "Character Id",
+            "type": "integer"
+          },
+          "character_name": {
+            "title": "Character Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "character_id",
+          "character_name"
+        ],
+        "title": "CurrentUserSchema",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -384,6 +402,140 @@
           }
         },
         "summary": "Read Root"
+      }
+    },
+    "/auth/sso/callback": {
+      "get": {
+        "operationId": "callback_auth_sso_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "State"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Error"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Callback",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/auth/sso/login": {
+      "get": {
+        "operationId": "login_auth_sso_login_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "next",
+            "required": false,
+            "schema": {
+              "default": "/",
+              "title": "Next",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/auth/sso/logout": {
+      "post": {
+        "operationId": "logout_auth_sso_logout_post",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Logout",
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/cache-test": {
@@ -875,6 +1027,27 @@
           }
         },
         "summary": "Health Check"
+      }
+    },
+    "/me": {
+      "get": {
+        "operationId": "me_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Me",
+        "tags": [
+          "Auth"
+        ]
       }
     },
     "/metrics": {

--- a/app/frontend/web/package-lock.json
+++ b/app/frontend/web/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "24.13.3",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-basic-ssl": "2.3.0",
         "@vitejs/plugin-react": "6.0.3",
         "eslint": "9.39.5",
         "eslint-config-prettier": "10.1.8",
@@ -2225,6 +2226,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz",
+      "integrity": "sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/app/frontend/web/package.json
+++ b/app/frontend/web/package.json
@@ -34,6 +34,7 @@
     "@types/node": "24.13.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-basic-ssl": "2.3.0",
     "@vitejs/plugin-react": "6.0.3",
     "eslint": "9.39.5",
     "eslint-config-prettier": "10.1.8",

--- a/app/frontend/web/playwright.config.ts
+++ b/app/frontend/web/playwright.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
   retries: 0,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'https://localhost:5173',
+    ignoreHTTPSErrors: true,
     trace: 'retain-on-failure',
   },
   projects: [
@@ -40,7 +41,8 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:5173',
+    url: 'https://localhost:5173',
+    ignoreHTTPSErrors: true,
     reuseExistingServer: true,
     timeout: 30_000,
   },

--- a/app/frontend/web/src/components/Button.tsx
+++ b/app/frontend/web/src/components/Button.tsx
@@ -8,15 +8,14 @@ const variants: Record<Variant, string> = {
   ghost: 'border border-line-strong text-ink-body hover:bg-raised active:bg-overlay',
 }
 
+export function buttonClasses(variant: Variant = 'ghost', className = ''): string {
+  return `inline-flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-3 text-sm transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40 ${variants[variant]} ${className}`
+}
+
 export function Button({
   variant = 'ghost',
   className = '',
   ...props
 }: { variant?: Variant } & ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      className={`inline-flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-3 text-sm transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-40 ${variants[variant]} ${className}`}
-      {...props}
-    />
-  )
+  return <button className={buttonClasses(variant, className)} {...props} />
 }

--- a/app/frontend/web/src/components/Input.tsx
+++ b/app/frontend/web/src/components/Input.tsx
@@ -1,9 +1,19 @@
 import type { InputHTMLAttributes } from 'react'
 
+// Tailwind v4 resolves same-specificity utility clashes by source order in the
+// compiled stylesheet, not by className/DOM order — `.text-sm` is emitted
+// AFTER the custom `.text-data` @utility, so appending `text-data` alongside
+// the base `text-sm` silently loses the font-size half of `text-data` (its
+// font-family/tabular-nums still apply; the size reverts to 14px). Drop the
+// base size whenever the caller supplies its own text-size utility so only
+// one font-size utility ever lands on the element (§9.6 M1 nit).
+const TEXT_SIZE_CLASS = /(?:^|\s)text-(?:data|xs|sm|base|lg|xl)(?:\s|$)/
+
 export function Input({ className = '', ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  const size = TEXT_SIZE_CLASS.test(className) ? '' : 'text-sm'
   return (
     <input
-      className={`h-8 w-full rounded-sm border border-line-strong bg-void px-2 text-sm text-ink transition-colors duration-150 placeholder:text-ink-faint hover:border-ink-faint focus:border-brand ${className}`}
+      className={`h-8 w-full rounded-sm border border-line-strong bg-void px-2 ${size} text-ink transition-colors duration-150 placeholder:text-ink-faint hover:border-ink-faint focus:border-brand ${className}`}
       {...props}
     />
   )

--- a/app/frontend/web/src/features/auth/components/HeaderIdentity.test.tsx
+++ b/app/frontend/web/src/features/auth/components/HeaderIdentity.test.tsx
@@ -1,0 +1,71 @@
+// ABOUTME: Header identity states over the real routeTree — anonymous link, authenticated cluster, logout.
+// ABOUTME: The login href must carry next=encodeURIComponent(pathname+search) exactly.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { jsonResponse } from '../../../test/http'
+import { renderApp } from '../../../test/renderApp'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('HeaderIdentity', () => {
+  it('renders a login link with the encoded next when anonymous', async () => {
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (/\/api\/v1\/me$/.test(url)) return jsonResponse({ detail: 'unauthenticated' }, 401)
+      return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+    })
+    const { router } = renderApp('/contracts?is_bpc=true')
+    const link = await screen.findByRole('link', { name: /log in with eve/i })
+    // The /contracts route's validateSearch defaults every field (page, size,
+    // sort_by, …) and TanStack Router writes the fully-resolved search back
+    // onto the location (confirmed even at the browser-history level — see
+    // e2e/sorting.spec.ts's bare `goto('/contracts')` asserting sort_by/
+    // sort_direction land in the URL). So "next" is derived from the SAME
+    // resolved location the app itself would carry, not a bare '?is_bpc=true'.
+    const expectedNext = encodeURIComponent(
+      router.state.location.pathname + router.state.location.searchStr,
+    )
+    expect(link).toHaveAttribute('href', `/api/v1/auth/sso/login?next=${expectedNext}`)
+    expect(expectedNext).toContain('is_bpc%3Dtrue')
+  })
+
+  it('renders portrait + name + logout when authenticated', async () => {
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (/\/api\/v1\/me$/.test(url)) return jsonResponse({ character_id: 91000001, character_name: 'Sesta Hound' })
+      return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+    })
+    renderApp('/contracts')
+    expect(await screen.findByText('Sesta Hound')).toBeInTheDocument()
+    // The portrait is decorative (alt="") so it has no accessible role — query the
+    // DOM directly; the src must carry the character id at 2x (size=64 for 24px).
+    const portrait = document.querySelector('img[src*="images.evetech.net"]') as HTMLImageElement
+    expect(portrait.getAttribute('src')).toBe('https://images.evetech.net/characters/91000001/portrait?size=64')
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
+  })
+
+  it('logs out and returns to anonymous', async () => {
+    const calls: { url: string; method?: string }[] = []
+    let authed = true
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input as Request
+      const url = req.url ?? String(input)
+      if (/\/api\/v1\/auth\/sso\/logout$/.test(url)) {
+        calls.push({ url, method: req.method ?? init?.method })
+        authed = false
+        return new Response(null, { status: 204 })
+      }
+      if (/\/api\/v1\/me$/.test(url)) {
+        return authed
+          ? jsonResponse({ character_id: 91000001, character_name: 'Sesta Hound' })
+          : jsonResponse({ detail: 'unauthenticated' }, 401)
+      }
+      return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+    })
+    renderApp('/contracts')
+    await userEvent.click(await screen.findByRole('button', { name: /log out/i }))
+    expect(calls[0].method).toBe('POST')
+    expect(await screen.findByRole('link', { name: /log in with eve/i })).toBeInTheDocument()
+  })
+})

--- a/app/frontend/web/src/features/auth/components/HeaderIdentity.tsx
+++ b/app/frontend/web/src/features/auth/components/HeaderIdentity.tsx
@@ -1,0 +1,41 @@
+// ABOUTME: Header identity cluster — login link when anonymous; portrait + name + logout when authenticated.
+// ABOUTME: Login is a FULL navigation to the backend redirect, with next=encodeURIComponent(path+search).
+import { useLocation } from '@tanstack/react-router'
+import { Button, buttonClasses } from '../../../components/Button'
+import { useCurrentUser } from '../hooks/useCurrentUser'
+import { useLogout } from '../hooks/useLogout'
+
+export function HeaderIdentity() {
+  const location = useLocation()
+  const { data: user, isPending } = useCurrentUser()
+  const logout = useLogout()
+
+  if (isPending) return <div className="ml-auto h-8" aria-hidden="true" />
+
+  if (!user) {
+    const next = encodeURIComponent(location.pathname + location.searchStr)
+    return (
+      // Full navigation (not an SPA route): the browser must leave the app to hit the
+      // backend redirect. encodeURIComponent keeps a query-bearing next intact (§4.1).
+      <a href={`/api/v1/auth/sso/login?next=${next}`} className={buttonClasses('ghost', 'ml-auto')}>
+        Log in with EVE
+      </a>
+    )
+  }
+
+  return (
+    <div className="ml-auto flex items-center gap-3">
+      <img
+        src={`https://images.evetech.net/characters/${user.character_id}/portrait?size=64`}
+        alt=""
+        width={24}
+        height={24}
+        className="h-6 w-6 rounded-full"
+      />
+      <span className="text-ink text-sm">{user.character_name}</span>
+      <Button variant="ghost" onClick={() => logout.mutate()} disabled={logout.isPending}>
+        Log out
+      </Button>
+    </div>
+  )
+}

--- a/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
@@ -1,0 +1,53 @@
+// ABOUTME: ?sso=denied|error notice — renders, dismiss strips only the sso param (replace navigation).
+// ABOUTME: Includes the root-redirect passthrough: /?sso=error must survive to /contracts.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { jsonResponse } from '../../../test/http'
+import { renderApp } from '../../../test/renderApp'
+
+afterEach(() => vi.unstubAllGlobals())
+
+function stubAnonymous() {
+  vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : (input as Request).url
+    if (/\/api\/v1\/me$/.test(url)) return jsonResponse({ detail: 'unauthenticated' }, 401)
+    return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+  })
+}
+
+describe('SsoNotice', () => {
+  it('renders the denied notice and strips ?sso on dismiss', async () => {
+    stubAnonymous()
+    const { router } = renderApp('/contracts?sso=denied')
+    const notice = await screen.findByText(/cancelled/i)
+    expect(notice).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    await waitFor(() => expect((router.state.location.search as Record<string, unknown>).sso).toBeUndefined())
+    expect(screen.queryByText(/cancelled/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the error notice', async () => {
+    stubAnonymous()
+    renderApp('/contracts?sso=error')
+    expect(await screen.findByText(/went wrong/i)).toBeInTheDocument()
+  })
+
+  it('renders the error notice when the flag lands on the root redirect', async () => {
+    // The state-missing callback exit redirects to FRONTEND_ORIGIN/?sso=error (no next
+    // is recoverable there — spec §4.1). The index route's redirect must forward the
+    // search (search: true) or the flag dies before SsoNotice ever mounts.
+    stubAnonymous()
+    const { router } = renderApp('/?sso=error')
+    expect(await screen.findByText(/went wrong/i)).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/contracts')
+    expect((router.state.location.search as Record<string, unknown>).sso).toBe('error')
+  })
+
+  it('renders nothing without an sso param', async () => {
+    stubAnonymous()
+    renderApp('/contracts')
+    await screen.findByRole('link', { name: /log in with eve/i })
+    expect(screen.queryByText(/cancelled|went wrong/i)).not.toBeInTheDocument()
+  })
+})

--- a/app/frontend/web/src/features/auth/components/SsoNotice.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Dismissible ?sso=denied|error notice under the header (polite live region).
+// ABOUTME: Reads the RAW search (typed validateSearch drops sso); dismiss replace-strips only that param.
+import { useLocation, useNavigate } from '@tanstack/react-router'
+
+export function SsoNotice() {
+  const location = useLocation()
+  // `from` is a type hint only (the notice is dismissed only from /contracts —
+  // spec §4.1's SSO redirects always land there): without it, useNavigate()'s
+  // search-reducer type resolves against the untyped root route ("never"),
+  // and `tsc -b` rejects the reducer regardless of the runtime-safe cast below.
+  const navigate = useNavigate({ from: '/contracts/' })
+  const sso = new URLSearchParams(location.searchStr).get('sso')
+  if (sso !== 'denied' && sso !== 'error') return null
+
+  const message =
+    sso === 'denied'
+      ? 'EVE sign-in was cancelled. You can try again anytime.'
+      : 'Something went wrong signing in with EVE. Please try again.'
+
+  const dismiss = () =>
+    navigate({
+      // Strip only sso; preserve the rest of the query. Replace so refresh/back
+      // and copied links don't re-show the notice (§5). Written delete-style, not
+      // rest-destructuring: the repo eslint config reports an unused rest-sibling
+      // binding (`_drop`) as @typescript-eslint/no-unused-vars at error level.
+      search: (prev) => {
+        const rest = { ...(prev as Record<string, unknown>) }
+        delete rest.sso
+        return rest
+      },
+      replace: true,
+    })
+
+  return (
+    <div role="status" aria-live="polite" className="mx-auto flex w-full max-w-[1400px] items-center gap-3 px-4 py-2 text-sm text-ink sm:px-6">
+      <span>{message}</span>
+      <button type="button" onClick={dismiss} aria-label="Dismiss" className="ml-auto rounded px-2 text-ink-dim hover:text-ink">
+        ×
+      </button>
+    </div>
+  )
+}

--- a/app/frontend/web/src/features/auth/components/SsoNotice.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.tsx
@@ -4,10 +4,12 @@ import { useLocation, useNavigate } from '@tanstack/react-router'
 
 export function SsoNotice() {
   const location = useLocation()
-  // `from` is a type hint only (the notice is dismissed only from /contracts —
-  // spec §4.1's SSO redirects always land there): without it, useNavigate()'s
-  // search-reducer type resolves against the untyped root route ("never"),
-  // and `tsc -b` rejects the reducer regardless of the runtime-safe cast below.
+  // `from` scopes the navigation to /contracts, which is where the notice is always
+  // shown (spec §4.1's SSO redirects always land there). It is also required for the
+  // types: without it, useNavigate()'s search-reducer resolves against the untyped
+  // root route ("never") and `tsc -b` rejects the reducer regardless of the
+  // runtime-safe cast below. Since dismiss only ever fires on /contracts, the
+  // resolved-path behavior `from` drives matches the current route either way.
   const navigate = useNavigate({ from: '/contracts/' })
   const sso = new URLSearchParams(location.searchStr).get('sso')
   if (sso !== 'denied' && sso !== 'error') return null

--- a/app/frontend/web/src/features/auth/hooks/useCurrentUser.test.tsx
+++ b/app/frontend/web/src/features/auth/hooks/useCurrentUser.test.tsx
@@ -1,0 +1,58 @@
+// ABOUTME: useCurrentUser hook contract — 200 → user, 401 → null, network failure → null.
+// ABOUTME: Asserts the request URL and that resolving (not rejecting) bypasses retry:1.
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { jsonResponse } from '../../../test/http'
+import { useCurrentUser } from './useCurrentUser'
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: 1 } } })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useCurrentUser', () => {
+  it('returns the user on 200 and requests /api/v1/me', async () => {
+    const calls: string[] = []
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      calls.push(typeof input === 'string' ? input : (input as Request).url ?? String(input))
+      return jsonResponse({ character_id: 91000001, character_name: 'Sesta Hound' })
+    })
+    const { result } = renderHook(() => useCurrentUser(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.data).toEqual({ character_id: 91000001, character_name: 'Sesta Hound' }))
+    expect(calls[0]).toContain('/api/v1/me')
+  })
+
+  it('resolves null on 401 without throwing (no retry storm)', async () => {
+    let count = 0
+    vi.stubGlobal('fetch', async () => {
+      count += 1
+      return jsonResponse({ detail: 'unauthenticated' }, 401)
+    })
+    const { result } = renderHook(() => useCurrentUser(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.isError).toBe(false)
+    expect(count).toBe(1)   // resolved, not retried
+  })
+
+  it('resolves null when fetch itself rejects (network failure)', async () => {
+    // Spec §5: "any failure" resolves to anonymous. openapi-fetch only returns
+    // { error } for HTTP statuses — it THROWS on network-level failure, so the
+    // hook's catch must convert the rejection into null too.
+    let count = 0
+    vi.stubGlobal('fetch', async () => {
+      count += 1
+      throw new TypeError('network down')
+    })
+    const { result } = renderHook(() => useCurrentUser(), { wrapper: wrapper() })
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.isError).toBe(false)
+    expect(count).toBe(1)   // resolved, not retried — the catch bypasses retry:1
+  })
+})

--- a/app/frontend/web/src/features/auth/hooks/useCurrentUser.ts
+++ b/app/frontend/web/src/features/auth/hooks/useCurrentUser.ts
@@ -1,0 +1,24 @@
+// ABOUTME: TanStack Query hook for GET /api/v1/me — the SPA's only identity source.
+// ABOUTME: Resolves null on ANY failure (401/HTTP/network) so anonymous is a state, not an error.
+import { useQuery } from '@tanstack/react-query'
+import { api, type CurrentUser } from '../../../lib/api/client'
+
+// ANY failure — 401, other HTTP errors, or a network-level rejection — resolves to
+// null (anonymous) rather than throwing (spec §5). Resolving bypasses the global
+// retry:1, so there is no retry storm and no error UI for the anonymous state.
+// openapi-fetch returns { error } for HTTP statuses but THROWS on fetch failure,
+// hence the try/catch.
+export function useCurrentUser() {
+  return useQuery<CurrentUser | null>({
+    queryKey: ['auth', 'me'],
+    staleTime: 60_000,
+    queryFn: async () => {
+      try {
+        const { data } = await api.GET('/me')
+        return data ?? null
+      } catch {
+        return null
+      }
+    },
+  })
+}

--- a/app/frontend/web/src/features/auth/hooks/useLogout.test.tsx
+++ b/app/frontend/web/src/features/auth/hooks/useLogout.test.tsx
@@ -1,0 +1,28 @@
+// ABOUTME: useLogout hook contract — POSTs /api/v1/auth/sso/logout and invalidates ['auth','me'].
+// ABOUTME: Asserts URL + METHOD at the fetch seam, not just query invalidation (TEST-5).
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useLogout } from './useLogout'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useLogout', () => {
+  it('POSTs /api/v1/auth/sso/logout and invalidates the me query', async () => {
+    const calls: { url: string; method?: string }[] = []
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input as Request
+      calls.push({ url: req.url ?? String(input), method: req.method ?? init?.method })
+      return new Response(null, { status: 204 })
+    })
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const w = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    const { result } = renderHook(() => useLogout(), { wrapper: w })
+    result.current.mutate()
+    await waitFor(() => expect(calls.length).toBe(1))
+    expect(calls[0].url).toContain('/api/v1/auth/sso/logout')
+    expect(calls[0].method).toBe('POST')
+    await waitFor(() => expect(spy).toHaveBeenCalledWith({ queryKey: ['auth', 'me'] }))
+  })
+})

--- a/app/frontend/web/src/features/auth/hooks/useLogout.ts
+++ b/app/frontend/web/src/features/auth/hooks/useLogout.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Logout mutation — POST /api/v1/auth/sso/logout, then invalidate the ['auth','me'] query.
+// ABOUTME: No redirect: the header re-renders anonymous once the invalidated /me returns 401.
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '../../../lib/api/client'
+
+export function useLogout() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      await api.POST('/auth/sso/logout')
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['auth', 'me'] }),
+  })
+}

--- a/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
+++ b/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
@@ -101,7 +101,7 @@ export function ContractsPage({ search, from }: { search: ContractSearch; from: 
             label to avoid a double read. */}
         <p className="sr-only" role="status" aria-live="polite">
           {data !== undefined
-            ? `${data.total.toLocaleString('en-US')} contracts match your filters`
+            ? `${data.total.toLocaleString('en-US')} ${data.total === 1 ? 'contract matches' : 'contracts match'} your filters`
             : ''}
         </p>
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">

--- a/app/frontend/web/src/features/contracts/components/a11y.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/a11y.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { screen } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 import * as matchers from 'vitest-axe/matchers'
-import { jsonResponse } from '../../../test/http'
+import { anonymousMe, jsonResponse } from '../../../test/http'
 import { renderApp } from '../../../test/renderApp'
 
 expect.extend(matchers)
@@ -50,7 +50,7 @@ afterEach(() => vi.unstubAllGlobals())
 
 describe('accessibility (axe)', () => {
   it('contract list view has no violations', async () => {
-    stubFetch(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] })))
     const { container } = renderApp('/contracts')
     await screen.findByText('Tristan')
 
@@ -58,7 +58,7 @@ describe('accessibility (axe)', () => {
   })
 
   it('contract detail view has no violations', async () => {
-    stubFetch(() => jsonResponse(CONTRACT))
+    stubFetch(anonymousMe(() => jsonResponse(CONTRACT)))
     const { container } = renderApp('/contracts/101')
     await screen.findByRole('heading', { name: 'Tristan' })
 
@@ -66,13 +66,13 @@ describe('accessibility (axe)', () => {
   })
 
   it('empty and error states have no violations', async () => {
-    stubFetch(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] })))
     const empty = renderApp('/contracts')
     await screen.findByText(/no contracts match/i)
     expect(await axe(empty.container)).toHaveNoViolations()
     empty.unmount()
 
-    stubFetch(() => jsonResponse({ detail: 'boom' }, 500))
+    stubFetch(anonymousMe(() => jsonResponse({ detail: 'boom' }, 500)))
     const errored = renderApp('/contracts?search=xyz')
     await screen.findByRole('alert')
     expect(await axe(errored.container)).toHaveNoViolations()

--- a/app/frontend/web/src/features/contracts/components/pages.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/pages.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { jsonResponse } from '../../../test/http'
+import { anonymousMe, jsonResponse } from '../../../test/http'
 import { renderApp } from '../../../test/renderApp'
 
 const CONTRACT = {
@@ -45,7 +45,7 @@ afterEach(() => vi.unstubAllGlobals())
 
 describe('ContractsPage', () => {
   it('renders fetched contracts in the table', async () => {
-    stubFetch(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] })))
 
     renderApp('/contracts')
 
@@ -59,7 +59,7 @@ describe('ContractsPage', () => {
   })
 
   it('announces the result count in a polite status region (WCAG 4.1.3)', async () => {
-    stubFetch(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] })))
 
     renderApp('/contracts')
 
@@ -68,7 +68,7 @@ describe('ContractsPage', () => {
     // without moving focus off a rail control.
     await screen.findByText('Tristan')
     const status = screen.getByRole('status')
-    expect(status).toHaveTextContent('1 contracts match your filters')
+    expect(status).toHaveTextContent('1 contract matches your filters')
     expect(status).toHaveAttribute('aria-live', 'polite')
   })
 
@@ -82,7 +82,7 @@ describe('ContractsPage', () => {
       title: '',
       items: [{ ...CONTRACT.items[0], type_name: null }],
     }
-    stubFetch(() => jsonResponse({ total: 1, page: 1, size: 50, items: [untitled] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 1, page: 1, size: 50, items: [untitled] })))
 
     renderApp('/contracts')
 
@@ -90,7 +90,7 @@ describe('ContractsPage', () => {
   })
 
   it('shows the empty state for zero results', async () => {
-    stubFetch(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] })))
 
     renderApp('/contracts')
 
@@ -98,7 +98,7 @@ describe('ContractsPage', () => {
   })
 
   it('shows the error state with a retry control on failure', async () => {
-    stubFetch(() => jsonResponse({ detail: 'boom' }, 500))
+    stubFetch(anonymousMe(() => jsonResponse({ detail: 'boom' }, 500)))
 
     renderApp('/contracts')
 
@@ -107,16 +107,19 @@ describe('ContractsPage', () => {
   })
 
   it('reads filters from the URL and sends them to the API', async () => {
-    const calls = stubFetch(() =>
-      jsonResponse({ total: 0, page: 1, size: 50, items: [] }),
+    const calls = stubFetch(
+      anonymousMe(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] })),
     )
 
     renderApp('/contracts?region_ids=10000002&is_bpc=true&sort_by=price&sort_direction=asc')
 
     await screen.findByText(/no contracts match/i)
-    expect(calls[0]).toContain('region_ids=10000002')
-    expect(calls[0]).toContain('is_bpc=true')
-    expect(calls[0]).toContain('sort_by=price')
+    // Order-independent: whether /me or the contracts query fires first is
+    // scheduling, not contract (the header now issues its own /me request).
+    const listCall = calls.find((u) => u.includes('/api/v1/contracts/'))!
+    expect(listCall).toContain('region_ids=10000002')
+    expect(listCall).toContain('is_bpc=true')
+    expect(listCall).toContain('sort_by=price')
   })
 
   it('carries a repeated region_ids URL through to repeated API params (shareable-URL contract)', async () => {
@@ -124,12 +127,16 @@ describe('ContractsPage', () => {
     // qss decode of ?region_ids=…&region_ids=… -> parseContractSearch array
     // coercion -> toApiQuery -> openapi-fetch's repeated-array serializer.
     // Guards the two-repeat case that single-value URL tests can't (TEST-5).
-    const calls = stubFetch(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] }))
+    const calls = stubFetch(
+      anonymousMe(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] })),
+    )
 
     renderApp('/contracts?region_ids=10000002&region_ids=10000020')
 
     await screen.findByText(/no contracts match/i)
-    expect(calls[0]).toContain('region_ids=10000002&region_ids=10000020')
+    // Order-independent: see the rationale above.
+    const listCall = calls.find((u) => u.includes('/api/v1/contracts/'))!
+    expect(listCall).toContain('region_ids=10000002&region_ids=10000020')
   })
 
   it('redirects an out-of-range page to the last page instead of a false empty state', async () => {
@@ -137,10 +144,12 @@ describe('ContractsPage', () => {
     // items:[]} without clamping. The app must navigate to the last valid page
     // and render the row — never the contradictory "no contracts match" card
     // (which the "30 matching" header would flatly contradict).
-    stubFetch((url) =>
-      url.includes('page=9')
-        ? jsonResponse({ total: 30, page: 9, size: 50, items: [] })
-        : jsonResponse({ total: 30, page: 1, size: 50, items: [CONTRACT] }),
+    stubFetch(
+      anonymousMe((url) =>
+        url.includes('page=9')
+          ? jsonResponse({ total: 30, page: 9, size: 50, items: [] })
+          : jsonResponse({ total: 30, page: 1, size: 50, items: [CONTRACT] }),
+      ),
     )
 
     const { router } = renderApp('/contracts?page=9')
@@ -151,8 +160,8 @@ describe('ContractsPage', () => {
   })
 
   it('resets to page 1 when a filter changes', async () => {
-    const calls = stubFetch(() =>
-      jsonResponse({ total: 200, page: 3, size: 50, items: [CONTRACT] }),
+    const calls = stubFetch(
+      anonymousMe(() => jsonResponse({ total: 200, page: 3, size: 50, items: [CONTRACT] })),
     )
 
     const { router } = renderApp('/contracts?page=3')
@@ -172,7 +181,7 @@ describe('ContractsPage', () => {
 
 describe('ContractDetailPage', () => {
   it('renders a contract with its items', async () => {
-    stubFetch(() => jsonResponse(CONTRACT))
+    stubFetch(anonymousMe(() => jsonResponse(CONTRACT)))
 
     renderApp('/contracts/101')
 
@@ -192,7 +201,7 @@ describe('ContractDetailPage', () => {
     // and the blank-"" ESI-title trap still falls through to the id when no
     // item name resolves (M1 acceptance discovery, preserved).
     const untitled = { ...CONTRACT, contract_id: 777, title: '' }
-    stubFetch(() => jsonResponse(untitled))
+    stubFetch(anonymousMe(() => jsonResponse(untitled)))
     const named = renderApp('/contracts/777')
     expect(await screen.findByRole('heading', { name: 'Tristan' })).toBeInTheDocument()
     named.unmount()
@@ -204,13 +213,13 @@ describe('ContractDetailPage', () => {
       title: '',
       items: [{ ...CONTRACT.items[0], type_name: null }],
     }
-    stubFetch(() => jsonResponse(bare))
+    stubFetch(anonymousMe(() => jsonResponse(bare)))
     renderApp('/contracts/778')
     expect(await screen.findByRole('heading', { name: 'Contract 778' })).toBeInTheDocument()
   })
 
   it('shows not-found for a 404', async () => {
-    stubFetch(() => jsonResponse({ detail: 'Contract not found' }, 404))
+    stubFetch(anonymousMe(() => jsonResponse({ detail: 'Contract not found' }, 404)))
 
     renderApp('/contracts/999')
 
@@ -225,12 +234,14 @@ describe('ContractDetailPage', () => {
     // no-wasted-request behavior — if the guard is reordered below the
     // isPending branch, the disabled query's isPending stays true forever and
     // this page would render an eternal "Loading contract…" instead.
-    const calls = stubFetch(() => jsonResponse(CONTRACT))
+    const calls = stubFetch(anonymousMe(() => jsonResponse(CONTRACT)))
 
     renderApp('/contracts/abc')
 
     expect(await screen.findByText(/not found/i)).toBeInTheDocument()
-    expect(calls).toHaveLength(0)
+    // The guarded behavior is "no CONTRACTS request" — the header's own /me
+    // request is expected and unrelated to the NaN-guard this test pins.
+    expect(calls.filter((u) => !u.includes('/api/v1/me'))).toHaveLength(0)
   })
 
   it('back link restores the exact list filter/sort state via history when navigated in-app', async () => {
@@ -238,10 +249,12 @@ describe('ContractDetailPage', () => {
     // that list with every URL param intact (PRODUCT #2: the URL is the
     // interface). It uses router.history.back() when the list is behind us,
     // rather than a bare to="/contracts" that would reset to defaults.
-    stubFetch((url) =>
-      /\/contracts\/\d+/.test(url)
-        ? jsonResponse(CONTRACT)
-        : jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] }),
+    stubFetch(
+      anonymousMe((url) =>
+        /\/contracts\/\d+/.test(url)
+          ? jsonResponse(CONTRACT)
+          : jsonResponse({ total: 1, page: 1, size: 50, items: [CONTRACT] }),
+      ),
     )
 
     const { router } = renderApp(
@@ -266,7 +279,7 @@ describe('ContractDetailPage', () => {
   it('back link falls back to the default list on a cold deep link (no in-app history)', async () => {
     // A shared /contracts/$id opened fresh has nothing behind it, so the back
     // control is a plain link to the list rather than a history button.
-    stubFetch(() => jsonResponse(CONTRACT))
+    stubFetch(anonymousMe(() => jsonResponse(CONTRACT)))
 
     renderApp('/contracts/101')
 

--- a/app/frontend/web/src/lib/api/client.ts
+++ b/app/frontend/web/src/lib/api/client.ts
@@ -4,6 +4,7 @@ import type { components, paths } from './schema'
 export type Contract = components['schemas']['ContractSchema']
 export type ContractItem = components['schemas']['ContractItemSchema']
 export type PaginatedContracts = components['schemas']['PaginatedResponse_ContractSchema_']
+export type CurrentUser = components['schemas']['CurrentUserSchema']
 
 export class ApiError extends Error {
   status: number

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -21,6 +21,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/sso/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Callback */
+        get: operations["callback_auth_sso_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Login */
+        get: operations["login_auth_sso_login_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Logout */
+        post: operations["logout_auth_sso_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/cache-test": {
         parameters: {
             query?: never;
@@ -93,6 +144,23 @@ export interface paths {
         };
         /** Health Check */
         get: operations["health_check_health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Me */
+        get: operations["me_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -206,6 +274,13 @@ export interface components {
             /** Volume */
             volume?: number | null;
         };
+        /** CurrentUserSchema */
+        CurrentUserSchema: {
+            /** Character Id */
+            character_id: number;
+            /** Character Name */
+            character_name: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -280,6 +355,88 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
+            };
+        };
+    };
+    callback_auth_sso_callback_get: {
+        parameters: {
+            query?: {
+                state?: string | null;
+                code?: string | null;
+                error?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    login_auth_sso_login_get: {
+        parameters: {
+            query?: {
+                next?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    logout_auth_sso_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -422,6 +579,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    me_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CurrentUserSchema"];
                 };
             };
         };

--- a/app/frontend/web/src/routes.test.tsx
+++ b/app/frontend/web/src/routes.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { screen } from '@testing-library/react'
-import { jsonResponse } from './test/http'
+import { anonymousMe, jsonResponse } from './test/http'
 import { renderApp } from './test/renderApp'
 
 function stubFetch(handler: (url: string) => Response) {
@@ -18,14 +18,14 @@ afterEach(() => vi.unstubAllGlobals())
 
 describe('route skeleton', () => {
   it('redirects / to /contracts', async () => {
-    stubFetch(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] }))
+    stubFetch(anonymousMe(() => jsonResponse({ total: 0, page: 1, size: 50, items: [] })))
     const { router } = renderApp('/')
     await screen.findByRole('heading', { name: /ship contracts/i })
     expect(router.state.location.pathname).toBe('/contracts')
   })
 
   it('renders the contract detail route', async () => {
-    stubFetch(() => jsonResponse({ detail: 'Contract not found' }, 404))
+    stubFetch(anonymousMe(() => jsonResponse({ detail: 'Contract not found' }, 404)))
     renderApp('/contracts/12345')
     await screen.findByText(/not found/i)
   })

--- a/app/frontend/web/src/routes/__root.tsx
+++ b/app/frontend/web/src/routes/__root.tsx
@@ -1,4 +1,6 @@
 import { createRootRoute, Link, Outlet } from '@tanstack/react-router'
+import { HeaderIdentity } from '../features/auth/components/HeaderIdentity'
+import { SsoNotice } from '../features/auth/components/SsoNotice'
 
 export const Route = createRootRoute({
   component: () => (
@@ -14,7 +16,9 @@ export const Route = createRootRoute({
           <span className="hidden text-meta text-ink-dim sm:inline">
             EVE Online ship contract market
           </span>
+          <HeaderIdentity />
         </div>
+        <SsoNotice />
       </header>
       <main className="mx-auto w-full max-w-[1400px] flex-1 px-4 py-5 sm:px-6">
         <Outlet />

--- a/app/frontend/web/src/routes/index.tsx
+++ b/app/frontend/web/src/routes/index.tsx
@@ -2,6 +2,8 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
-    throw redirect({ to: '/contracts' })
+    // Forward the incoming search (e.g. ?sso=error from the state-missing callback
+    // exit) — without `search: true` the redirect drops it entirely (§4.1).
+    throw redirect({ to: '/contracts', search: true })
   },
 })

--- a/app/frontend/web/src/test/http.ts
+++ b/app/frontend/web/src/test/http.ts
@@ -4,3 +4,10 @@ export function jsonResponse(body: unknown, status = 200): Response {
     headers: { 'Content-Type': 'application/json' },
   })
 }
+
+// Wrap a fetch handler so /api/v1/me answers 401 (anonymous) by default. The header
+// queries /me on every page now; without this, URL-agnostic stubs render a bogus
+// authenticated header (name undefined, portrait src .../characters/undefined/...).
+export function anonymousMe(handler: (url: string) => Response): (url: string) => Response {
+  return (url) => (/\/api\/v1\/me$/.test(url) ? jsonResponse({ detail: 'unauthenticated' }, 401) : handler(url))
+}

--- a/app/frontend/web/vite.config.ts
+++ b/app/frontend/web/vite.config.ts
@@ -1,11 +1,17 @@
 import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   // Router plugin must come before the React plugin.
-  plugins: [tanstackRouter({ target: 'react', autoCodeSplitting: true }), react(), tailwindcss()],
+  plugins: [
+    tanstackRouter({ target: 'react', autoCodeSplitting: true }),
+    react(),
+    tailwindcss(),
+    basicSsl(),
+  ],
   server: {
     proxy: {
       // Mirrors the deployment contract: the SPA calls /api/v1/*, the backend

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -2732,7 +2732,7 @@ git commit -m "feat(auth): add SSO login/callback/logout/me routes with state-bi
 
 ## Phase 7 — Backend wiring + codegen
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase7-wiring-codegen`)
 
 **Goal:** Mount the auth routers in `main.py` (the real schema change, D2), strip the Phase 6 fixture's temporary mount, regenerate `openapi.json` + `schema.d.ts`, commit both, add the `/me` `app.openapi()` schema assertion (TEST-1 schema check), and add the spec §4.4 development startup warning.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -74,7 +74,7 @@ notes and commit messages.
 | 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
 | 6 — Auth API routes | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 5), awaiting CI + codex gate | `3394b15`, `8c9b9b5` | spec review byte-exact (conftest additive, main.py untouched per D2); quality APPROVED, mutation probes clean; fix round `8c9b9b5` pinned the §4.4 ungated-logout/`/me` boundary; findings 1+2 (500-vs-redirect via merged sso.py/session.py gaps) → hardening PR |
 | 7 — Backend wiring + codegen | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 6), awaiting CI + codex gate | `5ce0b9a`, `2cdaa53`, a829fe9 | spec review byte-exact; quality ISSUES→fixed (mixed-config rows pin the OR mutant); codegen artifacts regeneration-verified byte-current; path count 6→10, no `/api/v1`; 172 green, tsc clean |
-| 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
+| 8 — Frontend | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 7), awaiting CI + codex gate | `0f3a4c2`, `c206915`, +comment-fix | spec SPEC-COMPLIANT (4 deviations vetted); quality APPROVED (DEV-1 login-`next` mutation-verified non-vacuous); 58 vitest, e2e 72/7-skip, tsc+eslint clean |
 | 9 — Docs | ⬜ Not started | — | pitfalls entries for traps discovered |
 
 <!-- Add "### Deviations" subsection here once execution begins. -->
@@ -2864,7 +2864,7 @@ git commit -m "feat(auth): warn at dev startup when EVE SSO is unconfigured"
 
 ## Phase 8 — Frontend
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase8-frontend`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase8-frontend`, commits `0f3a4c2`, `c206915`, +comment-fix) — spec review SPEC-COMPLIANT (four deviations vetted: DEV-1 login-`next` assertion derives from router ground-truth because `validateSearch` expands the URL defaults — the plan's literal was unreachable; DEV-2 `useNavigate({from})` type-hint; DEV-3 Task 8.4 sweep rewrites match plan; DEV-4 Task 8.5 applied via `Input.tsx`, `FilterRail.tsx` dropped); quality review APPROVED with DEV-1 mutation-verified non-vacuous (dropping encodeURIComponent + the router-drops-param case both caught) and useCurrentUser's resolve-null contract mutation-pinned. Gates: 58 vitest, eslint clean, `tsc -b` clean, e2e 72 passed/7 skipped (desktop+mobile). Comment-fix commit corrected the SsoNotice `from` mechanism note per spec review.
 
 **Goal:** Dev-HTTPS for the SSO callback origin (D-DELTA-1), `useCurrentUser` + `useLogout` hooks, header identity states + `?sso` notice in `__root.tsx`, the `CurrentUser` type alias, the existing-vitest-component-test sweep (URL-aware `/me`=401), the E2E auth fixtures + interceptors + every-existing-spec 401 sweep + new auth specs, and the §9.6 UI nits (spec §5, §9.6).
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -73,7 +73,7 @@ notes and commit messages.
 | 4 — SSO service | ✅ IMPLEMENTED — [PR #29](https://github.com/scarson/hangar-bay/pull/29) OPEN (stacked on #28), CI GREEN, awaiting Sam's codex gate | `a4a7c58`, `1d76416`, `6eb0be3`, `19eeb62` | spec review byte-exact (suite-wide warnings filter rejected → full-length secret); quality ISSUES→fixed: ~35-token adversarial probe clean, error boundary closed, ASCII-canonical ids, string-typed claims |
 | 5 — Auth service + schemas | ✅ IMPLEMENTED — PR OPEN (stacked on `dev`), awaiting CI + codex gate | `f2886b3`, `35c73a7`, `ac3919e` | spec review byte-exact; quality APPROVED; fix round `ac3919e` added mutation-proven expiry/last_login assertions; findings 3+5 → hardening PR |
 | 6 — Auth API routes | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 5), awaiting CI + codex gate | `3394b15`, `8c9b9b5` | spec review byte-exact (conftest additive, main.py untouched per D2); quality APPROVED, mutation probes clean; fix round `8c9b9b5` pinned the §4.4 ungated-logout/`/me` boundary; findings 1+2 (500-vs-redirect via merged sso.py/session.py gaps) → hardening PR |
-| 7 — Backend wiring + codegen | ⬜ Not started | — | mounts routers + commits codegen artifacts |
+| 7 — Backend wiring + codegen | ✅ IMPLEMENTED — PR OPEN (stacked on Phase 6), awaiting CI + codex gate | `5ce0b9a`, `2cdaa53`, a829fe9 | spec review byte-exact; quality ISSUES→fixed (mixed-config rows pin the OR mutant); codegen artifacts regeneration-verified byte-current; path count 6→10, no `/api/v1`; 172 green, tsc clean |
 | 8 — Frontend | ⬜ Not started | — | depends on Phase 7 `schema.d.ts` |
 | 9 — Docs | ⬜ Not started | — | pitfalls entries for traps discovered |
 
@@ -2732,7 +2732,7 @@ git commit -m "feat(auth): add SSO login/callback/logout/me routes with state-bi
 
 ## Phase 7 — Backend wiring + codegen
 
-**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase7-wiring-codegen`)
+**Execution Status:** ✅ IMPLEMENTED (2026-07-13, branch `claude/m2-phase7-wiring-codegen`, commits `5ce0b9a`, `2cdaa53`, `a829fe9`) — spec review byte-exact (mount verbatim, conftest cleanup exactly prescribed, codegen artifacts committed with the schema change per CLAUDE.md, D3 preserved); quality review ISSUES→fixed: openapi.json/schema.d.ts confirmed byte-current by regeneration, no duplicate-operation-id warnings after the fixture-mount strip, schema assertions non-vacuous (mutation-checked), and the fix round added two mixed-config parametrize rows that pin the OR in `warn_if_sso_unconfigured` (an `or→and` mutant previously survived). Path count 6→10 (+4 bare SSO routes, no `/api/v1`). 172 pytest green, pristine; `tsc -b` clean.
 
 **Goal:** Mount the auth routers in `main.py` (the real schema change, D2), strip the Phase 6 fixture's temporary mount, regenerate `openapi.json` + `schema.d.ts`, commit both, add the `/me` `app.openapi()` schema assertion (TEST-1 schema check), and add the spec §4.4 development startup warning.
 

--- a/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
+++ b/docs/superpowers/plans/2026-07-12-m2-eve-sso.md
@@ -2864,7 +2864,7 @@ git commit -m "feat(auth): warn at dev startup when EVE SSO is unconfigured"
 
 ## Phase 8 — Frontend
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS (2026-07-13, branch `claude/m2-phase8-frontend`)
 
 **Goal:** Dev-HTTPS for the SSO callback origin (D-DELTA-1), `useCurrentUser` + `useLogout` hooks, header identity states + `?sso` notice in `__root.tsx`, the `CurrentUser` type alias, the existing-vitest-component-test sweep (URL-aware `/me`=401), the E2E auth fixtures + interceptors + every-existing-spec 401 sweep + new auth specs, and the §9.6 UI nits (spec §5, §9.6).
 


### PR DESCRIPTION
## Phase 8 — Frontend (M2 EVE SSO)

Eighth phase of the M2 EVE SSO login work (F004). Adds the SSO UI: dev-HTTPS for the registered callback origin, the identity hooks, header identity states, the `?sso` redirect notice, and full E2E auth coverage. Sam's own app; standard defensive OAuth, described in plain correctness terms.

**Stacked on #33 (Phase 7).** Base is `claude/m2-phase7-wiring-codegen`.

### What this adds
- **Task 8.0 — dev HTTPS (D-DELTA-1):** `@vitejs/plugin-basic-ssl` serves the dev SPA over `https://localhost:5173` so it matches the registered callback origin char-for-char; the `/api/v1` Vite proxy target stays `http://localhost:8000` (PROXY-1 — the backend never sees TLS). Playwright runs against the HTTPS origin with `ignoreHTTPSErrors`.
- **`useCurrentUser`** — TanStack Query hook for `GET /api/v1/me`; resolves `null` on any failure (401 / other HTTP / network reject) rather than throwing, so anonymous is a state (and the global `retry:1` never storms).
- **`useLogout`** — `POST /api/v1/auth/sso/logout` then invalidates the identity query.
- **`HeaderIdentity`** — logged-in name + logout vs. an anonymous login link whose `next` preserves the current location.
- **`SsoNotice`** — renders a dismissible notice for `?sso=denied|error` and clears the flag without a reload, preserving other query params.
- The existing-component-test `/me`=401 sweep, the "1 contracts" pluralization nit, and the §9.6 price-label typography fix (a real Tailwind-v4 CSS-ordering bug where `.text-sm` won over `.text-data`, fixed in `Input.tsx`).
- E2E auth fixtures + interceptors, a `/me`=401 interceptor across every fixture-lane spec, and a new `e2e/auth.spec.ts`.

### Gates
vitest **58 passed**, `npx eslint .` clean, `npx tsc -b` clean, `npm run e2e` **72 passed / 7 skipped** (desktop + mobile; the skips are the expected responsive project-mismatch + live-smoke).

### Review trail (four deviations from the verbatim blocks, all vetted)
- **Spec-compliance:** SPEC-COMPLIANT. DEV-1 — the anonymous-login-`next` assertion was changed from the plan's literal `/contracts?is_bpc=true` to derive from the router's resolved location, because `validateSearch` expands every default onto the URL (the plan's literal was unreachable); the implementation is unchanged. DEV-2 — `useNavigate({from:'/contracts/'})` for the search-reducer types. DEV-3 — the Task 8.4 sweep rewrites match the plan's guidance without weakening. DEV-4 — Task 8.5 applied via `Input.tsx` (the plan's sanctioned alternate to `FilterRail.tsx`).
- **Quality (mutation probes):** APPROVED. DEV-1 is mutation-verified non-vacuous — dropping `encodeURIComponent` or hardcoding `next='/'` both fail the test, and the canary `toContain('is_bpc%3Dtrue')` catches a router-drops-param regression. `useCurrentUser`'s resolve-null contract is mutation-pinned (making it throw on 401 fails the test). `Input.tsx`'s size-class handling has no regression on the other callers.
- A follow-up comment-fix commit corrected the `SsoNotice` `from` note to accurately describe that it drives runtime path resolution (behaviorally inert here since dismiss only fires on `/contracts`).

Known non-blocking follow-up (recorded, not fixing here): the DEV-1 vitest equality line could be strengthened to decode `next` and assert discrete params; the canary already closes the one gap it leaves.

## Merge classification
`Routine` — SPA-side UI consuming the already-reviewed backend contract.

Leaving open for the `/codex` gate per the M2 merge-gate overlay. Do not self-merge.
