### PR TITLE
chore(backend): migrate FastAPI to current and move to Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,13 @@ jobs:
       TOKEN_CIPHER_KEYS: 1ENT-BXzxzKxMdnIhMN-Q-_LVIGorE-Stwjy1-FECkA=
     steps:
       - uses: actions/checkout@v7
-      # Both python-version pins below MUST move together (they will flip to 3.14
-      # when the FastAPI 0.115 hold lifts — see implementation-pitfalls ENV-5).
+      # Both python-version pins below MUST stay in sync (setup-python + setup-pdm).
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - uses: pdm-project/setup-pdm@v4
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Create the tests database
         run: PGPASSWORD=hangar psql -h localhost -U hangar -d hangar_bay -c 'CREATE DATABASE hangar_bay_test;'
       - name: Install backend deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,7 @@ After a backend schema change, regenerate the client end-to-end: `pdm run export
 
 | Layer | Backend | Frontend |
 |---|---|---|
-| Language | Python 3.11+ | TypeScript |
+| Language | Python 3.14+ | TypeScript |
 | Framework | FastAPI 0.139 | React 19 + Vite |
 | Data/state | SQLAlchemy 2.0 (async) + asyncpg → PostgreSQL; Valkey (redis-py) cache | TanStack Router + TanStack Query |
 | Scheduling | APScheduler (ESI ingestion) | — |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ After a backend schema change, regenerate the client end-to-end: `pdm run export
 | Layer | Backend | Frontend |
 |---|---|---|
 | Language | Python 3.11+ | TypeScript |
-| Framework | FastAPI 0.115 | React 19 + Vite |
+| Framework | FastAPI 0.139 | React 19 + Vite |
 | Data/state | SQLAlchemy 2.0 (async) + asyncpg → PostgreSQL; Valkey (redis-py) cache | TanStack Router + TanStack Query |
 | Scheduling | APScheduler (ESI ingestion) | — |
 | Styling | — | Tailwind CSS v4 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ After a backend schema change, regenerate the client end-to-end: `pdm run export
 
 | Layer | Backend | Frontend |
 |---|---|---|
-| Language | Python 3.11+ | TypeScript |
+| Language | Python 3.14+ | TypeScript |
 | Framework | FastAPI 0.139 | React 19 + Vite |
 | Data/state | SQLAlchemy 2.0 (async) + asyncpg → PostgreSQL; Valkey (redis-py) cache | TanStack Router + TanStack Query |
 | Scheduling | APScheduler (ESI ingestion) | — |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,7 @@ After a backend schema change, regenerate the client end-to-end: `pdm run export
 | Layer | Backend | Frontend |
 |---|---|---|
 | Language | Python 3.11+ | TypeScript |
-| Framework | FastAPI 0.115 | React 19 + Vite |
+| Framework | FastAPI 0.139 | React 19 + Vite |
 | Data/state | SQLAlchemy 2.0 (async) + asyncpg → PostgreSQL; Valkey (redis-py) cache | TanStack Router + TanStack Query |
 | Scheduling | APScheduler (ESI ingestion) | — |
 | Styling | — | Tailwind CSS v4 |

--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:30f917d267b39f755ab01b435d66b334cd78469381813deb8ebefebc17b79973"
+content_hash = "sha256:c694d33cc2d2397b3d360691220663041e75e2552b95adc0a0435c1dd614a6ab"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -42,6 +42,17 @@ files = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+requires_python = ">=3.8"
+summary = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+groups = ["default"]
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 requires_python = ">=3.8"
@@ -57,19 +68,18 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.9.0"
-requires_python = ">=3.9"
-summary = "High level compatibility layer for multiple asynchronous event loop implementations"
+version = "4.14.2"
+requires_python = ">=3.10"
+summary = "High-level concurrency and networking framework on top of asyncio or Trio"
 groups = ["default", "dev"]
 dependencies = [
     "exceptiongroup>=1.0.2; python_version < \"3.11\"",
     "idna>=2.8",
-    "sniffio>=1.1",
     "typing-extensions>=4.5; python_version < \"3.13\"",
 ]
 files = [
-    {file = "anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c"},
-    {file = "anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028"},
+    {file = "anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"},
+    {file = "anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"},
 ]
 
 [[package]]
@@ -369,18 +379,20 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.14"
-requires_python = ">=3.8"
+version = "0.139.0"
+requires_python = ">=3.10"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 groups = ["default"]
 dependencies = [
-    "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4",
-    "starlette<0.47.0,>=0.40.0",
+    "annotated-doc>=0.0.2",
+    "pydantic>=2.9.0",
+    "starlette>=0.46.0",
     "typing-extensions>=4.8.0",
+    "typing-inspection>=0.4.2",
 ]
 files = [
-    {file = "fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca"},
-    {file = "fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739"},
+    {file = "fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189"},
+    {file = "fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145"},
 ]
 
 [[package]]
@@ -519,13 +531,13 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.10"
-requires_python = ">=3.6"
+version = "3.18"
+requires_python = ">=3.9"
 summary = "Internationalized Domain Names in Applications (IDNA)"
 groups = ["default", "dev"]
 files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [[package]]
@@ -749,28 +761,28 @@ files = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.1"
+version = "0.25.0"
 requires_python = ">=3.9"
 summary = "Python client for the Prometheus monitoring system."
 groups = ["default"]
 files = [
-    {file = "prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094"},
-    {file = "prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28"},
+    {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
+    {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
 ]
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
-requires_python = ">=3.8"
+version = "8.0.2"
+requires_python = ">=3.10"
 summary = "Instrument your FastAPI app with Prometheus metrics"
 groups = ["default"]
 dependencies = [
     "prometheus-client<1.0.0,>=0.8.0",
-    "starlette<1.0.0,>=0.30.0",
+    "starlette<2.0.0,>=1.0.0",
 ]
 files = [
-    {file = "prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9"},
-    {file = "prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e"},
+    {file = "prometheus_fastapi_instrumentator-8.0.2-py3-none-any.whl", hash = "sha256:746002ec1e2c58b93f61444e1d104de959a9463a6a3f1c8909ac3757e16c3866"},
+    {file = "prometheus_fastapi_instrumentator-8.0.2.tar.gz", hash = "sha256:3c252e748151768a7aefd66824a04a870144f71de48a67aed211749a9ca2a548"},
 ]
 
 [[package]]
@@ -1247,17 +1259,6 @@ files = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-requires_python = ">=3.7"
-summary = "Sniff out which async library your code is running under"
-groups = ["default", "dev"]
-files = [
-    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
-    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
-]
-
-[[package]]
 name = "sqlalchemy"
 version = "2.0.41"
 requires_python = ">=3.7"
@@ -1339,17 +1340,17 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
-requires_python = ">=3.9"
+version = "1.3.1"
+requires_python = ">=3.10"
 summary = "The little ASGI library that shines."
 groups = ["default"]
 dependencies = [
     "anyio<5,>=3.6.2",
-    "typing-extensions>=3.10.0; python_version < \"3.10\"",
+    "typing-extensions>=4.10.0; python_version < \"3.13\"",
 ]
 files = [
-    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
-    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [[package]]

--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -5,10 +5,10 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c694d33cc2d2397b3d360691220663041e75e2552b95adc0a0435c1dd614a6ab"
+content_hash = "sha256:b6f5097c146903cb9e8d64a05909fc72c8c2405917286d35c7b115479c02ba17"
 
 [[metadata.targets]]
-requires_python = ">=3.11"
+requires_python = ">=3.14"
 
 [[package]]
 name = "aiosqlite"
@@ -1372,7 +1372,7 @@ name = "typing-extensions"
 version = "4.16.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["default", "dev"]
+groups = ["default"]
 files = [
     {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
     {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Samuel Carson", email = "samuel.carson@gmail.com"},
 ]
 dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.139.0", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=8.0.2", "cryptography>=49.0.0", "pyjwt[crypto]>=2.13.0"]
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "Samuel Carson", email = "samuel.carson@gmail.com"},
 ]
-dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.115.12,<0.116", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=7.1.0", "cryptography>=49.0.0", "pyjwt[crypto]>=2.13.0"]
+dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.139.0", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=8.0.2", "cryptography>=49.0.0", "pyjwt[crypto]>=2.13.0"]
 requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -362,6 +362,13 @@
       },
       "ValidationError": {
         "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
           "loc": {
             "items": {
               "anyOf": [

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -332,6 +332,10 @@ export interface components {
         SortableContractFields: "date_issued" | "date_expired" | "price" | "collateral" | "ship_name" | "volume";
         /** ValidationError */
         ValidationError: {
+            /** Context */
+            ctx?: Record<string, never>;
+            /** Input */
+            input?: unknown;
             /** Location */
             loc: (string | number)[];
             /** Message */

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -154,6 +154,8 @@ This document serves three audiences. Start here, then go directly to the sectio
 
 ### ENV-5: The backend venv/CI pin Python 3.12 until the FastAPI 0.115 hold lifts
 
+> **SUPERSEDED (2026-07-13):** Hold lifted — no longer applicable. The FastAPI-current / Python-3.14 chore migrated the backend to FastAPI 0.139 / Starlette 1.3.1 and moved the venv and both CI `python-version` pins to 3.14. FastAPI 0.139 precomputes `Dependant.is_coroutine_callable` at route registration and no longer calls the 3.14-deprecated `asyncio.iscoroutinefunction`, so the 16 DeprecationWarnings are gone at the source (never a filter mask). The spike that "broke 19 tests" traced to `prometheus-fastapi-instrumentator` 7.1.0, whose middleware crashes in `_get_route_name` against Starlette 0.52.x despite its `starlette<1.0` pin; reaching current Starlette required bumping it to 8.0.2 (`starlette>=1.0`). The pydantic-relock context below stays true; original content preserved for history.
+
 **The Flaw:** The default machine `python3` is CPython 3.14. The pydantic stack is relocked with cp314 wheels (pydantic 2.13 / pydantic-core 2.46), so 3.14 installs and passes — but FastAPI is deliberately held at 0.115 (`fastapi>=0.115.12,<0.116` in pyproject): its internals call `asyncio.iscoroutinefunction`, which 3.14 deprecates, emitting a DeprecationWarning block in every test run and violating the pristine-test-output gate. The unheld resolve (FastAPI 0.139 / Starlette 0.52) broke 19 tests on first contact — a real migration, not a version bump.
 
 **The Fix:** Keep the backend venv and CI on Python 3.12 (`actions/setup-python` + `setup-pdm` with `python-version: '3.12'`) until a dedicated FastAPI/Starlette migration lands; then flip the pins to 3.14 and delete this entry. Never mask the warnings with a filter, and do not "fix" application code for other interpreter versions.
@@ -180,7 +182,7 @@ This document serves three audiences. Start here, then go directly to the sectio
 - [ ] **Empty data after a backend (re)start is not diagnosed as a frontend bug** — startup drops/recreates tables and re-ingests; give ingestion time before concluding a data bug (ENV-2)
 - [ ] **After backend edits, run one clean cycle** — clear the Valkey aggregation lock, `touch main.py` once, hand off until ingestion completes; run dev servers as tracked background tasks with visible logs (ENV-3)
 - [ ] **`Settings.model_config` keeps `extra="ignore"`** — any new config field is also documented in `.env.example` (ENV-4)
-- [ ] **Backend venv/CI stay pinned to Python 3.12** until the FastAPI 0.115 hold is lifted by a dedicated migration — no interpreter-version bump, no warning-filter mask (ENV-5)
+- [ ] **Backend venv/CI run Python 3.14** — the FastAPI 0.115 / Python-3.12 hold is resolved (ENV-5, superseded); keep the two CI `python-version` pins in sync and never mask interpreter warnings with a filter (migrate off the deprecated API instead)
 - [ ] **Deleting a debug print/function also drops any module-level import it orphaned** — flake8 ignores F401 here so it won't catch it, but F811 will trip on an unrelated function (ENV-6)
 
 ---
@@ -208,6 +210,11 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 ---
 
 # Appendix A: Historical Changelog
+
+## 2026-07-13 — ENV-5 superseded: FastAPI-current / Python-3.14 migration
+
+- Lifted the FastAPI 0.115 hold: migrated the backend to FastAPI 0.139 / Starlette 1.3.1 (+ `prometheus-fastapi-instrumentator` 8.0.2, required for Starlette ≥1.0 — its 7.1.0 middleware crashes against Starlette 0.52.x despite a `starlette<1.0` pin). FastAPI 0.139 precomputes the dependant coroutine flag and no longer calls the 3.14-deprecated `asyncio.iscoroutinefunction`, eliminating the 16 DeprecationWarnings at the source (no filter mask). Flipped the backend venv and both CI `python-version` pins 3.12 → 3.14.
+- Marked ENV-5 `SUPERSEDED` (kept its original body + the pydantic-relock context as history); rewrote the §3.C checklist item to the current 3.14 invariant and updated the Appendix B status row.
 
 ## 2026-07-12 — M2 additions: ENV-4, ENV-5, ENV-6; ENV-1 two-Settings text retired
 
@@ -242,7 +249,7 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 | ENV-2 | Backend restart wipes and re-ingests all data | LOW | VALIDATED | Environment & Dev Loop |
 | ENV-3 | --reload + ingestion + Valkey lock interact badly in dev | MEDIUM | VALIDATED | Environment & Dev Loop |
 | ENV-4 | pydantic-settings rejects unknown .env keys unless extra="ignore" | MEDIUM | VALIDATED | Environment & Dev Loop |
-| ENV-5 | Backend venv/CI pin Python 3.12 until the FastAPI 0.115 hold lifts | LOW | VALIDATED | Environment & Dev Loop |
+| ENV-5 | FastAPI 0.115 / Python-3.12 hold (resolved 2026-07-13: FastAPI 0.139 + Python 3.14) | LOW | SUPERSEDED | Environment & Dev Loop |
 | ENV-6 | F811 cascade when removing debug prints/functions | LOW | VALIDATED | Environment & Dev Loop |
 | ORCH-1 | Analysis Dispatches Must Persist Findings | HIGH | VALIDATED | Orchestration |
 


### PR DESCRIPTION
Post-M2 maintenance chore: lift the FastAPI 0.115 hold, migrate to current FastAPI/Starlette, and move the backend + CI from Python 3.12 to 3.14. Closes the last blocker that pinned the interpreter.

## Result
- Backend suite **220 passed, zero warnings** on Python **3.14** — verified pristine with a cold `.pyc` cache and `-W error::DeprecationWarning -W error::PendingDeprecationWarning -W error::SyntaxWarning` (warnings are eliminated, not filtered — there is no `filterwarnings` anywhere).
- The **16 `asyncio.iscoroutinefunction` DeprecationWarnings** are gone at the source.
- Frontend unaffected: eslint clean, **62 vitest**, **72 e2e** (fixture lane; 3 live-smoke + desktop-responsive skips expected). `tsc -b` clean.
- Lint (`pdm run lint`): unchanged — **zero `.py` files touched**, so the pre-existing W293/E402/… ledger is byte-identical to `dev`.

## Method (interpreter held at the target throughout)
The handoff expected the venv on 3.12; this fresh worktree's venv was already 3.14. Rather than churn a 3.12 venv, I held the interpreter at the **target** and established a **baseline control** first: FastAPI 0.115 on 3.14 → **220 passed + exactly the 16 warnings**. That proves 3.14-alone breaks nothing, so any failure after the FastAPI bump is attributable to the library migration. Same isolation the 3.12-first path buys, without the redundant venv.

## Root cause (why the warnings existed, and why the migration was clean)
- **The warnings:** FastAPI 0.115 called `asyncio.iscoroutinefunction(dependant.call)` per request (`routing.py:233`); 3.14 deprecates that API. FastAPI 0.139 precomputes `Dependant.is_coroutine_callable` at route registration (`routing.py:386`) and never touches the deprecated call.
- **No test failures across a Starlette *major* bump (0.46 → 1.3)** — verified, not assumed:
  - The pytest harness talks to the ASGI app via `httpx.ASGITransport`, **never Starlette's `TestClient`**, so Starlette's TestClient/cookie-jar/response-API churn can't reach the tests. App source touches Starlette only via `BaseHTTPMiddleware` (stable public API).
  - Auth surface guarded explicitly: **38/38** `test_auth_flow.py` pass, including the single-use-state `[TIMING]` test and all cookie-attribute/Secure-flag cases.
- **The one real coupling:** `prometheus-fastapi-instrumentator` 7.1.0 declares `starlette<1.0.0` but its middleware actually **crashes in `_get_route_name` against Starlette 0.52.x** (this is the "19 tests broke" spike from the handoff — it reproduced as 57 failures on this larger suite). Reaching current Starlette (1.3.1) therefore requires instrumentator **8.0.2** (`starlette>=1.0.0`). The pyproject floor is bumped to `>=8.0.2` to encode that coupling.

## Scope discipline
A full `pdm lock` would sweep in **48** packages, including unrelated *major* bumps (pytest 9, redis 8, black 26). Those belong in their own PRs. This PR uses a targeted resolution — **8 packages**, all in the fastapi/starlette/instrumentator closure: fastapi 0.115→0.139, starlette 0.46→1.3.1, prometheus-fastapi-instrumentator 7.1.0→8.0.2 (+ prometheus-client), anyio 4.9→4.14, idna, annotated-doc (new), sniffio (dropped). **pydantic stack untouched** (2.13.4).

## OpenAPI / typed client
FastAPI 0.139 surfaces pydantic v2's `ctx`/`input` on the OpenAPI `ValidationError` model (additive, both optional). Regenerated the client (`export-openapi` → `generate:api`); `schema.d.ts` gains two optional fields; `tsc -b` clean. `openapi.json` + `schema.d.ts` committed with the schema change.

## Docs (ENV-5 retirement)
`implementation-pitfalls.md` ENV-5 ("pin 3.12 until the hold lifts") is superseded. Per Appendix C (mark, don't delete): `SUPERSEDED (2026-07-13)` banner with original body preserved, §3.C checklist flipped to the 3.14 invariant, Appendix B status → SUPERSEDED, Appendix A changelog line. IDs not renumbered. Also synced the CLAUDE.md/AGENTS.md tech-stack table (FastAPI 0.115 → 0.139).

## Commits
1. `chore(backend)` — migrate FastAPI/Starlette + instrumentator, regenerate client
2. `ci` — run backend on Python 3.14 (both pins)
3. `docs` — retire ENV-5, sync tech-stack version

## Merge classification
**Review — framework major migration (FastAPI + Starlette) touching the auth surface, and an OpenAPI serialization-contract change (`ValidationError` gains `ctx`/`input`).** Both are domain review triggers per `docs/git-strategy.md`. Codex review per the chore handoff; recommend merge once CI is green and codex is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)