### PR TITLE
chore(api): enable flake8-bugbear and fix the exception round-trip bugs it found

### DIFF
--- a/app/backend/.flake8
+++ b/app/backend/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F401, F403, F405
+ignore = E203, E266, E501, W503, F401, F403, F405, B950
 # E203: whitespace before ':'
 # E266: too many leading '#' for block comment
 # E501: line too long (we'll use Black for line length)
@@ -7,6 +7,13 @@ ignore = E203, E266, E501, W503, F401, F403, F405
 # F401: module imported but unused
 # F403: 'from module import *' used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports
+# B950: line too long at limit+10% — off until line length is enforced by a
+#       formatter run (Black adoption is an open decision); ~176 lines exceed
+#       97 chars today and hand-wrapping them would churn ahead of that call
+# FastAPI's DI idiom evaluates Depends() at definition time by design, so it is
+# exempt from B008. Deliberately ONLY Depends: a Query()/Path() call in a
+# default should still trip B008, nudging toward Annotated style (FASTAPI-1).
+extend-immutable-calls = Depends, fastapi.Depends
 max-line-length = 88
 max-complexity = 10
 select = C,E,F,W,B,B950

--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:b6f5097c146903cb9e8d64a05909fc72c8c2405917286d35c7b115479c02ba17"
+content_hash = "sha256:765a1de244802cc49c8229adb916d14ca39da16755747cb3457863914c646d53"
 
 [[metadata.targets]]
 requires_python = ">=3.14"
@@ -146,6 +146,17 @@ files = [
     {file = "asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590"},
     {file = "asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e"},
     {file = "asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851"},
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+requires_python = ">=3.9"
+summary = "Classes Without Boilerplate"
+groups = ["dev"]
+files = [
+    {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
+    {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
 ]
 
 [[package]]
@@ -409,6 +420,21 @@ dependencies = [
 files = [
     {file = "flake8-7.2.0-py2.py3-none-any.whl", hash = "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343"},
     {file = "flake8-7.2.0.tar.gz", hash = "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"},
+]
+
+[[package]]
+name = "flake8-bugbear"
+version = "25.11.29"
+requires_python = ">=3.10"
+summary = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+groups = ["dev"]
+dependencies = [
+    "attrs>=22.2.0",
+    "flake8>=7.2.0",
+]
+files = [
+    {file = "flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298"},
+    {file = "flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8"},
 ]
 
 [[package]]

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "httpx>=0.28.1",
     "pytest-httpx>=0.32.0",
     "pytest-vcr>=1.0.2",
+    "flake8-bugbear>=25.11.29",
 ]
 [tool.pdm]
 distribution = false

--- a/app/backend/src/fastapi_app/core/exceptions.py
+++ b/app/backend/src/fastapi_app/core/exceptions.py
@@ -8,7 +8,12 @@ class ESIRequestFailedError(ESIException):
     def __init__(self, status_code: int = 0, message: str = ""):
         self.status_code = status_code
         self.message = message
-        super().__init__(f"ESI request failed with status {status_code}: {message}")
+        # All ctor args go to BaseException verbatim so pickle/copy can
+        # reconstruct via cls(*args) without corrupting attributes (B042).
+        super().__init__(status_code, message)
+
+    def __str__(self):
+        return f"ESI request failed with status {self.status_code}: {self.message}"
 
 
 class ESINotModifiedError(ESIException):

--- a/app/backend/src/fastapi_app/services/sso.py
+++ b/app/backend/src/fastapi_app/services/sso.py
@@ -22,9 +22,14 @@ class SsoTokenError(Exception):
     errors) so callers can tell an invalid-grant 400 from a transient outage (§4.3).
     """
 
-    def __init__(self, message: str, *, status_code: Optional[int] = None) -> None:
-        super().__init__(message)
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        # All ctor args go to BaseException verbatim so pickle/copy can
+        # reconstruct via cls(*args) without corrupting attributes (B042).
+        super().__init__(message, status_code)
         self.status_code = status_code
+
+    def __str__(self) -> str:
+        return str(self.args[0]) if self.args else ""
 
 
 class SsoJwtError(Exception):

--- a/app/backend/src/fastapi_app/tests/core/test_exceptions.py
+++ b/app/backend/src/fastapi_app/tests/core/test_exceptions.py
@@ -1,0 +1,29 @@
+# ABOUTME: ESI exception classes — attribute, message, and pickle/copy round-trip contracts.
+# ABOUTME: Round-trips matter because exceptions cross process boundaries (multiprocessing, task queues) via pickle.
+import copy
+import pickle
+
+from fastapi_app.core.exceptions import ESIRequestFailedError
+
+
+def test_esi_request_failed_attributes_and_str():
+    exc = ESIRequestFailedError(status_code=503, message="upstream sad")
+    assert exc.status_code == 503
+    assert exc.message == "upstream sad"
+    assert str(exc) == "ESI request failed with status 503: upstream sad"
+
+
+def test_esi_request_failed_pickle_round_trip():
+    exc = ESIRequestFailedError(status_code=503, message="upstream sad")
+    clone = pickle.loads(pickle.dumps(exc))
+    assert clone.status_code == 503
+    assert clone.message == "upstream sad"
+    assert str(clone) == str(exc)
+
+
+def test_esi_request_failed_copy_round_trip():
+    exc = ESIRequestFailedError(status_code=404, message="no such page")
+    clone = copy.copy(exc)
+    assert clone.status_code == 404
+    assert clone.message == "no such page"
+    assert str(clone) == str(exc)

--- a/app/backend/src/fastapi_app/tests/services/test_sso.py
+++ b/app/backend/src/fastapi_app/tests/services/test_sso.py
@@ -460,3 +460,11 @@ def test_empty_jwks_key_set_rejected_not_pyjwksseterror(rsa_keypair, monkeypatch
     monkeypatch.setattr(client, "fetch_data", lambda: {"keys": []})
     with pytest.raises(sso.SsoJwtError):
         validate_access_token(_sign(priv, _claims()), key_provider=client, client_id=CLIENT_ID)
+
+
+def test_sso_token_error_pickle_round_trip_keeps_status_code():
+    import pickle
+    exc = sso.SsoTokenError("invalid_grant", status_code=400)
+    clone = pickle.loads(pickle.dumps(exc))
+    assert clone.status_code == 400   # 400-vs-outage discrimination (§4.3) must survive a round-trip
+    assert str(clone) == "invalid_grant"


### PR DESCRIPTION
## Summary

Follow-up to #47. The `.flake8` select list has opted into bugbear codes (`B`, `B950`) since it was written, but `flake8-bugbear` was never installed — every bugbear check has silently no-opped. This PR installs it and resolves everything the activation surfaces (223 raw findings → 0):

- **B042 ×2 (real bugs, fixed with TDD):** `ESIRequestFailedError` passed a pre-formatted string to `BaseException`, so pickle/copy round-trips double-formatted `str()` into garbage; `SsoTokenError`'s keyword-only `status_code` relied on `__dict__` state to survive. Both now pass ctor args to `BaseException` verbatim and format in `__str__` — `str()` output unchanged, attributes faithful under `cls(*args)` reconstruction. New round-trip tests lock the contract (red→green verified).
- **B008 ×45:** all are FastAPI's `Depends(...)` definition-time DI idiom. Exempted via `extend-immutable-calls` — deliberately only `Depends`, so a `Query()`/`Path()` default still fires B008 and nudges toward `Annotated` (pitfall FASTAPI-1).
- **B950 ×176:** line-length at limit+10%. Added to the ignore list beside E501 — hand-wrapping 176 lines ahead of the open Black-adoption decision would be churn. Until that call is made, line length remains unenforced (status quo).

Every other bugbear check (mutable defaults, closure captures, silent excepts, …) is now live and gated by the CI lint step from #47.

## Verification

- `pdm run lint` → exit 0 with bugbear 25.11.29 active (plugin proven live: `--isolated --select=B950/B008` fires; config handles them by decision)
- Full suite: **358 passed** (354 baseline + 4 new round-trip tests; new tests verified red against the old code first)

## Merge classification

Routine

🤖 Generated with [Claude Code](https://claude.com/claude-code)