### PR TITLE
fix(web): harden the SSO UI — logout failure, notice dismissal, login next

### DIFF
--- a/app/frontend/web/src/features/auth/components/HeaderIdentity.test.tsx
+++ b/app/frontend/web/src/features/auth/components/HeaderIdentity.test.tsx
@@ -30,6 +30,30 @@ describe('HeaderIdentity', () => {
     expect(expectedNext).toContain('is_bpc%3Dtrue')
   })
 
+  it('strips a stale ?sso flag out of the encoded next', async () => {
+    // A transient ?sso=error|denied on the current URL must not survive into `next` —
+    // otherwise a successful login round-trips the user right back to the stale
+    // error/denied notice. Derive the expectation from the router's own resolved
+    // location (same non-vacuous pattern as the test above), stripped of sso, so this
+    // doesn't degrade into a hand-rolled string that could pass for the wrong reason.
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (/\/api\/v1\/me$/.test(url)) return jsonResponse({ detail: 'unauthenticated' }, 401)
+      return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+    })
+    const { router } = renderApp('/contracts?sso=error&is_bpc=true')
+    const link = await screen.findByRole('link', { name: /log in with eve/i })
+    const params = new URLSearchParams(router.state.location.searchStr)
+    params.delete('sso')
+    const strippedSearch = params.toString()
+    const expectedNext = encodeURIComponent(
+      router.state.location.pathname + (strippedSearch ? `?${strippedSearch}` : ''),
+    )
+    expect(link).toHaveAttribute('href', `/api/v1/auth/sso/login?next=${expectedNext}`)
+    expect(expectedNext).toContain('is_bpc%3Dtrue')
+    expect(expectedNext).not.toContain('sso')
+  })
+
   it('renders portrait + name + logout when authenticated', async () => {
     vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as Request).url

--- a/app/frontend/web/src/features/auth/components/HeaderIdentity.tsx
+++ b/app/frontend/web/src/features/auth/components/HeaderIdentity.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Header identity cluster — login link when anonymous; portrait + name + logout when authenticated.
-// ABOUTME: Login is a FULL navigation to the backend redirect, with next=encodeURIComponent(path+search).
+// ABOUTME: Login is a FULL navigation to the backend redirect, with next=encodeURIComponent(path+search), sso stripped.
 import { useLocation } from '@tanstack/react-router'
 import { Button, buttonClasses } from '../../../components/Button'
 import { useCurrentUser } from '../hooks/useCurrentUser'
@@ -13,7 +13,13 @@ export function HeaderIdentity() {
   if (isPending) return <div className="ml-auto h-8" aria-hidden="true" />
 
   if (!user) {
-    const next = encodeURIComponent(location.pathname + location.searchStr)
+    // Strip a transient ?sso=denied|error before it gets baked into `next` — otherwise a
+    // successful login round-trips the user right back to the stale SSO notice (the
+    // param is only ever meant to be read once, by SsoNotice, then dismissed).
+    const params = new URLSearchParams(location.searchStr)
+    params.delete('sso')
+    const search = params.toString()
+    const next = encodeURIComponent(location.pathname + (search ? `?${search}` : ''))
     return (
       // Full navigation (not an SPA route): the browser must leave the app to hit the
       // backend redirect. encodeURIComponent keeps a query-bearing next intact (§4.1).

--- a/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
@@ -77,13 +77,14 @@ describe('SsoNotice', () => {
       }
       return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
     })
-    const { router } = renderApp('/contracts/123?sso=error&foo=bar')
+    const { router } = renderApp('/contracts/123?sso=error&foo=bar#items')
     const notice = await screen.findByText(/went wrong/i)
     expect(notice).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
     await waitFor(() => expect((router.state.location.search as Record<string, unknown>).sso).toBeUndefined())
     expect(router.state.location.pathname).toBe('/contracts/123')
     expect((router.state.location.search as Record<string, unknown>).foo).toBe('bar')
+    expect(router.state.location.hash).toBe('items')   // deep-linked #anchor survives dismiss
     expect(screen.queryByText(/went wrong/i)).not.toBeInTheDocument()
   })
 })

--- a/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.test.tsx
@@ -50,4 +50,40 @@ describe('SsoNotice', () => {
     await screen.findByRole('link', { name: /log in with eve/i })
     expect(screen.queryByText(/cancelled|went wrong/i)).not.toBeInTheDocument()
   })
+
+  it('dismiss on a contract detail page stays on that page (does not fall back to the list)', async () => {
+    // The notice is mounted at root, so an SSO redirect can land on ANY route, not just
+    // the list. A previous bug resolved dismiss against a hard-coded `from: '/contracts/'`,
+    // which discarded the detail segment: /contracts/123?sso=error&foo=bar -> /contracts?foo=bar.
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as Request).url
+      if (/\/api\/v1\/me$/.test(url)) return jsonResponse({ detail: 'unauthenticated' }, 401)
+      if (/\/api\/v1\/contracts\/123$/.test(url)) {
+        return jsonResponse({
+          contract_id: 123,
+          issuer_id: 1,
+          issuer_corporation_id: 101,
+          start_location_id: 60003760,
+          type: 'item_exchange',
+          status: 'outstanding',
+          title: 'Tristan for Sale',
+          for_corporation: false,
+          date_issued: '2026-07-01T00:00:00Z',
+          date_expired: '2026-07-08T00:00:00Z',
+          price: 1000000,
+          is_ship_contract: true,
+          items: [],
+        })
+      }
+      return jsonResponse({ total: 0, page: 1, size: 50, items: [] })
+    })
+    const { router } = renderApp('/contracts/123?sso=error&foo=bar')
+    const notice = await screen.findByText(/went wrong/i)
+    expect(notice).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    await waitFor(() => expect((router.state.location.search as Record<string, unknown>).sso).toBeUndefined())
+    expect(router.state.location.pathname).toBe('/contracts/123')
+    expect((router.state.location.search as Record<string, unknown>).foo).toBe('bar')
+    expect(screen.queryByText(/went wrong/i)).not.toBeInTheDocument()
+  })
 })

--- a/app/frontend/web/src/features/auth/components/SsoNotice.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.tsx
@@ -1,16 +1,10 @@
 // ABOUTME: Dismissible ?sso=denied|error notice under the header (polite live region).
 // ABOUTME: Reads the RAW search (typed validateSearch drops sso); dismiss replace-strips only that param.
-import { useLocation, useNavigate } from '@tanstack/react-router'
+import { useLocation, useRouter } from '@tanstack/react-router'
 
 export function SsoNotice() {
   const location = useLocation()
-  // `from` scopes the navigation to /contracts, which is where the notice is always
-  // shown (spec §4.1's SSO redirects always land there). It is also required for the
-  // types: without it, useNavigate()'s search-reducer resolves against the untyped
-  // root route ("never") and `tsc -b` rejects the reducer regardless of the
-  // runtime-safe cast below. Since dismiss only ever fires on /contracts, the
-  // resolved-path behavior `from` drives matches the current route either way.
-  const navigate = useNavigate({ from: '/contracts/' })
+  const router = useRouter()
   const sso = new URLSearchParams(location.searchStr).get('sso')
   if (sso !== 'denied' && sso !== 'error') return null
 
@@ -20,7 +14,17 @@ export function SsoNotice() {
       : 'Something went wrong signing in with EVE. Please try again.'
 
   const dismiss = () =>
-    navigate({
+    router.navigate({
+      // The notice is mounted at root, so an SSO redirect (and therefore a dismiss) can
+      // land on ANY route — the list, a contract detail page, wherever. `to` is the
+      // CURRENT pathname (not a hard-coded route) so dismiss stays put instead of
+      // falling back to some fixed location. `router.navigate` (not the typed
+      // `useNavigate({ from })`) is used deliberately: a hard-coded `from` resolves the
+      // search-reducer against ONE route, which silently drops the path segment on any
+      // other route (e.g. /contracts/123 -> /contracts). `to: location.pathname` is a
+      // plain string, not a literal from the generated route union, so it isn't subject
+      // to that per-route resolution at all.
+      to: location.pathname,
       // Strip only sso; preserve the rest of the query. Replace so refresh/back
       // and copied links don't re-show the notice (§5). Written delete-style, not
       // rest-destructuring: the repo eslint config reports an unused rest-sibling

--- a/app/frontend/web/src/features/auth/components/SsoNotice.tsx
+++ b/app/frontend/web/src/features/auth/components/SsoNotice.tsx
@@ -34,6 +34,9 @@ export function SsoNotice() {
         delete rest.sso
         return rest
       },
+      // Preserve any URL fragment (e.g. a deep-linked #anchor): TanStack Router
+      // clears the hash on navigate unless it is carried forward explicitly.
+      hash: true,
       replace: true,
     })
 

--- a/app/frontend/web/src/features/auth/hooks/useLogout.test.tsx
+++ b/app/frontend/web/src/features/auth/hooks/useLogout.test.tsx
@@ -8,7 +8,7 @@ import { useLogout } from './useLogout'
 afterEach(() => vi.unstubAllGlobals())
 
 describe('useLogout', () => {
-  it('POSTs /api/v1/auth/sso/logout and invalidates the me query', async () => {
+  it('POSTs /api/v1/auth/sso/logout and invalidates the me query on success (2xx)', async () => {
     const calls: { url: string; method?: string }[] = []
     vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
       const req = input as Request
@@ -24,5 +24,39 @@ describe('useLogout', () => {
     expect(calls[0].url).toContain('/api/v1/auth/sso/logout')
     expect(calls[0].method).toBe('POST')
     await waitFor(() => expect(spy).toHaveBeenCalledWith({ queryKey: ['auth', 'me'] }))
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+
+  it('does NOT invalidate the me query when the server returns a non-2xx response', async () => {
+    // openapi-fetch resolves non-2xx as { error, response }, it does not throw. A prior
+    // bug invalidated ['auth','me'] on every settlement regardless of status, which — if
+    // the follow-up /me request also failed — rendered a false logged-out header even
+    // though the server-side session was never destroyed.
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify({ detail: 'boom' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const w = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    const { result } = renderHook(() => useLogout(), { wrapper: w })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT invalidate the me query when the request rejects (network failure)', async () => {
+    vi.stubGlobal('fetch', async () => {
+      throw new TypeError('Failed to fetch')
+    })
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const w = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    const { result } = renderHook(() => useLogout(), { wrapper: w })
+    result.current.mutate()
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/app/frontend/web/src/features/auth/hooks/useLogout.ts
+++ b/app/frontend/web/src/features/auth/hooks/useLogout.ts
@@ -1,14 +1,22 @@
 // ABOUTME: Logout mutation — POST /api/v1/auth/sso/logout, then invalidate the ['auth','me'] query.
 // ABOUTME: No redirect: the header re-renders anonymous once the invalidated /me returns 401.
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { api } from '../../../lib/api/client'
+import { api, ApiError } from '../../../lib/api/client'
 
 export function useLogout() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async () => {
-      await api.POST('/auth/sso/logout')
+      // openapi-fetch resolves non-2xx as { error, response } rather than throwing, so a
+      // failed logout would otherwise look like a completed mutation. Only a confirmed
+      // 2xx counts as "logged out" here; both a non-2xx response and a thrown/network
+      // failure must leave the mutation in an error state so the header does NOT flip to
+      // anonymous while the server-side session may still be live. (The generated schema
+      // only declares a 204 response for this operation, so `error`'s type is `never` —
+      // check `response.ok` directly rather than the typed `error` field.)
+      const { response } = await api.POST('/auth/sso/logout')
+      if (!response.ok) throw new ApiError(response.status)
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['auth', 'me'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['auth', 'me'] }),
   })
 }


### PR DESCRIPTION
## Frontend hardening — codex review findings from the M2 SSO UI

Fixes three correctness findings a codex review surfaced in the merged M2 SSO UI (Phase 8). Sam's own app; standard defensive OAuth, described in plain correctness terms. TDD throughout — each finding was reproduced with a failing test before the fix.

- **[P1] `useLogout` false logged-out state on failure** (`useLogout.ts`). The hook invalidated the `/me` query on every settlement including a network rejection, and ignored a non-2xx `{ error }`. So a logout POST that failed (offline, 5xx) could still flip the header to anonymous while the server session stayed valid — a real hazard on a shared machine. Now it throws on `!response.ok` and invalidates only on a confirmed 2xx (`onSuccess`), leaving the mutation in an error state otherwise so the header keeps showing the authenticated user.
- **`SsoNotice` dismissal lost the location on detail pages** (`SsoNotice.tsx`). `useNavigate({ from: '/contracts/' })` hard-scoped dismissal to the list route, so dismissing from `/contracts/123?sso=error&foo=bar` navigated to `/contracts`, dropping the detail id and other params. Now dismisses to the current pathname, stripping only `sso`.
- **`HeaderIdentity` login `next` carried the stale `sso` flag** (`HeaderIdentity.tsx`). Logging in from `/contracts?sso=error` round-tripped the user back to the stale error notice. Now strips `sso` from `next` before encoding.

### Gates
vitest **62 passed** (+4 over baseline), `eslint` clean, `tsc -b` clean, `npm run e2e` **72 passed / 7 skipped** (`auth.spec.ts` green on desktop + mobile).

## Merge classification
`Routine` — SPA-side robustness fixes over the already-reviewed contract.
