### PR TITLE
fix(backend): harden the SSO backend — fail-closed DB gate, token/JWT/session error boundaries

### DIFF
--- a/app/backend/.env.example
+++ b/app/backend/.env.example
@@ -3,6 +3,11 @@
 
 ENVIRONMENT="development"
 LOG_LEVEL="INFO"
+# Explicit opt-in required for the destructive dev-only drop_all/create_all
+# recreate cycle at startup. Both ENVIRONMENT=="development" AND this flag must
+# be true; ENVIRONMENT defaulting to "development" (e.g. this var simply absent
+# in a deploy) is never, by itself, enough to trigger the recreate.
+DB_RECREATE_ON_STARTUP="true"
 
 # Required — no default. Backend refuses to start without these.
 DATABASE_URL="postgresql+asyncpg://user:password@localhost:5432/hangar_bay_db"

--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -86,7 +86,15 @@ def _clear_state_cookie(resp: Response) -> None:
 
 
 # --- routes ---
-@router.get("/login", dependencies=[Depends(require_sso_configured)])
+@router.get(
+    "/login",
+    dependencies=[Depends(require_sso_configured)],
+    # login always redirects (302 to EVE's authorize endpoint); it never returns
+    # 200 application/json. Without this the generated OpenAPI schema (and the
+    # typed frontend client built from it) mis-declares the response shape.
+    status_code=status.HTTP_302_FOUND,
+    response_class=RedirectResponse,
+)
 async def login(request: Request, next: str = "/", redis: Redis = Depends(get_cache)):
     s = get_settings()
     validated_next = validate_next(next)
@@ -162,7 +170,20 @@ async def _finalize_login(db: AsyncSession, redis: Redis, identity, tokens: dict
         return None
 
 
-@router.get("/callback")
+@router.get(
+    "/callback",
+    # callback's success path redirects (302 to FRONTEND_ORIGIN); it never
+    # returns 200 application/json. Without this the generated OpenAPI schema
+    # (and the typed frontend client built from it) mis-declares the response
+    # shape. The two hard-error exits (§ (C) binding mismatch, and the shared
+    # not-configured guard) are documented explicitly since they're real,
+    # reachable alternate outcomes, not just the redirect-based ones.
+    status_code=status.HTTP_302_FOUND,
+    responses={
+        400: {"description": "SSO state/browser-binding mismatch."},
+        503: {"description": "EVE SSO is not configured."},
+    },
+)
 async def callback(
     request: Request,
     state: Optional[str] = None,

--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -20,7 +20,7 @@ from ..core.logging import get_logger, log_key_event
 from ..core.session import create_session, destroy_session, get_current_session
 from ..core.token_cipher import is_token_cipher_configured
 from ..db import get_db
-from ..schemas.auth import CurrentUserSchema
+from ..schemas.auth import CurrentUserSchema, ErrorDetail
 from ..services import auth_service, sso
 
 logger = get_logger(__name__)
@@ -94,6 +94,9 @@ def _clear_state_cookie(resp: Response) -> None:
     # typed frontend client built from it) mis-declares the response shape.
     status_code=status.HTTP_302_FOUND,
     response_class=RedirectResponse,
+    responses={
+        503: {"model": ErrorDetail, "description": "EVE SSO is not configured."},
+    },
 )
 async def login(request: Request, next: str = "/", redis: Redis = Depends(get_cache)):
     s = get_settings()
@@ -190,8 +193,8 @@ async def _finalize_login(db: AsyncSession, redis: Redis, identity, tokens: dict
     status_code=status.HTTP_302_FOUND,
     response_class=RedirectResponse,
     responses={
-        400: {"description": "SSO state/browser-binding mismatch."},
-        503: {"description": "EVE SSO is not configured."},
+        400: {"model": ErrorDetail, "description": "SSO state/browser-binding mismatch."},
+        503: {"model": ErrorDetail, "description": "EVE SSO is not configured."},
     },
 )
 async def callback(

--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -160,13 +160,21 @@ async def _finalize_login(db: AsyncSession, redis: Redis, identity, tokens: dict
     None on ANY failure (DB, cache, etc.) — by this point the code has already
     been spent at EVE's token endpoint (a single-use authorization_code), so
     there is no safe way to retry the exchange; the caller redirects sso=error
-    and the user retries login from scratch."""
+    and the user retries login from scratch.
+
+    A failing flush (e.g. the concurrent first-login race: two same-character
+    callbacks both insert character_id -> IntegrityError) leaves the DB
+    transaction poisoned. Roll it back before returning, otherwise get_db's
+    post-request commit raises PendingRollbackError and turns the intended
+    sso=error redirect into a 500. The rollback is the graceful handling of
+    that race — it degrades to sso=error and the user simply retries."""
     try:
         user = await auth_service.upsert_user(db, identity, tokens)
         return await create_session(
             redis, user_id=user.id, character_id=identity.character_id, character_name=identity.character_name
         )
     except Exception:
+        await db.rollback()
         return None
 
 

--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -181,12 +181,14 @@ async def _finalize_login(db: AsyncSession, redis: Redis, identity, tokens: dict
 @router.get(
     "/callback",
     # callback's success path redirects (302 to FRONTEND_ORIGIN); it never
-    # returns 200 application/json. Without this the generated OpenAPI schema
-    # (and the typed frontend client built from it) mis-declares the response
-    # shape. The two hard-error exits (§ (C) binding mismatch, and the shared
+    # returns 200 application/json. status_code + response_class together make
+    # the generated OpenAPI schema declare an empty 302 redirect (not a JSON
+    # body), so the typed frontend client doesn't mis-declare the response shape.
+    # The two hard-error exits (§ (C) binding mismatch, and the shared
     # not-configured guard) are documented explicitly since they're real,
     # reachable alternate outcomes, not just the redirect-based ones.
     status_code=status.HTTP_302_FOUND,
+    response_class=RedirectResponse,
     responses={
         400: {"description": "SSO state/browser-binding mismatch."},
         503: {"description": "EVE SSO is not configured."},

--- a/app/backend/src/fastapi_app/api/auth.py
+++ b/app/backend/src/fastapi_app/api/auth.py
@@ -50,9 +50,27 @@ def validate_next(value: Optional[str]) -> str:
     return value
 
 
+def _parse_state_payload(raw: str) -> Optional[dict]:
+    """Decode + shape-validate a GETDEL'd state payload. Returns None for anything
+    undecodable or malformed (non-JSON, a non-object document, or one missing/
+    mistyping "next") so the caller folds it into the same "state missing" path
+    (exit B) as an expired/absent state, instead of 500ing on stored["next"]."""
+    try:
+        candidate = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(candidate, dict) or not isinstance(candidate.get("next"), str):
+        return None
+    return candidate
+
+
 def build_redirect(frontend_origin: str, next_path: str, flag: Optional[str]) -> str:
     split = urlsplit(next_path)
-    query = parse_qsl(split.query, keep_blank_values=True)
+    # Strip any existing sso param first: a retry landing back on e.g.
+    # /contracts?sso=error must not accumulate a second sso param — the
+    # frontend's URLSearchParams.get('sso') reads only the first value, so a
+    # stale leftover would silently win over the one we're about to append.
+    query = [(k, v) for k, v in parse_qsl(split.query, keep_blank_values=True) if k != "sso"]
     if flag is not None:
         query.append(("sso", flag))
     rebuilt = urlunsplit(("", "", split.path or "/", urlencode(query), split.fragment))
@@ -96,7 +114,55 @@ def _signing_key_provider() -> jwt.PyJWKClient:
     return jwt.PyJWKClient(get_settings().ESI_SSO_JWKS_URI)
 
 
-@router.get("/callback", dependencies=[Depends(require_sso_configured)])
+async def _sso_configured_guard_response() -> Optional[Response]:
+    """503 (with hb_sso_state cleared) if SSO isn't configured, else None.
+    Called inline rather than via the declarative `dependencies=` list used on
+    /login, so the 503 exit can still clear the cookie — a dependency-raised
+    HTTPException never reaches the response built in the route body, so it
+    would otherwise leave a stale cookie on the browser."""
+    try:
+        await require_sso_configured()
+    except HTTPException as exc:
+        resp = JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+        _clear_state_cookie(resp)
+        return resp
+    return None
+
+
+async def _resolve_stored_state(redis: Redis, state: Optional[str]) -> Optional[dict]:
+    """GETDEL + shape-validate the stored state payload (single-use consume).
+    None if state is falsy, the key was already gone, or the payload is
+    undecodable/malformed."""
+    if not state:
+        return None
+    raw = await redis.getdel(f"sso_state:{state}")
+    if raw is None:
+        return None
+    return _parse_state_payload(raw)
+
+
+def _sso_flagged_redirect(frontend_origin: str, next_path: str, flag: str) -> RedirectResponse:
+    resp = RedirectResponse(build_redirect(frontend_origin, next_path, flag), status_code=status.HTTP_302_FOUND)
+    _clear_state_cookie(resp)
+    return resp
+
+
+async def _finalize_login(db: AsyncSession, redis: Redis, identity, tokens: dict) -> Optional[str]:
+    """Exit F: upsert the user + mint a session. Returns the new session id, or
+    None on ANY failure (DB, cache, etc.) — by this point the code has already
+    been spent at EVE's token endpoint (a single-use authorization_code), so
+    there is no safe way to retry the exchange; the caller redirects sso=error
+    and the user retries login from scratch."""
+    try:
+        user = await auth_service.upsert_user(db, identity, tokens)
+        return await create_session(
+            redis, user_id=user.id, character_id=identity.character_id, character_name=identity.character_name
+        )
+    except Exception:
+        return None
+
+
+@router.get("/callback")
 async def callback(
     request: Request,
     state: Optional[str] = None,
@@ -107,13 +173,13 @@ async def callback(
     db: AsyncSession = Depends(get_db),
 ):
     s = get_settings()
+    guard_resp = await _sso_configured_guard_response()
+    if guard_resp is not None:
+        return guard_resp
+
     started = time.perf_counter()
     cookie_state = request.cookies.get(_STATE_COOKIE)
-    stored = None
-    if state:
-        raw = await redis.getdel(f"sso_state:{state}")   # single-use consume
-        if raw is not None:
-            stored = json.loads(raw)
+    stored = await _resolve_stored_state(redis, state)
 
     # (A) EVE-side denial — no session, redirect with sso=denied.
     # Sanctioned ordering (plan-review round 2): the denial exit precedes the binding
@@ -121,15 +187,11 @@ async def callback(
     # redirect) wins over the hard 400; a pinning test covers denial+cookie-mismatch.
     if error is not None:
         nxt = validate_next(stored["next"]) if stored else "/"
-        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, nxt, "denied"), status_code=status.HTTP_302_FOUND)
-        _clear_state_cookie(resp)
-        return resp
+        return _sso_flagged_redirect(s.FRONTEND_ORIGIN, nxt, "denied")
 
-    # (B) State missing/expired (GETDEL miss) — innocent, redirect with sso=error.
+    # (B) State missing/expired (GETDEL miss, or an undecodable/malformed payload) — innocent, redirect with sso=error.
     if stored is None:
-        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, "/", "error"), status_code=status.HTTP_302_FOUND)
-        _clear_state_cookie(resp)
-        return resp
+        return _sso_flagged_redirect(s.FRONTEND_ORIGIN, "/", "error")
 
     # (C) State live but browser binding fails — the only hard-400 exit (callback doesn't match this browser's login).
     if cookie_state is None or cookie_state != state:
@@ -150,9 +212,7 @@ async def callback(
         log_key_event(logger, "sso_callback", success=False,
                       duration_ms=(time.perf_counter() - started) * 1000,
                       outcome="token_exchange_failed")
-        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
-        _clear_state_cookie(resp)
-        return resp
+        return _sso_flagged_redirect(s.FRONTEND_ORIGIN, validated_next, "error")
 
     # (E) Validate JWT — the JWKS fetch inside is synchronous urllib, so run the whole
     # validation off the event loop (§3.2). Failure → sso=error redirect.
@@ -166,13 +226,15 @@ async def callback(
         log_key_event(logger, "sso_callback", success=False,
                       duration_ms=(time.perf_counter() - started) * 1000,
                       outcome="jwt_validation_failed")
-        resp = RedirectResponse(build_redirect(s.FRONTEND_ORIGIN, validated_next, "error"), status_code=status.HTTP_302_FOUND)
-        _clear_state_cookie(resp)
-        return resp
+        return _sso_flagged_redirect(s.FRONTEND_ORIGIN, validated_next, "error")
 
-    # (F) Upsert + session.
-    user = await auth_service.upsert_user(db, identity, tokens)
-    sid = await create_session(redis, user_id=user.id, character_id=identity.character_id, character_name=identity.character_name)
+    # (F) Upsert + session — see _finalize_login for why any failure there is sso=error, never a 500.
+    sid = await _finalize_login(db, redis, identity, tokens)
+    if sid is None:
+        log_key_event(logger, "sso_callback", success=False,
+                      duration_ms=(time.perf_counter() - started) * 1000,
+                      outcome="user_store_failed")
+        return _sso_flagged_redirect(s.FRONTEND_ORIGIN, validated_next, "error")
     log_key_event(logger, "sso_callback", success=True,
                   duration_ms=(time.perf_counter() - started) * 1000,
                   outcome="login", character_id=identity.character_id)

--- a/app/backend/src/fastapi_app/core/config.py
+++ b/app/backend/src/fastapi_app/core/config.py
@@ -14,6 +14,12 @@ class Settings(BaseSettings):
     # General
     ENVIRONMENT: Literal["development", "production", "test"] = "development"
     LOG_LEVEL: str = "INFO"
+    # Fail-closed opt-in for the destructive dev-only drop_all/create_all recreate
+    # cycle at startup (see main.create_db_tables). ENVIRONMENT alone is NOT
+    # sufficient — it defaults to "development" when simply omitted, so a
+    # production deploy that forgot to set ENVIRONMENT must not also need to
+    # forget this flag before its schema is safe. Both must be explicit.
+    DB_RECREATE_ON_STARTUP: bool = False
 
     # ESI data API
     ESI_BASE_URL: str = "https://esi.evetech.net"

--- a/app/backend/src/fastapi_app/core/config.py
+++ b/app/backend/src/fastapi_app/core/config.py
@@ -12,13 +12,19 @@ class Settings(BaseSettings):
     """Application settings loaded from environment variables and app/backend/src/.env."""
 
     # General
-    ENVIRONMENT: Literal["development", "production", "test"] = "development"
+    # Secure-by-default: an OMITTED ENVIRONMENT resolves to "production", never
+    # "development" (P1). Every dev-only branch keyed on ENVIRONMENT == "development"
+    # — the destructive create_db_tables recreate, SQL echo (db.py), the
+    # cookie Secure flag (api/auth.py), and the SSO-unconfigured startup warning —
+    # therefore takes its safe/off setting when the var is unset. .env.example
+    # sets ENVIRONMENT=development, so copying it preserves the dev workflow.
+    ENVIRONMENT: Literal["development", "production", "test"] = "production"
     LOG_LEVEL: str = "INFO"
     # Fail-closed opt-in for the destructive dev-only drop_all/create_all recreate
-    # cycle at startup (see main.create_db_tables). ENVIRONMENT alone is NOT
-    # sufficient — it defaults to "development" when simply omitted, so a
-    # production deploy that forgot to set ENVIRONMENT must not also need to
-    # forget this flag before its schema is safe. Both must be explicit.
+    # cycle at startup (see main.create_db_tables). Requires BOTH this flag true
+    # AND ENVIRONMENT == "development"; with ENVIRONMENT secure-by-default to
+    # "production" (above), an unset environment never recreates even if this
+    # flag was inherited/copied as true.
     DB_RECREATE_ON_STARTUP: bool = False
 
     # ESI data API

--- a/app/backend/src/fastapi_app/core/session.py
+++ b/app/backend/src/fastapi_app/core/session.py
@@ -82,13 +82,15 @@ async def read_session(redis: Redis, sid: str, *, now: Optional[int] = None) -> 
     if now >= deadline:
         await redis.delete(key)   # over the 30-day cap: delete in the same request
         return None
-    if deadline - now < s.SESSION_IDLE_TTL_SECONDS:
-        # Absolute EXPIREAT(deadline), not a relative EXPIRE(deadline-now): the
-        # `now` above was captured before the GETEX await, so a relative EXPIRE
-        # computed against it and applied after further latency can land past
-        # the real 30-day deadline. EXPIREAT is race-free — it lands at exactly
-        # `deadline` regardless of how much wall time elapsed in between (§7).
-        await redis.expireat(key, deadline)
+    # Always apply an ABSOLUTE EXPIREAT at min(sliding idle window, deadline), never
+    # a conditional relative EXPIRE. The GETEX above renewed the key RELATIVE to the
+    # command's own (server-side) execution time, which can be later than the `now`
+    # captured before the await; a cap gated on that stale `now` can be skipped even
+    # though the renewal actually lands past the deadline (§7). EXPIREAT at an
+    # absolute timestamp is immune to that latency: it caps at `deadline` when near
+    # it, and slides at `now + idle_ttl` otherwise, so the key can never be
+    # scheduled to outlive the 30-day deadline regardless of command latency.
+    await redis.expireat(key, min(now + s.SESSION_IDLE_TTL_SECONDS, deadline))
     return payload
 
 

--- a/app/backend/src/fastapi_app/core/session.py
+++ b/app/backend/src/fastapi_app/core/session.py
@@ -69,9 +69,13 @@ async def create_session(
 
 async def read_session(redis: Redis, sid: str, *, now: Optional[int] = None) -> Optional[dict]:
     s = get_settings()
-    now = int(time.time()) if now is None else now
     key = _session_key(sid)
     raw = await redis.getex(key, ex=s.SESSION_IDLE_TTL_SECONDS)  # atomic read + idle renew (D4)
+    # Capture the clock AFTER the GETEX round-trip (not before), so the deadline check
+    # and the absolute EXPIREAT below reflect the time the renewal actually landed —
+    # never a pre-await `now` that command latency could have left stale. An injected
+    # `now` (tests) is used verbatim for determinism.
+    now = int(time.time()) if now is None else now
     if raw is None:
         return None
     payload = _parse_session_payload(raw)

--- a/app/backend/src/fastapi_app/core/session.py
+++ b/app/backend/src/fastapi_app/core/session.py
@@ -94,6 +94,17 @@ async def read_session(redis: Redis, sid: str, *, now: Optional[int] = None) -> 
     # absolute timestamp is immune to that latency: it caps at `deadline` when near
     # it, and slides at `now + idle_ttl` otherwise, so the key can never be
     # scheduled to outlive the 30-day deadline regardless of command latency.
+    #
+    # ACCEPTED TRADEOFF (spec §4.2 / D4, sanctioned two-command read): GETEX and this
+    # EXPIREAT are two separate commands, not one atomic op — a single capped-renew is
+    # impossible because the cap needs `created_at`, which lives inside the value being
+    # read. So two bounded, non-security edges remain: (a) a crash/cancel between GETEX
+    # and EXPIREAT can leave the key stored up to idle_ttl past `deadline`, and
+    # (b) concurrent reads can move the idle expiry a few seconds. NEITHER serves an
+    # over-cap session — the `now >= deadline` check above (keyed on `created_at`) is the
+    # authoritative boundary and rejects+deletes any expired session on read, whatever
+    # the physical key TTL. Closing these fully needs a Lua/EVAL atomic read-and-capped-
+    # renew; deferred to M3 as a session-store enhancement, out of scope for M2.
     await redis.expireat(key, min(now + s.SESSION_IDLE_TTL_SECONDS, deadline))
     return payload
 

--- a/app/backend/src/fastapi_app/core/session.py
+++ b/app/backend/src/fastapi_app/core/session.py
@@ -16,6 +16,36 @@ def _session_key(sid: str) -> str:
     return f"session:{sid}"
 
 
+def _is_plain_int(value: object) -> bool:
+    """True ints only — bool is an int subclass in Python and JSON true/false
+    must not silently pass as a timestamp/id."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _parse_session_payload(raw: str) -> Optional[dict]:
+    """Decode + shape-validate a stored session payload. Returns None for anything
+    undecodable or malformed — truncated JSON, a non-object document, or one
+    missing/mistyping the fields read_session and downstream consumers (get_
+    current_session, /me) rely on — so the caller can treat it as an absent
+    session (DEL + None) instead of a raw exception reaching the callback/route
+    as a 500."""
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not _is_plain_int(payload.get("created_at")):
+        return None
+    if not _is_plain_int(payload.get("user_id")):
+        return None
+    if not _is_plain_int(payload.get("character_id")):
+        return None
+    if not isinstance(payload.get("character_name"), str):
+        return None
+    return payload
+
+
 async def create_session(
     redis: Redis,
     *,
@@ -44,14 +74,21 @@ async def read_session(redis: Redis, sid: str, *, now: Optional[int] = None) -> 
     raw = await redis.getex(key, ex=s.SESSION_IDLE_TTL_SECONDS)  # atomic read + idle renew (D4)
     if raw is None:
         return None
-    payload = json.loads(raw)
+    payload = _parse_session_payload(raw)
+    if payload is None:
+        await redis.delete(key)   # corrupt/malformed payload: treat as absent, never 500
+        return None
     deadline = payload["created_at"] + s.SESSION_ABSOLUTE_TTL_SECONDS
     if now >= deadline:
         await redis.delete(key)   # over the 30-day cap: delete in the same request
         return None
-    remaining = deadline - now
-    if remaining < s.SESSION_IDLE_TTL_SECONDS:
-        await redis.expire(key, remaining)  # never outlive the absolute cap
+    if deadline - now < s.SESSION_IDLE_TTL_SECONDS:
+        # Absolute EXPIREAT(deadline), not a relative EXPIRE(deadline-now): the
+        # `now` above was captured before the GETEX await, so a relative EXPIRE
+        # computed against it and applied after further latency can land past
+        # the real 30-day deadline. EXPIREAT is race-free — it lands at exactly
+        # `deadline` regardless of how much wall time elapsed in between (§7).
+        await redis.expireat(key, deadline)
     return payload
 
 

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -156,8 +156,12 @@ def warn_if_sso_unconfigured() -> None:
     if settings.ENVIRONMENT != "development":
         return
     if not settings.ESI_CLIENT_ID or not is_token_cipher_configured():
+        # Only login and callback are guarded (require_sso_configured) — logout
+        # stays operational (204) regardless, so the message must name the two
+        # affected routes rather than claim the whole /auth/sso/* family 503s.
         logger.warning(
-            "EVE SSO is not configured (ESI_CLIENT_ID/TOKEN_CIPHER_KEYS empty); /auth/sso/* returns 503."
+            "EVE SSO is not configured (ESI_CLIENT_ID/TOKEN_CIPHER_KEYS empty); "
+            "/auth/sso/login and /auth/sso/callback return 503."
         )
 
 

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -129,9 +129,20 @@ async def create_db_tables():
     """
     Drops and recreates database tables to keep the dev schema current (ENV-2).
     Development-only: production schema management is future migrations work (M2 SSO design spec §8, future work).
+
+    Fail-closed gate (P1): ENVIRONMENT alone is not a sufficient guard, because it
+    defaults to "development" when the env var is simply omitted — an operator who
+    forgets to set ENVIRONMENT in a production deploy would otherwise still trip
+    this destructive path. DB_RECREATE_ON_STARTUP is a second, independently-defaulted-
+    False flag that must ALSO be explicitly set, so an omitted/unknown environment
+    never recreates regardless of the flag, and the flag never fires outside
+    development regardless of how it's set.
     """
-    if settings.ENVIRONMENT != "development":
-        logger.info("Skipping destructive create_db_tables (ENVIRONMENT=%s).", settings.ENVIRONMENT)
+    if settings.ENVIRONMENT != "development" or not settings.DB_RECREATE_ON_STARTUP:
+        logger.info(
+            "Skipping destructive create_db_tables (ENVIRONMENT=%s, DB_RECREATE_ON_STARTUP=%s).",
+            settings.ENVIRONMENT, settings.DB_RECREATE_ON_STARTUP,
+        )
         return
     logger.info("Dropping and recreating database tables...")
     async with async_engine.begin() as conn:

--- a/app/backend/src/fastapi_app/main.py
+++ b/app/backend/src/fastapi_app/main.py
@@ -130,13 +130,12 @@ async def create_db_tables():
     Drops and recreates database tables to keep the dev schema current (ENV-2).
     Development-only: production schema management is future migrations work (M2 SSO design spec §8, future work).
 
-    Fail-closed gate (P1): ENVIRONMENT alone is not a sufficient guard, because it
-    defaults to "development" when the env var is simply omitted — an operator who
-    forgets to set ENVIRONMENT in a production deploy would otherwise still trip
-    this destructive path. DB_RECREATE_ON_STARTUP is a second, independently-defaulted-
-    False flag that must ALSO be explicitly set, so an omitted/unknown environment
-    never recreates regardless of the flag, and the flag never fires outside
-    development regardless of how it's set.
+    Fail-closed gate (P1): two independent conditions, and ENVIRONMENT is
+    secure-by-default. An OMITTED ENVIRONMENT resolves to "production" (see
+    core/config.py), so an operator who forgets to set it never trips this path
+    even if DB_RECREATE_ON_STARTUP was inherited/copied as true. Recreate requires
+    BOTH ENVIRONMENT == "development" AND DB_RECREATE_ON_STARTUP true, set
+    explicitly — .env.example sets both, preserving the dev workflow.
     """
     if settings.ENVIRONMENT != "development" or not settings.DB_RECREATE_ON_STARTUP:
         logger.info(

--- a/app/backend/src/fastapi_app/schemas/auth.py
+++ b/app/backend/src/fastapi_app/schemas/auth.py
@@ -1,4 +1,4 @@
-# ABOUTME: Pydantic response schema for GET /me — the SPA's only identity source.
+# ABOUTME: Pydantic response schemas for the auth routes — the SPA's only identity source.
 from pydantic import BaseModel, ConfigDict
 
 
@@ -7,3 +7,11 @@ class CurrentUserSchema(BaseModel):
     character_name: str
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ErrorDetail(BaseModel):
+    """The FastAPI HTTPException / JSONResponse error body shape ({"detail": ...}),
+    declared so the login/callback 400 and 503 responses carry their real JSON
+    body in the OpenAPI contract instead of an empty one."""
+
+    detail: str

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -14,15 +14,15 @@ from .sso import VerifiedIdentity
 
 
 async def upsert_user(db: AsyncSession, identity: VerifiedIdentity, tokens: dict) -> User:
-    # TODO(M3): select-then-insert race — two simultaneous first logins for the
-    # same character_id can both see `user is None` and both attempt an insert;
-    # the loser's flush raises IntegrityError (character_id is unique) instead
-    # of being handled as "someone else just created this row, use it." A
-    # concurrency-safe upsert (catch IntegrityError + re-select, or an actual
-    # INSERT ... ON CONFLICT) is deferred — this is a narrow first-login-only
-    # window, not reachable from any M2 endpoint's normal single-request flow,
-    # and a clean concurrent-session integration test for it is nontrivial to
-    # keep non-flaky, so it's left for M3 rather than risked here.
+    # Concurrent first-login race: two simultaneous first logins for the same
+    # character_id can both see `user is None` and both attempt an insert; the
+    # loser's flush raises IntegrityError (character_id is unique). This is
+    # handled correctly at the callable boundary — _finalize_login rolls the
+    # poisoned transaction back and redirects sso=error, so the loser simply
+    # retries (and the winner's row is then found). A future optimization
+    # (TODO(M3): catch IntegrityError + re-select, or INSERT ... ON CONFLICT)
+    # could make the loser succeed transparently instead of retrying, but the
+    # graceful-retry behavior is already correct for M2.
     now = datetime.now(timezone.utc)
     expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
     user = (

--- a/app/backend/src/fastapi_app/services/auth_service.py
+++ b/app/backend/src/fastapi_app/services/auth_service.py
@@ -14,6 +14,15 @@ from .sso import VerifiedIdentity
 
 
 async def upsert_user(db: AsyncSession, identity: VerifiedIdentity, tokens: dict) -> User:
+    # TODO(M3): select-then-insert race — two simultaneous first logins for the
+    # same character_id can both see `user is None` and both attempt an insert;
+    # the loser's flush raises IntegrityError (character_id is unique) instead
+    # of being handled as "someone else just created this row, use it." A
+    # concurrency-safe upsert (catch IntegrityError + re-select, or an actual
+    # INSERT ... ON CONFLICT) is deferred — this is a narrow first-login-only
+    # window, not reachable from any M2 endpoint's normal single-request flow,
+    # and a clean concurrent-session integration test for it is nontrivial to
+    # keep non-flaky, so it's left for M3 rather than risked here.
     now = datetime.now(timezone.utc)
     expires_at = now + timedelta(seconds=int(tokens["expires_in"]))
     user = (
@@ -76,6 +85,13 @@ async def refresh_user_tokens(db: AsyncSession, http_client: "httpx.AsyncClient"
             client_id=s.ESI_CLIENT_ID, client_secret=s.ESI_CLIENT_SECRET.get_secret_value(),
         )
     except sso.SsoTokenError as exc:
+        # TODO(M3): not every 400 here is actually invalid_grant (EVE can 400 for
+        # other request-shape reasons too) — this should discriminate on the
+        # response body's error field, not status_code alone. Also: concurrent
+        # callers refreshing the same user's tokens can race on this read-modify-
+        # write (no row lock / optimistic version check); needs a concurrency-safe
+        # rotation strategy. Deferred: no M2 endpoint calls refresh_user_tokens —
+        # it's M3 foundation only.
         if exc.status_code == 400:   # invalid-grant shape: the grant itself is dead
             await mark_for_reauth(db, user)
             return

--- a/app/backend/src/fastapi_app/services/sso.py
+++ b/app/backend/src/fastapi_app/services/sso.py
@@ -53,6 +53,26 @@ def build_authorize_url(*, state: str, client_id: str, redirect_uri: str, author
     return f"{authorize_url}?{urlencode(params)}"
 
 
+def _validate_token_body(payload: dict, *, status_code: int) -> None:
+    """A 200 with a malformed success body (missing/wrong-typed access_token or
+    expires_in) must fail here — SsoTokenError is _post_token's declared contract —
+    rather than let downstream callers (upsert_user, refresh_token_pair) raise a raw
+    KeyError/ValueError and turn the callback into a 500 instead of taking the
+    sso=error path."""
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise SsoTokenError("token endpoint response missing access_token", status_code=status_code)
+    expires_in = payload.get("expires_in")
+    if expires_in is None or isinstance(expires_in, bool):
+        raise SsoTokenError("token endpoint response missing expires_in", status_code=status_code)
+    try:
+        int(expires_in)
+    except (TypeError, ValueError) as exc:
+        raise SsoTokenError(
+            "token endpoint response has non-numeric expires_in", status_code=status_code
+        ) from exc
+
+
 async def _post_token(client: httpx.AsyncClient, *, token_url: str, client_id: str, client_secret: str, form: dict) -> dict:
     try:
         resp = await client.post(
@@ -72,6 +92,7 @@ async def _post_token(client: httpx.AsyncClient, *, token_url: str, client_id: s
         raise SsoTokenError("token endpoint returned a non-JSON body", status_code=resp.status_code) from exc
     if not isinstance(payload, dict):
         raise SsoTokenError("token endpoint returned a non-object body", status_code=resp.status_code)
+    _validate_token_body(payload, status_code=resp.status_code)
     return payload
 
 
@@ -101,13 +122,22 @@ def validate_access_token(token: str, *, key_provider: SigningKeyProvider, clien
             leeway=_LEEWAY_SECONDS,         # exp/nbf/iat skew tolerance (§3.2)
             options={"verify_iss": False, "require": ["exp", "sub", "aud"]},
         )
-    except (jwt.InvalidTokenError, jwt.exceptions.PyJWKClientError) as exc:
-        # PyJWKClientError (kid miss / JWKS fetch failure) is NOT an InvalidTokenError
-        # subclass — without this clause a kid miss escapes as a 500 at the callback.
+    except (
+        jwt.InvalidTokenError,
+        jwt.exceptions.PyJWKClientError,
+        jwt.exceptions.PyJWKSetError,
+    ) as exc:
+        # PyJWKClientError (kid miss / JWKS fetch failure) and PyJWKSetError (an
+        # empty/keyless JWKS document) are NOT InvalidTokenError subclasses — and
+        # PyJWKSetError is not even a PyJWKClientError subclass — without this
+        # clause either escapes as a 500 at the callback instead of SsoJwtError.
         raise SsoJwtError(f"jwt validation failed: {exc}") from exc
 
     iss = claims.get("iss")
-    if iss not in _VALID_ISSUERS:            # dual-iss allowlist checked explicitly (§2.2)
+    # iss must be a string to be checked for allowlist membership at all — a
+    # list/dict iss is unhashable and would raise a raw TypeError from the
+    # frozenset `in` check below rather than the declared SsoJwtError contract.
+    if not isinstance(iss, str) or iss not in _VALID_ISSUERS:  # dual-iss allowlist (§2.2)
         raise SsoJwtError(f"unexpected iss: {iss!r}")
 
     sub = claims.get("sub", "")
@@ -116,7 +146,10 @@ def validate_access_token(token: str, *, key_provider: SigningKeyProvider, clien
         raise SsoJwtError(f"unexpected sub shape: {sub!r}")
     id_part = sub[len(prefix):]
     # ASCII digits only — int() alone accepts sign/underscore/whitespace/non-ASCII digits.
-    if not re.fullmatch(r"[0-9]+", id_part):
+    # Also bound the length: int() rejects digit strings past Python's integer-string
+    # conversion limit (sys.int_info.default_max_str_digits, ~4300) with a raw
+    # ValueError, and no real EVE character id is anywhere near that long.
+    if not re.fullmatch(r"[0-9]+", id_part) or len(id_part) > 20:
         raise SsoJwtError(f"non-canonical character id in sub: {sub!r}")
     character_id = int(id_part)
 

--- a/app/backend/src/fastapi_app/services/sso.py
+++ b/app/backend/src/fastapi_app/services/sso.py
@@ -1,5 +1,6 @@
 # ABOUTME: EVE SSO protocol — authorize URL, code exchange, refresh grant, local JWT validation.
 # ABOUTME: JWKS comes through an injectable key-provider seam so the validator runs for real in tests (m2-eve-sso design spec §3.2; §-refs below cite that spec).
+import math
 import re
 from dataclasses import dataclass
 from typing import Optional, Protocol
@@ -65,9 +66,14 @@ def _validate_token_body(payload: dict, *, status_code: int) -> None:
     expires_in = payload.get("expires_in")
     if expires_in is None or isinstance(expires_in, bool):
         raise SsoTokenError("token endpoint response missing expires_in", status_code=status_code)
+    # Reject non-finite floats (JSON "Infinity"/"NaN", e.g. expires_in: 1e309) up
+    # front: int(inf) raises OverflowError, which is neither ValueError nor
+    # TypeError — caught here too so it maps to SsoTokenError rather than 500ing.
+    if isinstance(expires_in, float) and not math.isfinite(expires_in):
+        raise SsoTokenError("token endpoint response has non-finite expires_in", status_code=status_code)
     try:
         int(expires_in)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise SsoTokenError(
             "token endpoint response has non-numeric expires_in", status_code=status_code
         ) from exc
@@ -126,11 +132,16 @@ def validate_access_token(token: str, *, key_provider: SigningKeyProvider, clien
         jwt.InvalidTokenError,
         jwt.exceptions.PyJWKClientError,
         jwt.exceptions.PyJWKSetError,
+        TypeError,
+        OverflowError,
     ) as exc:
         # PyJWKClientError (kid miss / JWKS fetch failure) and PyJWKSetError (an
         # empty/keyless JWKS document) are NOT InvalidTokenError subclasses — and
-        # PyJWKSetError is not even a PyJWKClientError subclass — without this
-        # clause either escapes as a 500 at the callback instead of SsoJwtError.
+        # PyJWKSetError is not even a PyJWKClientError subclass. TypeError and
+        # OverflowError come from PyJWT's own NumericDate handling on a malformed
+        # exp/nbf/iat claim (e.g. exp: {} -> TypeError, exp: 1e309 -> int(inf)
+        # OverflowError), also not InvalidTokenError subclasses. Without this
+        # clause any of them escapes as a 500 at the callback instead of SsoJwtError.
         raise SsoJwtError(f"jwt validation failed: {exc}") from exc
 
     iss = claims.get("iss")

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -298,6 +298,74 @@ async def test_callback_upsert_user_failure_redirects_sso_error_not_500(
 
 
 @pytest.mark.asyncio
+async def test_callback_upsert_integrity_error_rolls_back_not_500(
+    auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session
+):
+    # Finding 2: a failing flush at exit F poisons the DB transaction. Without a
+    # rollback in the exception handler the session stays poisoned, so get_db's
+    # post-request commit() raises PendingRollbackError and turns the intended
+    # sso=error redirect into a 500. This is the M2-reachable first-login race in
+    # miniature: two concurrent same-character callbacks both insert character_id
+    # -> IntegrityError.
+    #
+    # auth_client's default get_db override returns the begin()-wrapped db_session,
+    # which never runs get_db's post-yield commit — the exact step that 500s. So
+    # model production get_db faithfully here: a plain session (no begin() wrapper)
+    # that commits after the request and rolls back + re-raises on error, on the
+    # same test engine (tables already created by the db_session fixture).
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from fastapi_app.api import auth as auth_api
+    from fastapi_app.db import get_db
+    from fastapi_app.main import app as real_app
+    from fastapi_app.models import User
+
+    # Own async engine against the test DB (tables already created + committed by
+    # the db_session fixture, so a separate connection sees them).
+    engine = create_async_engine(str(settings.DATABASE_URL_TESTS), echo=False)
+    maker = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async def _production_get_db():
+        async with maker() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    real_app.dependency_overrides[get_db] = _production_get_db
+
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    httpx_mock.add_response(
+        url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"}
+    )
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+
+    async def _racing_upsert(db, identity, tokens):
+        db.add(User(character_id=identity.character_id))
+        await db.flush()                       # first insert lands
+        db.add(User(character_id=identity.character_id))
+        await db.flush()                       # duplicate character_id -> IntegrityError, poisons the session
+
+    monkeypatch.setattr(auth_api.auth_service, "upsert_user", _racing_upsert)
+
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302     # not a 500 from get_db committing a poisoned transaction
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+    # The rollback undid the poisoned insert: a fresh session sees no rows, proving
+    # both that the transaction was recovered and that nothing partial persisted.
+    async with maker() as verify:
+        rows = (await verify.execute(select(User))).scalars().all()
+    assert rows == []
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_callback_503_not_configured_clears_state_cookie(auth_client, monkeypatch):
     # Finding 8c: the shared not-configured guard runs before the callback body,
     # so it must clear hb_sso_state itself (defense-in-depth — the state is

--- a/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_flow.py
@@ -230,6 +230,92 @@ async def test_callback_never_yields_protocol_relative_location(auth_client, con
 
 
 @pytest.mark.asyncio
+async def test_callback_malformed_state_json_redirects_sso_error_not_500(auth_client, configured_sso):
+    # Finding 8a: a truncated/undecodable stored state value must not 500 the
+    # callback — it must fall through the same path as a missing/expired state.
+    await auth_client.fake_redis.set("sso_state:STATE123", "{not valid json", ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+    state_clear = next(c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state="))
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()
+
+
+@pytest.mark.asyncio
+async def test_callback_state_payload_not_object_redirects_sso_error_not_500(auth_client, configured_sso):
+    await auth_client.fake_redis.set("sso_state:STATE123", json.dumps(["not", "an", "object"]), ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+
+
+@pytest.mark.asyncio
+async def test_callback_state_payload_missing_next_redirects_sso_error_not_500(auth_client, configured_sso):
+    await auth_client.fake_redis.set("sso_state:STATE123", json.dumps({"foo": "bar"}), ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=error"
+
+
+@pytest.mark.asyncio
+async def test_callback_denial_with_malformed_state_payload_falls_back_to_root(auth_client, configured_sso):
+    # Exit (A) also indexes stored["next"] — a malformed-but-present state payload
+    # must fall back to "/" rather than 500 on the denial path too.
+    await auth_client.fake_redis.set("sso_state:STATE123", json.dumps({"foo": "bar"}), ex=600)
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "error": "access_denied"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/?sso=denied"
+
+
+@pytest.mark.asyncio
+async def test_callback_upsert_user_failure_redirects_sso_error_not_500(
+    auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch
+):
+    # Finding 8b: exit F (upsert_user) must never 500 the callback — any error
+    # there takes the same sso=error redirect as the earlier exchange/JWT exits.
+    from fastapi_app.api import auth as auth_api
+    priv, pub = rsa_keypair
+    _inject_jwks(monkeypatch, pub)
+    httpx_mock.add_response(
+        url=TOKEN_URL, json={"access_token": _sign_access_token(priv), "expires_in": 1200, "token_type": "Bearer"}
+    )
+    await _seed_state(auth_client, next_="/contracts")
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+
+    async def _boom(db, identity, tokens):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(auth_api.auth_service, "upsert_user", _boom)
+
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "CODE"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == f"{settings.FRONTEND_ORIGIN}/contracts?sso=error"
+    assert "hb_session=" not in resp.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_callback_503_not_configured_clears_state_cookie(auth_client, monkeypatch):
+    # Finding 8c: the shared not-configured guard runs before the callback body,
+    # so it must clear hb_sso_state itself (defense-in-depth — the state is
+    # unconsumed on a 503, but the cookie shouldn't be left stale on the browser).
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "ESI_CLIENT_ID", "test-client")
+    monkeypatch.setattr(settings, "TOKEN_CIPHER_KEYS", SecretStr("   "))
+    auth_client.cookies.set("hb_sso_state", "STATE123")
+    resp = await auth_client.get("/auth/sso/callback", params={"state": "STATE123", "code": "C"}, follow_redirects=False)
+    assert resp.status_code == 503
+    state_clear = next(
+        (c for c in resp.headers.get_list("set-cookie") if c.startswith("hb_sso_state=")), None
+    )
+    assert state_clear is not None
+    assert "max-age=0" in state_clear.lower() or "expires=" in state_clear.lower()
+
+
+@pytest.mark.asyncio
 async def test_callback_owner_hash_transfer(auth_client, configured_sso, httpx_mock, rsa_keypair, monkeypatch, db_session):
     from sqlalchemy import select
     from fastapi_app.models import User

--- a/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
+++ b/app/backend/src/fastapi_app/tests/api/test_auth_helpers.py
@@ -34,3 +34,22 @@ def test_build_redirect_cannot_yield_protocol_relative_location():
     # next was already validated to "/", so the Location stays under FRONTEND_ORIGIN.
     out = build_redirect("https://localhost:5173", validate_next("//evil.com"), flag="error")
     assert out == "https://localhost:5173/?sso=error"
+
+
+def test_build_redirect_strips_existing_sso_param_before_appending_its_own():
+    # Finding 8d: a retry landing back on e.g. /contracts?sso=error must not
+    # accumulate a second sso param — URLSearchParams.get('sso') on the frontend
+    # reads only the FIRST value, so a stale one would silently win over the
+    # freshly-appended one.
+    out = build_redirect("https://localhost:5173", "/contracts?sso=error", flag="denied")
+    assert out == "https://localhost:5173/contracts?sso=denied"
+
+
+def test_build_redirect_strips_existing_sso_param_with_no_new_flag():
+    out = build_redirect("https://localhost:5173", "/contracts?sso=error", flag=None)
+    assert out == "https://localhost:5173/contracts"
+
+
+def test_build_redirect_strips_existing_sso_param_among_other_params():
+    out = build_redirect("https://localhost:5173", "/contracts?sso=error&type=bpc", flag="denied")
+    assert out == "https://localhost:5173/contracts?type=bpc&sso=denied"

--- a/app/backend/src/fastapi_app/tests/api/test_me_schema.py
+++ b/app/backend/src/fastapi_app/tests/api/test_me_schema.py
@@ -13,6 +13,18 @@ def test_me_and_sso_routes_mounted_bare():
     assert not any(p.startswith("/api/v1") for p in schema["paths"])
 
 
+def test_login_and_callback_declare_302_not_200():
+    # Finding 10: login/callback always redirect — they never return 200
+    # application/json — so the generated OpenAPI schema (and the typed
+    # frontend client built from it) must declare 302, not the FastAPI
+    # default of 200, or callers mis-type the response shape.
+    schema = app.openapi()
+    login_responses = schema["paths"]["/auth/sso/login"]["get"]["responses"]
+    callback_responses = schema["paths"]["/auth/sso/callback"]["get"]["responses"]
+    assert "302" in login_responses and "200" not in login_responses
+    assert "302" in callback_responses and "200" not in callback_responses
+
+
 def test_me_response_schema_shape():
     schema = app.openapi()
     ref = schema["paths"]["/me"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]

--- a/app/backend/src/fastapi_app/tests/core/test_config.py
+++ b/app/backend/src/fastapi_app/tests/core/test_config.py
@@ -88,7 +88,8 @@ def test_reconciled_non_sso_defaults(monkeypatch):
     assert s.ESI_TIMEOUT == 20.0
     assert s.AGGREGATION_REGION_IDS == [10000002]
     assert s.AGGREGATION_DEV_CONTRACT_LIMIT == 100
-    assert s.ENVIRONMENT == "development"
+    assert s.ENVIRONMENT == "production"   # secure-by-default: unset ENVIRONMENT is prod, never dev (P1)
+    assert s.DB_RECREATE_ON_STARTUP is False   # destructive recreate is opt-in and off by default
 
 
 def test_region_ids_validator_direct_construction_forms(monkeypatch):

--- a/app/backend/src/fastapi_app/tests/core/test_session.py
+++ b/app/backend/src/fastapi_app/tests/core/test_session.py
@@ -14,8 +14,14 @@ ABSOLUTE = settings.SESSION_ABSOLUTE_TTL_SECONDS  # 2592000
 
 @pytest.mark.asyncio
 async def test_create_then_read_renews_idle_window():
-    r = FakeRedis()
+    # Injected clock in lockstep with the business timestamps: read_session now
+    # applies an ABSOLUTE EXPIREAT(min(now + idle_ttl, deadline)), so the fake's
+    # own clock must share the timeline of `now`/`created` for the renewal to land
+    # where expected (a real-wall-clock fake with a 1970-era injected now would put
+    # the absolute deadline in the distant past and purge the key immediately).
     now = 1_000_000
+    clock = {"t": float(now)}
+    r = FakeRedis(clock=lambda: clock["t"])
     sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=now)
     key = f"session:{sid}"
     assert r.ttl_for(key) == IDLE
@@ -23,10 +29,11 @@ async def test_create_then_read_renews_idle_window():
     # itself — straight after create it would hold even if read never renewed.
     await r.expire(key, 123)
     assert r.ttl_for(key) == 123
+    clock["t"] = float(now + 100)
     payload = await sess.read_session(r, sid, now=now + 100)
     assert payload["character_id"] == 91
     assert payload["created_at"] == now
-    assert r.ttl_for(key) == IDLE            # GETEX renewed the idle window
+    assert r.ttl_for(key) == IDLE            # read renewed the idle window (min(now+idle, deadline) == now+idle)
 
 
 @pytest.mark.asyncio
@@ -246,6 +253,37 @@ async def test_read_caps_ttl_with_absolute_expireat_immune_to_command_latency():
     assert payload is not None
     deadline = created + ABSOLUTE
     assert r.expires_at[key] == deadline   # exact — not deadline + LATENCY
+
+
+@pytest.mark.asyncio
+async def test_read_idle_renewal_cannot_outlive_deadline_under_latency():
+    # Finding 3: the EXPIREAT cap was CONDITIONAL on the stale pre-GETEX `now`.
+    # When the session is not near its deadline at that captured `now`
+    # (deadline - now >= idle_ttl, so the old `< idle_ttl` branch was skipped),
+    # GETEX's RELATIVE idle renewal still lands at getex_time + idle_ttl — which,
+    # under command latency (getex_time > captured now), can cross the 30-day
+    # absolute deadline with no cap ever applied. The key must NEVER be scheduled
+    # to expire after the absolute deadline, regardless of latency.
+    clock = {"t": 0.0}
+    r = FakeRedis(clock=lambda: clock["t"])
+    created = 1_000_000
+    clock["t"] = float(created)
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
+    key = f"session:{sid}"
+    deadline = created + ABSOLUTE
+
+    # Captured now EXACTLY idle_ttl before the deadline: deadline - now == idle_ttl,
+    # so the old conditional `deadline - now < idle_ttl` is False and skips the cap.
+    now = deadline - IDLE
+    LATENCY = 30
+    # Pin the key freshly-renewed so it is still alive at read time (a real session
+    # this close to its deadline has been renewed on every prior request).
+    r.expires_at[key] = now + LATENCY + 1000
+    # GETEX executes LATENCY seconds after the captured `now`.
+    clock["t"] = now + LATENCY
+    payload = await sess.read_session(r, sid, now=now)
+    assert payload is not None
+    assert r.expires_at[key] <= deadline   # capped — not (now+LATENCY)+IDLE == deadline+LATENCY
 
 
 @pytest.mark.asyncio

--- a/app/backend/src/fastapi_app/tests/core/test_session.py
+++ b/app/backend/src/fastapi_app/tests/core/test_session.py
@@ -31,12 +31,24 @@ async def test_create_then_read_renews_idle_window():
 
 @pytest.mark.asyncio
 async def test_read_caps_ttl_so_key_never_outlives_absolute_deadline():
-    r = FakeRedis()
+    # Injected clock kept in lockstep with the business `now`/`created` values:
+    # the cap step now applies an ABSOLUTE EXPIREAT(deadline) (§7), so ttl_for's
+    # introspection (when - fake-clock-now) is only meaningful if the fake's own
+    # clock shares the same timeline as the business timestamps under test.
     created = 1_000_000
+    clock = {"t": float(created)}
+    r = FakeRedis(clock=lambda: clock["t"])
     sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
     key = f"session:{sid}"
     # 100s before the 30-day deadline: renewal must cap at 100, not idle (604800).
+    # Pin the fake's TTL bookkeeping to "freshly renewed" before the jump — this
+    # test is about the cap-application step, not about surviving ~30 days of
+    # simulated time with zero intervening renewals (a real deployment renews on
+    # every request; see test_idle_expiry_actually_expires_key_when_never_renewed
+    # for the honest idle-lapse case).
     now = created + ABSOLUTE - 100
+    r.expires_at[key] = now + 10_000
+    clock["t"] = float(now)
     payload = await sess.read_session(r, sid, now=now)
     assert payload is not None
     assert r.ttl_for(key) == 100
@@ -140,6 +152,112 @@ async def test_get_optional_session_none_without_cookie():
     r = FakeRedis()
     request = SimpleNamespace(cookies={})
     assert await sess.get_optional_session(request, redis=r) is None
+
+
+@pytest.mark.asyncio
+async def test_read_malformed_json_payload_is_treated_as_absent():
+    # Finding 6: a truncated/undecodable value must not 500 read_session — it
+    # must be treated the same as "no session" (and the corrupt key purged).
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = "{not valid json"
+    assert await sess.read_session(r, "bad-sid", now=1) is None
+    assert await r.exists(key) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_non_object_json_payload_is_treated_as_absent():
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = json.dumps(["not", "an", "object"])
+    assert await sess.read_session(r, "bad-sid", now=1) is None
+    assert await r.exists(key) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_payload_missing_created_at_is_treated_as_absent():
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = json.dumps({"user_id": 1, "character_id": 91, "character_name": "X"})
+    assert await sess.read_session(r, "bad-sid", now=1) is None
+    assert await r.exists(key) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_payload_with_non_int_created_at_is_treated_as_absent():
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = json.dumps(
+        {"user_id": 1, "character_id": 91, "character_name": "X", "created_at": "not-a-number"}
+    )
+    assert await sess.read_session(r, "bad-sid", now=1) is None
+    assert await r.exists(key) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_current_session_401s_on_corrupt_payload():
+    from types import SimpleNamespace
+    from fastapi import HTTPException
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = "{not valid json"
+    request = SimpleNamespace(cookies={settings.SESSION_COOKIE_NAME: "bad-sid"})
+    with pytest.raises(HTTPException) as exc:
+        await sess.get_current_session(request, redis=r)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_optional_session_none_on_corrupt_payload():
+    from types import SimpleNamespace
+    r = FakeRedis()
+    key = "session:bad-sid"
+    r.store[key] = "{not valid json"
+    request = SimpleNamespace(cookies={settings.SESSION_COOKIE_NAME: "bad-sid"})
+    assert await sess.get_optional_session(request, redis=r) is None
+
+
+@pytest.mark.asyncio
+async def test_read_caps_ttl_with_absolute_expireat_immune_to_command_latency():
+    # Finding 7: the old code captured `now` before GETEX, then applied a
+    # RELATIVE EXPIRE(deadline-now) after another await — so if wall time moves
+    # between that captured `now` and the EXPIRE actually landing (a concurrent
+    # request, GC pause, network latency...), the key's real expiry drifts PAST
+    # the 30-day absolute deadline. An absolute EXPIREAT(deadline) is immune to
+    # this: it lands at exactly `deadline` no matter how much latency elapsed.
+    clock = {"t": 0.0}
+    r = FakeRedis(clock=lambda: clock["t"])
+    created = 1_000_000
+    clock["t"] = float(created)
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=created)
+    key = f"session:{sid}"
+
+    now = created + ABSOLUTE - 100   # 100s from the hard cap: renewal must cap
+    LATENCY = 30
+    # Only the cap-application step is under test here, so pin the key's fake-TTL
+    # bookkeeping to "freshly renewed" first — otherwise fast-forwarding the clock
+    # this far in one jump would also trip the (unrelated, and itself correct as
+    # of finding 9) idle-TTL purge before the cap logic ever runs.
+    r.expires_at[key] = now + LATENCY + 10_000
+    # Simulate the command reaching the fake's clock LATENCY seconds after the
+    # caller's captured `now` — the exact gap a relative EXPIRE mis-handles.
+    clock["t"] = now + LATENCY
+    payload = await sess.read_session(r, sid, now=now)
+    assert payload is not None
+    deadline = created + ABSOLUTE
+    assert r.expires_at[key] == deadline   # exact — not deadline + LATENCY
+
+
+@pytest.mark.asyncio
+async def test_idle_expiry_actually_expires_key_when_never_renewed():
+    # Finding 9 follow-through: FakeRedis previously never expired keys, so this
+    # scenario (idle TTL lapses with zero renewing reads in between) could not be
+    # exercised honestly — read_session would still "succeed" via a stale GETEX.
+    clock = {"t": 1_000_000.0}
+    r = FakeRedis(clock=lambda: clock["t"])
+    sid = await sess.create_session(r, user_id=1, character_id=91, character_name="X", now=int(clock["t"]))
+    clock["t"] += IDLE + 1   # idle window lapsed with no intervening renewal
+    assert await sess.read_session(r, sid, now=int(clock["t"])) is None
 
 
 @pytest.mark.asyncio

--- a/app/backend/src/fastapi_app/tests/fake_redis.py
+++ b/app/backend/src/fastapi_app/tests/fake_redis.py
@@ -1,6 +1,7 @@
 # ABOUTME: In-memory async Valkey double for session + SSO-state tests (decode_responses=True).
 # ABOUTME: Extends the _FakeLockRedis precedent with get/set(ex)/getex/getdel/delete/exists + TTL.
-from typing import Dict, Optional
+import time as _time_module
+from typing import Callable, Dict, Optional, Union
 
 
 class FakeRedis:
@@ -8,57 +9,107 @@ class FakeRedis:
 
     Deliberately mirrors real Redis semantics: SET without EX makes the key
     persistent (any recorded TTL is cleared), and EXPIRE with ttl <= 0 deletes the key.
+
+    TTL is honored for real: a key past its absolute expiry reads as absent on
+    get/getex/getdel/exists, purged lazily on access. The clock is injectable (any
+    zero-arg callable returning epoch seconds) so tests can simulate time passing
+    without real sleeps; it defaults to time.time for callers that don't care.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, clock: Optional[Callable[[], float]] = None) -> None:
         self.store: Dict[str, str] = {}
         self.ttls: Dict[str, int] = {}   # last-set TTL per key, for test assertions
+        self.expires_at: Dict[str, float] = {}  # absolute expiry (epoch seconds), honored on read
+        self._clock: Callable[[], float] = clock or _time_module.time
+
+    def _now(self) -> float:
+        return self._clock()
+
+    def _purge_if_expired(self, key: str) -> None:
+        deadline = self.expires_at.get(key)
+        if deadline is not None and self._now() >= deadline:
+            self.store.pop(key, None)
+            self.ttls.pop(key, None)
+            self.expires_at.pop(key, None)
+
+    def _set_relative_ttl(self, key: str, ttl: int) -> None:
+        self.ttls[key] = ttl
+        self.expires_at[key] = self._now() + ttl
 
     async def get(self, key: str) -> Optional[str]:
+        self._purge_if_expired(key)
         return self.store.get(key)
 
     async def set(self, key: str, value: str, ex: Optional[int] = None, nx: bool = False):
+        self._purge_if_expired(key)
         if nx and key in self.store:
             return None
         self.store[key] = value
         if ex is not None:
-            self.ttls[key] = ex
+            self._set_relative_ttl(key, ex)
         else:
             self.ttls.pop(key, None)
+            self.expires_at.pop(key, None)
         return True
 
     async def getex(self, key: str, ex: Optional[int] = None) -> Optional[str]:
+        self._purge_if_expired(key)
         value = self.store.get(key)
         if value is not None and ex is not None:
-            self.ttls[key] = ex
+            self._set_relative_ttl(key, ex)
         return value
 
     async def getdel(self, key: str) -> Optional[str]:
+        self._purge_if_expired(key)
         self.ttls.pop(key, None)
+        self.expires_at.pop(key, None)
         return self.store.pop(key, None)   # atomic single-use consume
 
     async def expire(self, key: str, ttl: int) -> bool:
+        self._purge_if_expired(key)
         if key in self.store:
             if ttl <= 0:
                 del self.store[key]
                 self.ttls.pop(key, None)
+                self.expires_at.pop(key, None)
                 return True
-            self.ttls[key] = ttl
+            self._set_relative_ttl(key, ttl)
             return True
         return False
+
+    async def expireat(self, key: str, when: Union[int, float]) -> bool:
+        """Absolute-deadline expiry (race-free vs. a relative EXPIRE computed
+        against a stale `now`captured before an earlier await — see session.py's
+        read path). `when` is an epoch-seconds timestamp, matching redis-py's
+        int/datetime `when` param (datetimes aren't accepted here; callers pass ints)."""
+        self._purge_if_expired(key)
+        if key not in self.store:
+            return False
+        if when <= self._now():
+            del self.store[key]
+            self.ttls.pop(key, None)
+            self.expires_at.pop(key, None)
+            return True
+        self.expires_at[key] = when
+        self.ttls[key] = int(when - self._now())
+        return True
 
     async def delete(self, *keys: str) -> int:
         removed = 0
         for key in keys:
+            self._purge_if_expired(key)
             if key in self.store:
                 del self.store[key]
                 self.ttls.pop(key, None)
+                self.expires_at.pop(key, None)
                 removed += 1
         return removed
 
     async def exists(self, key: str) -> int:
+        self._purge_if_expired(key)
         return 1 if key in self.store else 0
 
     def ttl_for(self, key: str) -> Optional[int]:
         """Test-only introspection of the last-applied TTL."""
+        self._purge_if_expired(key)
         return self.ttls.get(key)

--- a/app/backend/src/fastapi_app/tests/services/test_sso.py
+++ b/app/backend/src/fastapi_app/tests/services/test_sso.py
@@ -208,6 +208,29 @@ async def test_exchange_code_200_null_expires_in_raises_sso_token_error(httpx_mo
             )
 
 
+@pytest.mark.asyncio
+async def test_exchange_code_200_non_finite_expires_in_raises_sso_token_error(httpx_mock):
+    # Finding 4: a body whose expires_in is out-of-range (1e309) parses to float
+    # inf via resp.json(); int(inf) raises OverflowError, which is neither
+    # ValueError nor TypeError, so it would escape _validate_token_body and 500
+    # the callback instead of taking the sso=error path. Sent as raw text (the
+    # wire form a real endpoint could emit) because strict JSON serialization
+    # refuses to encode inf.
+    import httpx
+    httpx_mock.add_response(
+        url="https://login.eveonline.com/v2/oauth/token",
+        text='{"access_token": "AT", "expires_in": 1e309}',
+        headers={"content-type": "application/json"},
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+
+
 import time
 
 import jwt
@@ -317,6 +340,26 @@ def test_nbf_in_future_beyond_leeway_rejected(rsa_keypair):
     now = int(time.time())
     with pytest.raises(sso.SsoJwtError):
         validate_access_token(_sign(priv, _claims(nbf=now + 3600)), key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
+
+
+@pytest.mark.parametrize("bad_exp", [{}, 1e309])
+def test_malformed_numericdate_exp_rejected_not_typeerror_or_overflow(rsa_keypair, bad_exp):
+    # Finding 5: a NumericDate claim of the wrong shape makes PyJWT raise a raw
+    # TypeError (exp: {}) or OverflowError (exp: 1e309 -> inf), neither of which
+    # is an InvalidTokenError subclass — so without broadening the decode except
+    # they escape validate_access_token and 500 the callback. Must map to
+    # SsoJwtError. (jwt.encode passes these through unvalidated; jwt.decode is
+    # where the raw error surfaces.)
+    priv, pub = rsa_keypair
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(_sign(priv, _claims(exp=bad_exp)), key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
+
+
+def test_malformed_numericdate_iat_rejected_not_typeerror(rsa_keypair):
+    # Same class of defect on another NumericDate claim (iat), for coverage breadth.
+    priv, pub = rsa_keypair
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(_sign(priv, _claims(iat={})), key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
 
 
 def _jwks_for(pub, kid="JWT-Signature-Key"):

--- a/app/backend/src/fastapi_app/tests/services/test_sso.py
+++ b/app/backend/src/fastapi_app/tests/services/test_sso.py
@@ -129,6 +129,85 @@ async def test_exchange_code_200_with_non_object_json_raises(httpx_mock):
     assert exc.value.status_code == 200
 
 
+# --- finding 2: a 200 body that lacks/malforms access_token or expires_in must raise
+# SsoTokenError (its declared contract) here, not KeyError/ValueError downstream in
+# upsert_user/refresh_token_pair, which would 500 the callback instead of sso=error. ---
+
+@pytest.mark.asyncio
+async def test_exchange_code_200_missing_access_token_raises_sso_token_error(httpx_mock):
+    import httpx
+    httpx_mock.add_response(url="https://login.eveonline.com/v2/oauth/token", json={"expires_in": 1200})
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError) as exc:
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+    assert exc.value.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_200_non_string_access_token_raises_sso_token_error(httpx_mock):
+    import httpx
+    httpx_mock.add_response(
+        url="https://login.eveonline.com/v2/oauth/token",
+        json={"access_token": 12345, "expires_in": 1200},
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_200_missing_expires_in_raises_sso_token_error(httpx_mock):
+    import httpx
+    httpx_mock.add_response(url="https://login.eveonline.com/v2/oauth/token", json={"access_token": "AT"})
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_200_non_numeric_expires_in_raises_sso_token_error(httpx_mock):
+    import httpx
+    httpx_mock.add_response(
+        url="https://login.eveonline.com/v2/oauth/token",
+        json={"access_token": "AT", "expires_in": "not-a-number"},
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_200_null_expires_in_raises_sso_token_error(httpx_mock):
+    import httpx
+    httpx_mock.add_response(
+        url="https://login.eveonline.com/v2/oauth/token",
+        json={"access_token": "AT", "expires_in": None},
+    )
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(sso.SsoTokenError):
+            await sso.exchange_code(
+                client, code="C",
+                token_url="https://login.eveonline.com/v2/oauth/token",
+                client_id="cid", client_secret="secret",
+            )
+
+
 import time
 
 import jwt
@@ -284,3 +363,57 @@ def test_non_string_name_claim_rejected(rsa_keypair):
     priv, pub = rsa_keypair
     with pytest.raises(sso.SsoJwtError):
         validate_access_token(_sign(priv, _claims(name=5)), key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
+
+
+def _sign_raw_claims(priv, claims, *, alg="RS256", kid="JWT-Signature-Key"):
+    """Like _sign, but bypasses PyJWT encode()'s own claim validation (e.g. its
+    str-only check on iss, added for PyJWT issue #1039) by signing pre-serialized
+    JSON bytes directly through the lower-level PyJWS. Used to reproduce claim
+    shapes that a real signer external to this codebase's PyJWT version could
+    still emit, or that a corrupted/forged token could carry."""
+    import json as json_mod
+    from jwt.api_jws import PyJWS
+    payload_bytes = json_mod.dumps(claims).encode()
+    return PyJWS().encode(payload_bytes, priv, algorithm=alg, headers={"kid": kid})
+
+
+def test_non_string_iss_rejected_not_typeerror(rsa_keypair):
+    # A signed token carrying iss as a list/dict must map to SsoJwtError, not an
+    # unhandled TypeError from the frozenset membership check (`iss not in
+    # _VALID_ISSUERS`) when iss is unhashable.
+    priv, pub = rsa_keypair
+    token = _sign_raw_claims(priv, _claims(iss=[]))
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(token, key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
+
+
+def test_non_string_iss_dict_rejected_not_typeerror(rsa_keypair):
+    priv, pub = rsa_keypair
+    token = _sign_raw_claims(priv, _claims(iss={}))
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(token, key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID)
+
+
+def test_oversized_digit_sub_rejected_not_valueerror(rsa_keypair):
+    # int() rejects integer strings over Python's digit-conversion limit
+    # (sys.int_info.default_max_str_digits, ~4300) with a raw ValueError; a
+    # character id substring that is all ASCII digits but absurdly long must
+    # still map to SsoJwtError, not escape as a 500.
+    priv, pub = rsa_keypair
+    huge_digits = "9" * 4301
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(
+            _sign(priv, _claims(sub=f"CHARACTER:EVE:{huge_digits}")),
+            key_provider=_StaticKeyProvider(pub), client_id=CLIENT_ID,
+        )
+
+
+def test_empty_jwks_key_set_rejected_not_pyjwksseterror(rsa_keypair, monkeypatch):
+    # PyJWKSetError (raised by PyJWKClient when the JWKS has zero keys) is NOT a
+    # subclass of PyJWKClientError — the current except clause misses it, so an
+    # empty/keyless JWKS document would escape validate_access_token uncaught.
+    priv, pub = rsa_keypair
+    client = jwt.PyJWKClient("https://login.eveonline.com/oauth/jwks")
+    monkeypatch.setattr(client, "fetch_data", lambda: {"keys": []})
+    with pytest.raises(sso.SsoJwtError):
+        validate_access_token(_sign(priv, _claims()), key_provider=client, client_id=CLIENT_ID)

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -30,14 +30,15 @@ async def test_create_db_tables_skips_outside_development(monkeypatch, caplog):
     assert "Skipping" in caplog.text
 
 
+@pytest.mark.parametrize("recreate_flag", [False, True])
 @pytest.mark.asyncio
-async def test_create_db_tables_skips_when_environment_unset(monkeypatch):
-    # P1: Settings.ENVIRONMENT defaults to "development" when the env var is simply
-    # omitted (e.g. a production deploy that forgot to set it) — indistinguishable,
-    # by value alone, from someone explicitly opting into the dev workflow. A fresh
-    # Settings instance built with no ENVIRONMENT source (mirrors test_reconciled_
-    # non_sso_defaults in test_config.py) must NOT trigger the destructive recreate;
-    # only an explicit second opt-in may.
+async def test_create_db_tables_skips_when_environment_unset(monkeypatch, recreate_flag):
+    # P1 (fully closed): when ENVIRONMENT is simply omitted, a fresh Settings must
+    # NOT resolve to "development" — otherwise DB_RECREATE_ON_STARTUP=true (easily
+    # inherited/copied into a prod env that omits ENVIRONMENT) satisfies BOTH gate
+    # conditions and drops every table. Secure-by-default: unset ENVIRONMENT is
+    # "production", so the destructive recreate never runs regardless of the flag.
+    # Parametrized over the flag so the flag=True case (the missed one) is pinned.
     from fastapi_app.core.config import Settings
 
     fresh_settings = Settings(
@@ -45,8 +46,9 @@ async def test_create_db_tables_skips_when_environment_unset(monkeypatch):
         DATABASE_URL="postgresql+asyncpg://u:p@localhost/x",
         CACHE_URL="redis://localhost:6379/9",
         ESI_USER_AGENT="test",
+        DB_RECREATE_ON_STARTUP=recreate_flag,
     )
-    assert fresh_settings.ENVIRONMENT == "development"  # the fail-open trap
+    assert fresh_settings.ENVIRONMENT == "production"  # secure-by-default, never dev when unset
     monkeypatch.setattr(main_mod, "settings", fresh_settings)
 
     called = {"drop_or_create": False}
@@ -54,7 +56,7 @@ async def test_create_db_tables_skips_when_environment_unset(monkeypatch):
     class _Boom:
         async def __aenter__(self):
             called["drop_or_create"] = True
-            raise AssertionError("engine.begin() must not run with no explicit opt-in")
+            raise AssertionError("engine.begin() must not run with an unset ENVIRONMENT")
 
         async def __aexit__(self, *a):
             return False

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -31,6 +31,62 @@ async def test_create_db_tables_skips_outside_development(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_create_db_tables_skips_when_environment_unset(monkeypatch):
+    # P1: Settings.ENVIRONMENT defaults to "development" when the env var is simply
+    # omitted (e.g. a production deploy that forgot to set it) — indistinguishable,
+    # by value alone, from someone explicitly opting into the dev workflow. A fresh
+    # Settings instance built with no ENVIRONMENT source (mirrors test_reconciled_
+    # non_sso_defaults in test_config.py) must NOT trigger the destructive recreate;
+    # only an explicit second opt-in may.
+    from fastapi_app.core.config import Settings
+
+    fresh_settings = Settings(
+        _env_file=None,
+        DATABASE_URL="postgresql+asyncpg://u:p@localhost/x",
+        CACHE_URL="redis://localhost:6379/9",
+        ESI_USER_AGENT="test",
+    )
+    assert fresh_settings.ENVIRONMENT == "development"  # the fail-open trap
+    monkeypatch.setattr(main_mod, "settings", fresh_settings)
+
+    called = {"drop_or_create": False}
+
+    class _Boom:
+        async def __aenter__(self):
+            called["drop_or_create"] = True
+            raise AssertionError("engine.begin() must not run with no explicit opt-in")
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(main_mod, "async_engine", SimpleNamespace(begin=lambda: _Boom()))
+    await main_mod.create_db_tables()
+    assert called["drop_or_create"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_db_tables_skips_in_development_without_explicit_flag(monkeypatch):
+    # Pins the "AND", not "OR": ENVIRONMENT=="development" alone (however it got set)
+    # must not be enough — DB_RECREATE_ON_STARTUP defaults False and must be flipped
+    # on independently, or the two-gate design collapses back to the single-gate bug.
+    monkeypatch.setattr(main_mod.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(main_mod.settings, "DB_RECREATE_ON_STARTUP", False)
+    called = {"drop_or_create": False}
+
+    class _Boom:
+        async def __aenter__(self):
+            called["drop_or_create"] = True
+            raise AssertionError("engine.begin() must not run without the explicit recreate flag")
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(main_mod, "async_engine", SimpleNamespace(begin=lambda: _Boom()))
+    await main_mod.create_db_tables()
+    assert called["drop_or_create"] is False
+
+
+@pytest.mark.asyncio
 async def test_create_db_tables_runs_in_development(monkeypatch):
     # Mirror direction (testing-pitfalls §6 Boundary): development must still reach
     # engine.begin()/drop_all/create_all — a gate that no-ops everywhere would pass
@@ -38,6 +94,7 @@ async def test_create_db_tables_runs_in_development(monkeypatch):
     from fastapi_app.db import Base
 
     monkeypatch.setattr(main_mod.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(main_mod.settings, "DB_RECREATE_ON_STARTUP", True)
     synced = []
 
     async def _record(fn):

--- a/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
+++ b/app/backend/src/fastapi_app/tests/test_create_db_tables_gate.py
@@ -137,3 +137,21 @@ def test_sso_unconfigured_startup_warning(monkeypatch, caplog, env, client_id, k
         main_mod.warn_if_sso_unconfigured()
     warnings = [r for r in caplog.records if "EVE SSO is not configured" in r.getMessage()]
     assert len(warnings) == (1 if expect_warning else 0)
+
+
+def test_sso_unconfigured_startup_warning_names_only_login_and_callback(monkeypatch, caplog):
+    # Finding 11: the message previously claimed every /auth/sso/* route 503s,
+    # but logout stays operational (204, not guarded) — the warning must name
+    # login and callback specifically, not the whole route family.
+    monkeypatch.setattr(main_mod.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(main_mod.settings, "ESI_CLIENT_ID", "")
+    from pydantic import SecretStr
+    monkeypatch.setattr(main_mod.settings, "TOKEN_CIPHER_KEYS", SecretStr(""))
+    with caplog.at_level(logging.WARNING):
+        main_mod.warn_if_sso_unconfigured()
+    messages = [r.getMessage() for r in caplog.records if "EVE SSO is not configured" in r.getMessage()]
+    assert len(messages) == 1
+    assert "/auth/sso/login" in messages[0]
+    assert "/auth/sso/callback" in messages[0]
+    assert "/auth/sso/*" not in messages[0]   # the over-broad claim must be gone
+    assert "/auth/sso/logout" not in messages[0]   # logout is never guarded (§4.4)

--- a/app/backend/src/fastapi_app/tests/test_fake_redis.py
+++ b/app/backend/src/fastapi_app/tests/test_fake_redis.py
@@ -1,0 +1,123 @@
+# ABOUTME: FakeRedis must honor TTL for real (a key past its expiry reads as absent)
+# ABOUTME: so idle-expiration and post-expiry session behavior can be tested honestly.
+import pytest
+
+from fastapi_app.tests.fake_redis import FakeRedis
+
+
+class _Clock:
+    """Mutable fake clock: tests advance `.t` to simulate wall-time passing."""
+
+    def __init__(self, start: float = 0.0):
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_after_ttl_expiry():
+    clock = _Clock(1000.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=10)
+    assert await r.get("k") == "v"
+    clock.t = 1000.0 + 10  # exactly at expiry: already expired
+    assert await r.get("k") is None
+
+
+@pytest.mark.asyncio
+async def test_get_returns_value_before_ttl_expiry():
+    clock = _Clock(1000.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=10)
+    clock.t = 1000.0 + 9
+    assert await r.get("k") == "v"
+
+
+@pytest.mark.asyncio
+async def test_getex_returns_none_after_ttl_expiry():
+    clock = _Clock(0.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=5)
+    clock.t = 5.001
+    assert await r.getex("k", ex=5) is None
+
+
+@pytest.mark.asyncio
+async def test_exists_is_false_after_ttl_expiry():
+    clock = _Clock(0.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=5)
+    clock.t = 6.0
+    assert await r.exists("k") == 0
+
+
+@pytest.mark.asyncio
+async def test_getdel_returns_none_after_ttl_expiry():
+    clock = _Clock(0.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=5)
+    clock.t = 6.0
+    assert await r.getdel("k") is None
+
+
+@pytest.mark.asyncio
+async def test_getex_renewal_extends_past_previous_deadline():
+    # A GETEX before the old deadline renews the idle window from the current
+    # clock, not the original set() time.
+    clock = _Clock(0.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=5)
+    clock.t = 4.0
+    assert await r.getex("k", ex=5) == "v"   # renew: new deadline is 4.0 + 5 = 9.0
+    clock.t = 8.9
+    assert await r.get("k") == "v"           # still alive past the ORIGINAL 5s deadline
+    clock.t = 9.1
+    assert await r.get("k") is None          # but not past the RENEWED deadline
+
+
+@pytest.mark.asyncio
+async def test_persistent_set_without_ex_never_expires():
+    clock = _Clock(0.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v")
+    clock.t = 10_000_000.0
+    assert await r.get("k") == "v"
+
+
+@pytest.mark.asyncio
+async def test_expireat_sets_absolute_deadline():
+    clock = _Clock(100.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v", ex=5)   # relative deadline would be 105
+    await r.expireat("k", 200)    # override with an absolute deadline far later
+    clock.t = 150.0
+    assert await r.get("k") == "v"
+    clock.t = 200.0
+    assert await r.get("k") is None   # expireat deadline reached
+
+
+@pytest.mark.asyncio
+async def test_expireat_in_the_past_deletes_immediately():
+    clock = _Clock(100.0)
+    r = FakeRedis(clock=clock)
+    await r.set("k", "v")
+    await r.expireat("k", 50)   # already in the past relative to clock
+    assert await r.get("k") is None
+    assert await r.exists("k") == 0
+
+
+@pytest.mark.asyncio
+async def test_expireat_on_missing_key_returns_false():
+    r = FakeRedis(clock=_Clock(0.0))
+    assert await r.expireat("nope", 100) is False
+
+
+@pytest.mark.asyncio
+async def test_default_clock_is_real_time_and_does_not_immediately_expire():
+    # No clock passed: defaults to real wall time. A key set with a real TTL must
+    # still be readable immediately after (regression guard against a fixed t=0
+    # default clock that would make everything look pre-expired).
+    r = FakeRedis()
+    await r.set("k", "v", ex=60)
+    assert await r.get("k") == "v"

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -459,11 +459,6 @@
         ],
         "responses": {
           "302": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
             "description": "Successful Response"
           },
           "400": {

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -277,6 +277,20 @@
         "title": "CurrentUserSchema",
         "type": "object"
       },
+      "ErrorDetail": {
+        "description": "The FastAPI HTTPException / JSONResponse error body shape ({\"detail\": ...}),\ndeclared so the login/callback 400 and 503 responses carry their real JSON\nbody in the OpenAPI contract instead of an empty one.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorDetail",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -462,6 +476,13 @@
             "description": "Successful Response"
           },
           "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetail"
+                }
+              }
+            },
             "description": "SSO state/browser-binding mismatch."
           },
           "422": {
@@ -475,6 +496,13 @@
             "description": "Validation Error"
           },
           "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetail"
+                }
+              }
+            },
             "description": "EVE SSO is not configured."
           }
         },
@@ -512,6 +540,16 @@
               }
             },
             "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetail"
+                }
+              }
+            },
+            "description": "EVE SSO is not configured."
           }
         },
         "summary": "Login",

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -458,13 +458,16 @@
           }
         ],
         "responses": {
-          "200": {
+          "302": {
             "content": {
               "application/json": {
                 "schema": {}
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "SSO state/browser-binding mismatch."
           },
           "422": {
             "content": {
@@ -475,6 +478,9 @@
               }
             },
             "description": "Validation Error"
+          },
+          "503": {
+            "description": "EVE SSO is not configured."
           }
         },
         "summary": "Callback",
@@ -499,12 +505,7 @@
           }
         ],
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
+          "302": {
             "description": "Successful Response"
           },
           "422": {

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -281,6 +281,16 @@ export interface components {
             /** Character Name */
             character_name: string;
         };
+        /**
+         * ErrorDetail
+         * @description The FastAPI HTTPException / JSONResponse error body shape ({"detail": ...}),
+         *     declared so the login/callback 400 and 503 responses carry their real JSON
+         *     body in the OpenAPI contract instead of an empty one.
+         */
+        ErrorDetail: {
+            /** Detail */
+            detail: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -383,7 +393,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorDetail"];
+                };
             };
             /** @description Validation Error */
             422: {
@@ -399,7 +411,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["ErrorDetail"];
+                };
             };
         };
     };
@@ -428,6 +442,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description EVE SSO is not configured. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorDetail"];
                 };
             };
         };

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -372,13 +372,20 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            302: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
                 };
+            };
+            /** @description SSO state/browser-binding mismatch. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -388,6 +395,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description EVE SSO is not configured. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -403,13 +417,11 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            302: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": unknown;
-                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -376,9 +376,7 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": unknown;
-                };
+                content?: never;
             };
             /** @description SSO state/browser-binding mismatch. */
             400: {


### PR DESCRIPTION
## Backend hardening — codex review findings from the M2 SSO backend

Fixes the correctness findings a codex review surfaced across the merged M2 SSO backend (Phases 0–7). Sam's own app; standard defensive OAuth, described in plain correctness terms. TDD throughout — each finding reproduced with a failing test before the fix. Baseline 172 → **213 tests passing**, no new warnings, no new lint findings.

### Fixes
- **[P1] `create_db_tables` fail-open.** `ENVIRONMENT` defaults to `"development"`, so a production deploy that merely omits the var would run `drop_all` on startup and wipe every table. Now destructive recreate is fail-closed: it requires an explicit `DB_RECREATE_ON_STARTUP=true` **and** `ENVIRONMENT == "development"`. `.env.example` documents it so the local dev workflow is preserved; unset/unknown/production never drops.
- **`_post_token` token-body validation.** A 200 response missing/malformed `access_token` or `expires_in` used to pass through and raise a raw `KeyError`/`ValueError` downstream, 500ing the callback instead of taking the `sso=error` path. Now validated → `SsoTokenError`. Closes the missing-`expires_in`→500 family (original #29 + the #31/#32 downstream exposures).
- **JWT claim edge cases in `sso.py`:** non-string `iss` (`[]`/`{}`) → `SsoJwtError` (was `TypeError`); oversized all-digit `sub` past Python's int-string limit → `SsoJwtError` (was `ValueError`); empty-keys JWKS `{"keys":[]}` → `SsoJwtError` (`PyJWKSetError` was escaping the except clause).
- **`session.py`:** corrupt/malformed/missing-`created_at` session payloads are now treated as absent (delete + None → 401/None) instead of 500ing; the 30-day absolute cap uses `EXPIREAT(deadline)` instead of a relative `EXPIRE`, closing a race where concurrent readers could push the key past the deadline.
- **Callback hardening (`api/auth.py`):** the GETDEL'd state payload is shape-validated before use (corrupt → `sso=error` + cleared cookie, not 500); `upsert_user` is inside the error boundary; the 503 not-configured guard clears `hb_sso_state`; `build_redirect` strips any existing `sso` param before appending so a retry can't accumulate `?sso=…&sso=…`.
- **Test-double fidelity:** the fake Valkey now honors TTL expiry (with an injectable clock) and supports `EXPIREAT`, enabling an idle-expiry test that was previously impossible to write honestly.
- **OpenAPI accuracy:** `login`/`callback` now declare `302` (they always redirect) instead of `200 application/json`; `openapi.json` + `schema.d.ts` regenerated together (`tsc -b` clean).
- **Startup-warning wording:** names `/auth/sso/login` and `/auth/sso/callback` specifically (logout stays operational).

### Deferred to M3 (documented `# TODO(M3):`, unreachable from any M2 endpoint)
`refresh_user_tokens`' 400-discrimination and concurrency-safe rotation (that function is called by no M2 endpoint), and `upsert_user`'s simultaneous-first-login race. The Uvicorn access-log handling of `state`/`code` is noted as operational config, not app code.

## Merge classification
`Review — domain (security: auth/session/crypto error boundaries + a fail-closed destructive-DB gate)`.
