### PR TITLE
refactor(api): reduce get_contracts complexity below the C901 budget

### DIFF
--- a/app/backend/src/fastapi_app/services/contract_service.py
+++ b/app/backend/src/fastapi_app/services/contract_service.py
@@ -31,7 +31,147 @@ SORT_MAP = {
 }
 
 
-async def get_contracts(  # noqa: C901
+def _needs_item_join(filters: ContractFilters) -> bool:
+    """
+    Determine if a JOIN on the ContractItem table is necessary. A join is
+    required if we need to filter or sort on item attributes.
+    """
+    return bool(
+        filters.search
+        or filters.type_ids
+        or filters.is_bpc is not None
+        or filters.min_runs is not None
+        or filters.max_runs is not None
+        # Add sorting by ship name to the condition
+        or filters.sort_by == SortableContractFields.ship_name
+    )
+
+
+def _apply_contract_filters(query, filters: ContractFilters):
+    """Apply the contract-level filters, narrowing the results."""
+    # 1. Text search (on contract title or item name)
+    if filters.search:
+        search_term = f"%{filters.search}%"
+        # This OR condition requires the join to be present.
+        query = query.filter(
+            or_(
+                Contract.title.ilike(search_term),
+                ContractItem.type_name.ilike(search_term),
+            )
+        )
+
+    # 2. Price and Collateral filters
+    if filters.min_price is not None:
+        query = query.filter(Contract.price >= filters.min_price)
+    if filters.max_price is not None:
+        query = query.filter(Contract.price <= filters.max_price)
+    if filters.min_collateral is not None:
+        query = query.filter(Contract.collateral >= filters.min_collateral)
+    if filters.max_collateral is not None:
+        query = query.filter(Contract.collateral <= filters.max_collateral)
+
+    # 2b. Contract-level flags (indexed column; no item join required)
+    if filters.is_ship_contract is not None:
+        query = query.filter(Contract.is_ship_contract == filters.is_ship_contract)
+
+    # 3. Location filters
+    if filters.region_ids:
+        query = query.filter(Contract.start_location_region_id.in_(filters.region_ids))
+    if filters.system_ids:
+        query = query.filter(Contract.start_location_system_id.in_(filters.system_ids))
+    if filters.station_ids:
+        query = query.filter(Contract.start_location_id.in_(filters.station_ids))
+
+    return query
+
+
+def _apply_item_filters(query, filters: ContractFilters):
+    """Apply the Contract Item specific filters."""
+    if filters.type_ids:
+        query = query.filter(ContractItem.type_id.in_(filters.type_ids))
+    if filters.is_bpc is not None:
+        query = query.filter(ContractItem.is_blueprint_copy == filters.is_bpc)
+    # BPC Run filters (Note: ME/TE not implemented as data is not in model)
+    if filters.min_runs is not None:
+        query = query.filter(ContractItem.raw_quantity >= filters.min_runs)
+    if filters.max_runs is not None:
+        query = query.filter(ContractItem.raw_quantity <= filters.max_runs)
+
+    return query
+
+
+async def _count_distinct_contracts(db: AsyncSession, query) -> int:
+    """
+    To get an accurate total count of matching *contracts* (not items),
+    we must count the distinct contract_ids from our filtered query.
+    This is crucial because the join can create duplicate contract rows.
+    """
+    count_subquery = select(query.subquery().c.contract_id).distinct().subquery()
+    count_query = select(func.count()).select_from(count_subquery)
+
+    total_result = await db.execute(count_query)
+    return total_result.scalar_one()
+
+
+async def _fetch_page_joined(
+    db: AsyncSession,
+    query,
+    filters: ContractFilters,
+    sort_column,
+    descending: bool,
+) -> list[Contract]:
+    # Paginating the joined query directly would offset/limit over
+    # joined (duplicated) rows, producing short pages and contracts
+    # skipped or repeated across page boundaries. Paginate over
+    # distinct contract IDs first, then load that page's contracts.
+    # Ordering uses an aggregate of the sort column (min/max picks
+    # the sort-direction-appropriate representative when a contract
+    # has multiple items) with contract_id as a deterministic
+    # tiebreaker.
+    sort_aggregate = func.max(sort_column) if descending else func.min(sort_column)
+    order_expr = sort_aggregate.desc() if descending else sort_aggregate.asc()
+    id_query = (
+        query.with_only_columns(Contract.contract_id)
+        .group_by(Contract.contract_id)
+        .order_by(order_expr, Contract.contract_id.asc())
+        .offset((filters.page - 1) * filters.size)
+        .limit(filters.size)
+    )
+    id_result = await db.execute(id_query)
+    page_ids = [row[0] for row in id_result.all()]
+
+    data_query = (
+        select(Contract)
+        .where(Contract.contract_id.in_(page_ids))
+        .options(selectinload(Contract.items))
+    )
+    result = await db.execute(data_query)
+    contracts = list(result.scalars().unique().all())
+    # Restore the page order computed by id_query.
+    position = {cid: index for index, cid in enumerate(page_ids)}
+    contracts.sort(key=lambda contract: position[contract.contract_id])
+    return contracts
+
+
+async def _fetch_page_simple(
+    db: AsyncSession,
+    query,
+    filters: ContractFilters,
+    sort_column,
+    descending: bool,
+) -> list[Contract]:
+    order_expr = sort_column.desc() if descending else sort_column.asc()
+    data_query = (
+        query.order_by(order_expr, Contract.contract_id.asc())
+        .offset((filters.page - 1) * filters.size)
+        .limit(filters.size)
+        .options(selectinload(Contract.items))
+    )
+    result = await db.execute(data_query)
+    return result.scalars().unique().all()
+
+
+async def get_contracts(
     db: AsyncSession, filters: ContractFilters
 ) -> PaginatedResponse[ContractSchema]:
     """
@@ -63,17 +203,7 @@ async def get_contracts(  # noqa: C901
         # Start with the base query for the Contract model.
         query = select(Contract)
 
-        # Determine if a JOIN on the ContractItem table is necessary. A join is
-        # required if we need to filter or sort on item attributes.
-        needs_item_join = (
-            filters.search
-            or filters.type_ids
-            or filters.is_bpc is not None
-            or filters.min_runs is not None
-            or filters.max_runs is not None
-            # Add sorting by ship name to the condition
-            or filters.sort_by == SortableContractFields.ship_name
-        )
+        needs_item_join = _needs_item_join(filters)
 
         if needs_item_join:
             # Use an outer join to ensure contracts without items are not excluded
@@ -82,60 +212,11 @@ async def get_contracts(  # noqa: C901
 
         # --- Apply Filters ---
         # Each filter is applied to the query object, narrowing the results.
-
-        # 1. Text search (on contract title or item name)
-        if filters.search:
-            search_term = f"%{filters.search}%"
-            # This OR condition requires the join to be present.
-            query = query.filter(
-                or_(
-                    Contract.title.ilike(search_term),
-                    ContractItem.type_name.ilike(search_term),
-                )
-            )
-
-        # 2. Price and Collateral filters
-        if filters.min_price is not None:
-            query = query.filter(Contract.price >= filters.min_price)
-        if filters.max_price is not None:
-            query = query.filter(Contract.price <= filters.max_price)
-        if filters.min_collateral is not None:
-            query = query.filter(Contract.collateral >= filters.min_collateral)
-        if filters.max_collateral is not None:
-            query = query.filter(Contract.collateral <= filters.max_collateral)
-
-        # 2b. Contract-level flags (indexed column; no item join required)
-        if filters.is_ship_contract is not None:
-            query = query.filter(Contract.is_ship_contract == filters.is_ship_contract)
-
-        # 3. Location filters
-        if filters.region_ids:
-            query = query.filter(Contract.start_location_region_id.in_(filters.region_ids))
-        if filters.system_ids:
-            query = query.filter(Contract.start_location_system_id.in_(filters.system_ids))
-        if filters.station_ids:
-            query = query.filter(Contract.start_location_id.in_(filters.station_ids))
-
-        # 4. Contract Item specific filters
-        if filters.type_ids:
-            query = query.filter(ContractItem.type_id.in_(filters.type_ids))
-        if filters.is_bpc is not None:
-            query = query.filter(ContractItem.is_blueprint_copy == filters.is_bpc)
-        # BPC Run filters (Note: ME/TE not implemented as data is not in model)
-        if filters.min_runs is not None:
-            query = query.filter(ContractItem.raw_quantity >= filters.min_runs)
-        if filters.max_runs is not None:
-            query = query.filter(ContractItem.raw_quantity <= filters.max_runs)
+        query = _apply_contract_filters(query, filters)
+        query = _apply_item_filters(query, filters)
 
         # --- Count Query ---
-        # To get an accurate total count of matching *contracts* (not items),
-        # we must count the distinct contract_ids from our filtered query.
-        # This is crucial because the join can create duplicate contract rows.
-        count_subquery = select(query.subquery().c.contract_id).distinct().subquery()
-        count_query = select(func.count()).select_from(count_subquery)
-
-        total_result = await db.execute(count_query)
-        total = total_result.scalar_one()
+        total = await _count_distinct_contracts(db, query)
 
         if total == 0:
             duration_ms = (time.time() - start_time) * 1000
@@ -164,46 +245,9 @@ async def get_contracts(  # noqa: C901
         descending = filters.sort_direction == SortDirection.desc
 
         if needs_item_join:
-            # Paginating the joined query directly would offset/limit over
-            # joined (duplicated) rows, producing short pages and contracts
-            # skipped or repeated across page boundaries. Paginate over
-            # distinct contract IDs first, then load that page's contracts.
-            # Ordering uses an aggregate of the sort column (min/max picks
-            # the sort-direction-appropriate representative when a contract
-            # has multiple items) with contract_id as a deterministic
-            # tiebreaker.
-            sort_aggregate = func.max(sort_column) if descending else func.min(sort_column)
-            order_expr = sort_aggregate.desc() if descending else sort_aggregate.asc()
-            id_query = (
-                query.with_only_columns(Contract.contract_id)
-                .group_by(Contract.contract_id)
-                .order_by(order_expr, Contract.contract_id.asc())
-                .offset((filters.page - 1) * filters.size)
-                .limit(filters.size)
-            )
-            id_result = await db.execute(id_query)
-            page_ids = [row[0] for row in id_result.all()]
-
-            data_query = (
-                select(Contract)
-                .where(Contract.contract_id.in_(page_ids))
-                .options(selectinload(Contract.items))
-            )
-            result = await db.execute(data_query)
-            contracts = list(result.scalars().unique().all())
-            # Restore the page order computed by id_query.
-            position = {cid: index for index, cid in enumerate(page_ids)}
-            contracts.sort(key=lambda contract: position[contract.contract_id])
+            contracts = await _fetch_page_joined(db, query, filters, sort_column, descending)
         else:
-            order_expr = sort_column.desc() if descending else sort_column.asc()
-            data_query = (
-                query.order_by(order_expr, Contract.contract_id.asc())
-                .offset((filters.page - 1) * filters.size)
-                .limit(filters.size)
-                .options(selectinload(Contract.items))
-            )
-            result = await db.execute(data_query)
-            contracts = result.scalars().unique().all()
+            contracts = await _fetch_page_simple(db, query, filters, sort_column, descending)
 
         # Calculate duration and log successful completion
         duration_ms = (time.time() - start_time) * 1000

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -175,8 +175,26 @@ async def test_complex_query(db_session: AsyncSession, setup_contracts):
     assert result.items[0].contract_id == 101
 
 
-async def test_zero_results_returns_empty_page(db_session: AsyncSession, setup_contracts):
-    """No matching contracts short-circuits to an empty page that still echoes page/size."""
+async def test_zero_results_returns_empty_page(
+    db_session: AsyncSession, setup_contracts, monkeypatch
+):
+    """No matching contracts short-circuits to an empty page that still echoes page/size.
+
+    The short-circuit is pinned by the key event it emits, not by the response alone.
+    Deleting the early return would still yield an empty response through the normal
+    pagination path, so the response assertions cannot tell the two branches apart. The
+    early return's search_terms payload carries exactly four keys; the normal path's
+    carries eight, which is the difference this test locks.
+    """
+    events = []
+    real_log_key_event = contract_service.log_key_event
+
+    def recording_log_key_event(*args, **kwargs):
+        events.append(kwargs)
+        return real_log_key_event(*args, **kwargs)
+
+    monkeypatch.setattr(contract_service, "log_key_event", recording_log_key_event)
+
     filters = ContractFilters(search="no-such-ship-name-anywhere", page=1, size=10)
 
     result = await get_contracts(db_session, filters)
@@ -185,6 +203,15 @@ async def test_zero_results_returns_empty_page(db_session: AsyncSession, setup_c
     assert result.items == []
     assert result.page == 1
     assert result.size == 10
+
+    assert len(events) == 1
+    assert events[0]["event"] == "contract_search_executed"
+    assert events[0]["success"] is True
+    assert events[0]["results_count"] == 0
+    assert set(events[0]["search_terms"]) == {"search", "type_ids", "page", "size"}
+    assert events[0]["search_terms"]["search"] == "no-such-ship-name-anywhere"
+    assert events[0]["search_terms"]["page"] == 1
+    assert events[0]["search_terms"]["size"] == 10
 
 
 async def test_unmapped_sort_falls_back_to_date_issued(db_session: AsyncSession):
@@ -245,18 +272,33 @@ async def test_db_error_logs_failure_and_reraises(
 
     monkeypatch.setattr(contract_service, "log_key_event", recording_log_key_event)
 
+    boom_error = RuntimeError("simulated db failure")
+
     async def boom(*args, **kwargs):
-        raise RuntimeError("simulated db failure")
+        raise boom_error
 
     monkeypatch.setattr(db_session, "execute", boom)
 
     filters = ContractFilters(page=1, size=10)
-    with pytest.raises(RuntimeError, match="simulated db failure"):
+    with pytest.raises(RuntimeError, match="simulated db failure") as excinfo:
         await get_contracts(db_session, filters)
+
+    # The except block re-raises bare, so the ORIGINAL exception object propagates —
+    # not an equivalent instance wrapped around the same message.
+    assert excinfo.value is boom_error
 
     failure_events = [e for e in events if e.get("success") is False]
     assert len(failure_events) == 1
-    assert "simulated db failure" in failure_events[0]["error_message"]
+    assert failure_events[0]["event"] == "contract_search_executed"
+    assert failure_events[0]["error_message"] == "simulated db failure"
+    assert set(failure_events[0]["search_terms"]) == {
+        "search",
+        "type_ids",
+        "min_price",
+        "max_price",
+        "page",
+        "size",
+    }
 
 
 async def test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id(

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -31,6 +31,7 @@ from fastapi_app.schemas.contracts import (
     SortableContractFields,
     SortDirection,
 )
+import fastapi_app.services.contract_service as contract_service
 from fastapi_app.services.contract_service import get_contracts
 
 # Mark all tests in this file as asyncio
@@ -172,3 +173,140 @@ async def test_complex_query(db_session: AsyncSession, setup_contracts):
     assert result.total == 1
     assert len(result.items) == 1
     assert result.items[0].contract_id == 101
+
+
+async def test_zero_results_returns_empty_page(db_session: AsyncSession, setup_contracts):
+    """No matching contracts short-circuits to an empty page that still echoes page/size."""
+    filters = ContractFilters(search="no-such-ship-name-anywhere", page=1, size=10)
+
+    result = await get_contracts(db_session, filters)
+
+    assert result.total == 0
+    assert result.items == []
+    assert result.page == 1
+    assert result.size == 10
+
+
+async def test_unmapped_sort_falls_back_to_date_issued(db_session: AsyncSession):
+    """An unmapped sort key falls back to date_issued with the default desc direction.
+
+    sort_by is NON-optional in the schema (default SortableContractFields.date_issued,
+    sort_direction default desc), so SORT_MAP.get(filters.sort_by) can only return None
+    if validation is bypassed — the fallback branch is defensive. It is characterized via
+    model_construct, which skips validation while still populating declared defaults, so
+    only the overrides need passing.
+
+    TEST-3: setup_contracts is deliberately NOT used here — its date_issued values are
+    independent datetime.now() calls (nondeterministic, possibly equal). These three
+    contracts carry fixed, strictly distinct date_issued values in a region id no other
+    fixture uses.
+    """
+    region_id = 99999901
+    base_date = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    db_session.add_all([
+        Contract(
+            contract_id=940000 + offset,
+            title=f"Sort Fallback {offset}",
+            price=1_000_000,
+            collateral=0,
+            status="outstanding",
+            type="item_exchange",
+            issuer_id=940,
+            issuer_corporation_id=940,
+            start_location_id=60003760,
+            start_location_system_id=30000142,
+            start_location_region_id=region_id,
+            for_corporation=False,
+            date_issued=base_date + timedelta(days=offset - 1),
+            date_expired=base_date + timedelta(days=30),
+        )
+        for offset in (1, 2, 3)
+    ])
+    await db_session.flush()
+
+    filters = ContractFilters.model_construct(sort_by=None, region_ids=[region_id])
+
+    result = await get_contracts(db_session, filters)
+
+    # Fallback = Contract.date_issued, default direction desc, contract_id tiebreak:
+    assert [item.contract_id for item in result.items] == [940003, 940002, 940001]
+
+
+async def test_db_error_logs_failure_and_reraises(
+    db_session: AsyncSession, setup_contracts, monkeypatch
+):
+    """A query failure logs a failure key event and the original exception propagates."""
+    events = []
+    real_log_key_event = contract_service.log_key_event
+
+    def recording_log_key_event(*args, **kwargs):
+        events.append(kwargs)
+        return real_log_key_event(*args, **kwargs)
+
+    monkeypatch.setattr(contract_service, "log_key_event", recording_log_key_event)
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("simulated db failure")
+
+    monkeypatch.setattr(db_session, "execute", boom)
+
+    filters = ContractFilters(page=1, size=10)
+    with pytest.raises(RuntimeError, match="simulated db failure"):
+        await get_contracts(db_session, filters)
+
+    failure_events = [e for e in events if e.get("success") is False]
+    assert len(failure_events) == 1
+    assert "simulated db failure" in failure_events[0]["error_message"]
+
+
+async def test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id(
+    db_session: AsyncSession, setup_contracts
+):
+    """Equal sort keys under the item join split deterministically on contract_id ASC.
+
+    SQLA-1 net: with the item join active (search filter) and EQUAL sort keys, pages must
+    split on the contract_id tiebreaker with no contract skipped or repeated across the
+    boundary (TEST-4).
+    """
+    db_session.add_all([
+        Contract(
+            contract_id=contract_id,
+            title="Tiebreak Listing",
+            price=500.0,
+            collateral=0,
+            status="outstanding",
+            type="item_exchange",
+            issuer_id=930,
+            issuer_corporation_id=930,
+            start_location_id=60003760,
+            start_location_system_id=30000142,
+            start_location_region_id=10000002,
+            for_corporation=False,
+            date_issued=datetime.now(timezone.utc),
+            date_expired=datetime.now(timezone.utc) + timedelta(days=7),
+            items=[
+                ContractItem(
+                    record_id=record_id,
+                    type_id=587,
+                    type_name="Tiebreakship",
+                    quantity=1,
+                    is_included=True,
+                    is_singleton=False,
+                    is_blueprint_copy=False,
+                )
+            ],
+        )
+        for contract_id, record_id in ((930001, 9300011), (930002, 9300021))
+    ])
+    await db_session.flush()
+
+    filters_p1 = ContractFilters(search="tiebreakship", sort_by=SortableContractFields.price,
+                                 sort_direction=SortDirection.asc, page=1, size=1)
+    filters_p2 = filters_p1.model_copy(update={"page": 2})
+
+    page1 = await get_contracts(db_session, filters_p1)
+    page2 = await get_contracts(db_session, filters_p2)
+
+    assert page1.total == 2 and page2.total == 2
+    assert [c.contract_id for c in page1.items] == [930001]
+    assert [c.contract_id for c in page2.items] == [930002]

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -264,12 +264,37 @@ async def test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id(
 ):
     """Equal sort keys under the item join split deterministically on contract_id ASC.
 
-    SQLA-1 net: with the item join active (search filter) and EQUAL sort keys, pages must
-    split on the contract_id tiebreaker with no contract skipped or repeated across the
-    boundary (TEST-4).
+    SQLA-1 net: 930001 carries TWO matching items, so the joined row count (3) exceeds the
+    contract count (2). Every item shares one type_name, so the aggregate sort key ties and
+    930001's second row lands at offset 1 — paginating the joined rows directly repeats
+    930001 on page 2 and drops 930002 entirely. This is the assertion that bites: merging
+    the joined fetch path into the simple one turns page 2 into [930001]. The pages are
+    also asserted to partition the result set exactly, with no contract skipped or repeated
+    across the boundary (TEST-4).
+
+    Scope limit — what this test does NOT lock: the `Contract.contract_id.asc()` tiebreaker
+    on the joined path's id_query. At this fixture size Postgres feeds the final sort from a
+    GroupAggregate that is already sorted by contract_id, so tied keys emerge ascending
+    whether or not the tiebreaker is present and its removal is unobservable here. The
+    tiebreaker matters at scale, where a HashAggregate emits groups in arbitrary order; it
+    is covered behaviorally by test_pagination_sorted_by_ship_name_no_duplicates in
+    tests/api/test_contract_filters.py, whose larger row set does reach that plan.
     """
-    db_session.add_all([
-        Contract(
+    ship_name = "Tiebreakship"
+
+    def tiebreak_item(record_id: int, type_id: int) -> ContractItem:
+        return ContractItem(
+            record_id=record_id,
+            type_id=type_id,
+            type_name=ship_name,
+            quantity=1,
+            is_included=True,
+            is_singleton=False,
+            is_blueprint_copy=False,
+        )
+
+    def tiebreak_contract(contract_id: int, items: list[ContractItem]) -> Contract:
+        return Contract(
             contract_id=contract_id,
             title="Tiebreak Listing",
             price=500.0,
@@ -284,23 +309,19 @@ async def test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id(
             for_corporation=False,
             date_issued=datetime.now(timezone.utc),
             date_expired=datetime.now(timezone.utc) + timedelta(days=7),
-            items=[
-                ContractItem(
-                    record_id=record_id,
-                    type_id=587,
-                    type_name="Tiebreakship",
-                    quantity=1,
-                    is_included=True,
-                    is_singleton=False,
-                    is_blueprint_copy=False,
-                )
-            ],
+            items=items,
         )
-        for contract_id, record_id in ((930001, 9300011), (930002, 9300021))
+
+    db_session.add_all([
+        tiebreak_contract(930002, [tiebreak_item(9300021, 587)]),
+        tiebreak_contract(930001, [
+            tiebreak_item(9300011, 587),
+            tiebreak_item(9300012, 588),
+        ]),
     ])
     await db_session.flush()
 
-    filters_p1 = ContractFilters(search="tiebreakship", sort_by=SortableContractFields.price,
+    filters_p1 = ContractFilters(search=ship_name, sort_by=SortableContractFields.ship_name,
                                  sort_direction=SortDirection.asc, page=1, size=1)
     filters_p2 = filters_p1.model_copy(update={"page": 2})
 
@@ -310,3 +331,8 @@ async def test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id(
     assert page1.total == 2 and page2.total == 2
     assert [c.contract_id for c in page1.items] == [930001]
     assert [c.contract_id for c in page2.items] == [930002]
+
+    page1_ids = {c.contract_id for c in page1.items}
+    page2_ids = {c.contract_id for c in page2.items}
+    assert page1_ids | page2_ids == {930001, 930002}
+    assert page1_ids & page2_ids == set()

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -102,10 +102,11 @@ tests SQL strings rather than behavior.
 **Phase 1, Task 1.2 — two annotation-level deviations from the normative helper signatures.**
 (a) `_needs_item_join` wraps its expression in `bool()`; the original assigned a raw truthy value, and
 the plan's normative signature declares `-> bool`. Consumed only by `if`, so no caller can observe it.
-(b) `_fetch_page_joined` / `_fetch_page_simple` keep the plan's normative `-> list[Contract]`
-annotation but return a SQLAlchemy `Sequence`. Inserting `list(...)` would have been a real (if tiny)
-behavior change, so the statement was moved verbatim and the loose annotation kept. No caller performs
-list-specific operations.
+(b) `_fetch_page_simple` keeps the plan's normative `-> list[Contract]` annotation but returns a
+SQLAlchemy `Sequence`. Inserting `list(...)` would have been a real (if tiny) behavior change, so the
+statement was moved verbatim and the loose annotation kept. No caller performs list-specific
+operations. `_fetch_page_joined`'s annotation is honest — its position-restoration step builds a real
+`list` — so this applies to the simple path only.
 
 ### Discoveries
 

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -60,15 +60,66 @@ notes and commit messages.
 
 ## Execution Status
 
-**Overall:** Not started.
+**Overall:** In progress — Phase 1 claimed 2026-07-18.
+
+**Baseline at Phase 1 claim** (branch point `bfaf495`, fresh `origin/dev`): `pdm run pytest` = **358 passed**; `pdm run lint` = exit 0; `grep -rn "noqa: C901" src/` = the 5 expected sites.
 
 | Phase | Status | Ship SHA(s) | Notes |
 |---|---|---|---|
-| 1 — get_contracts | ⬜ Not started | — | — |
+| 1 — get_contracts | 🚧 PR open | `69b0112`, `3d4e61e`, `1ca0aa0` | branch `claude/c901-get-contracts`; complexity 20 → 7; suite 358 → 362 |
 | 2 — _process_contracts | ⬜ Not started | — | same file as Phase 3; run before it |
 | 3 — run_aggregation | ⬜ Not started | — | blocked by Phase 2 (same file) |
 | 4 — _get_esi_object + shared retry helper | ⬜ Not started | — | introduces `_get_with_transient_retry` |
 | 5 — get_esi_data_with_etag_caching | ⬜ Not started | — | blocked by Phase 4 (uses its helper); write its missing tests FIRST |
+
+### Deviations
+
+**Phase 1, Task 1.1 — the plan's tiebreaker test as written was vacuous; its fixture was reshaped.**
+`test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id` was specified with a normative body
+in Task 1.1. Written exactly as specified, it passed against BOTH of the mutations it claimed to
+guard against: deleting `Contract.contract_id.asc()` from the joined `id_query`, and merging
+`_fetch_page_joined` into `_fetch_page_simple` (the change non-negotiable ground rule 4 forbids). Two
+review lenses independently mutation-tested it and converged on this. Root causes: each contract
+carried exactly ONE matching `ContractItem`, so the join produced no duplicated rows for SQLA-1 to
+bite on; and the fixture inserted `930001` before `930002`, so heap order accidentally matched the
+asserted order. Fix (commit `1ca0aa0`, test file only): contract 930001 now carries 2 matching items
+(joined row count 3 > contract count 2), rows are inserted in descending contract_id order, the sort
+key moved from `price` to `ship_name` so the tie is on the aggregated item column, and TEST-4
+partition assertions were added (union of pages == full set, intersection empty). Test name and the
+plan's normative assertions are unchanged.
+
+**Residual limit, documented rather than faked:** the tiebreaker-removal mutation still cannot be made
+red at this fixture size. `EXPLAIN` shows Postgres feeds the final sort from a `GroupAggregate` that is
+already sorted by `contract_id`, so tied keys emerge contract_id-ascending whether or not the
+tiebreaker exists; descending inserts, 3 contracts, item-column sorts, and forcing `HashAggregate` via
+`enable_sort=off` were all tried and all still returned ascending. The tiebreaker IS covered — by the
+pre-existing `tests/api/test_contract_filters.py::test_pagination_sorted_by_ship_name_no_duplicates`,
+which does go red under that mutation. The test's docstring now states what it locks (SQLA-1
+joined-row pagination + TEST-4 partition), what it does not (the tiebreaker), and where the tiebreaker
+is actually covered. The rejected alternative was asserting on the compiled `ORDER BY` SQL text, which
+tests SQL strings rather than behavior.
+
+**Phase 1, Task 1.2 — two annotation-level deviations from the normative helper signatures.**
+(a) `_needs_item_join` wraps its expression in `bool()`; the original assigned a raw truthy value, and
+the plan's normative signature declares `-> bool`. Consumed only by `if`, so no caller can observe it.
+(b) `_fetch_page_joined` / `_fetch_page_simple` keep the plan's normative `-> list[Contract]`
+annotation but return a SQLAlchemy `Sequence`. Inserting `list(...)` would have been a real (if tiny)
+behavior change, so the statement was moved verbatim and the loose annotation kept. No caller performs
+list-specific operations.
+
+### Discoveries
+
+**Concurrent pytest runs clobber the shared test database.** `pdm run pytest` drops and recreates the
+database named by `DATABASE_URL_TESTS`; isolation comes from per-run drop/recreate, not per-test
+rollback. Two agents running the suite simultaneously produce spurious `IntegrityError` / `DROP TABLE`
+failures that look like real test defects. Reviewers doing mutation testing must serialize, or point
+their own `DATABASE_URL_TESTS` at a scratch database. This bit the Phase 1 review round (2026-07-18)
+and cost one reviewer several confusing runs before it was diagnosed.
+
+**`_apply_contract_filters` measures exactly 10 — at the C901 limit.** The plan's contingency
+(`_apply_location_filters`) was correctly NOT applied, since the plan says do not preemptively split
+and the measurement is not > 10. But the next filter added to `get_contracts` will break the build.
+Whoever adds it should apply the documented contingency at that time.
 
 ---
 
@@ -92,7 +143,12 @@ notes and commit messages.
 
 ## Phase 1 — `get_contracts` (complexity 20 → ≤ 10)
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 PR OPEN — branch `claude/c901-get-contracts`, claimed 2026-07-18T22:21Z.
+Commits `69b0112` (characterization tests), `3d4e61e` (extraction), `1ca0aa0` (mutation-sensitivity fix
+for the tiebreaker fixture — see Deviations). Gates: red gate observed
+(`C901 'get_contracts' is too complex (20)`); after extraction `pdm run lint` exit 0,
+`--select=C901` empty, `get_contracts` 20 → 7, `_apply_contract_filters` 10, `_apply_item_filters` 5;
+full suite 358 → 362 passed; 4 `# noqa: C901` remain (Phases 2-5).
 
 **Files:**
 - Modify: `app/backend/src/fastapi_app/services/contract_service.py`


### PR DESCRIPTION
Phase 1 of the [C901 complexity-refactor plan](docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md): pays down the `# noqa: C901` on `get_contracts`, with zero behavior change proven by characterization tests written before the extraction.

## Merge classification

`Routine — auto-merge on green CI`

Read-path query construction only. No ingestion, no database writes, no external transport. The four other `# noqa: C901` sites are untouched.

## What changed

| Commit | Change |
|---|---|
| `69b0112` | Characterization tests for three uncovered paths: zero-result early return, defensive sort fallback, and the DB-error branch |
| `3d4e61e` | Extraction of six module-private query helpers; `# noqa: C901` removed |
| `1ca0aa0` | Reshaped the joined-pagination fixture so it is actually mutation-sensitive (see Deviations) |
| `7ae0576` | Plan banners, deviations, discoveries |

`get_contracts` now delegates to `_needs_item_join`, `_apply_contract_filters`, `_apply_item_filters`, `_count_distinct_contracts`, `_fetch_page_joined`, and `_fetch_page_simple`. All are module-private; the public signature is unchanged.

## Gates

- **Red gate observed before extraction:** `C901 'get_contracts' is too complex (20)`
- **After:** `pdm run lint` exit 0; `flake8 --select=C901` on the file is empty
- **Complexity:** `get_contracts` 20 → 7; `_apply_contract_filters` 10; `_apply_item_filters` 5; the rest 1
- **Suite:** 358 → 362 passed (4 added, none dropped)
- **Remaining suppressions:** 4, all belonging to Phases 2-5

## Behavior changes

**None.** The plan authorizes exactly two behavior changes across all five phases, and neither is in this one. Log message text, `log_key_event` payloads, exception types, filter order, and every SQLAlchemy clause were moved verbatim. The SQLA-1 pagination fix (grouped subquery, aggregate-based ordering, `contract_id` tiebreaker, id_query/page_ids/data_query split, position restoration) survives byte-identically in `_fetch_page_joined`, and the two fetch paths remain separate.

## Deviations from the plan

**The plan's normatively-specified tiebreaker test was vacuous; its fixture was reshaped.** Written exactly as the plan specified, `test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id` passed against both mutations it claimed to guard: deleting the `contract_id` tiebreaker, and merging the two fetch paths (the change ground rule 4 forbids). Two review lenses independently mutation-tested it and converged. Causes: each contract carried exactly one matching item, so the join produced no duplicated rows for SQLA-1 to bite on; and rows were inserted in ascending id order, so heap order accidentally matched the assertion.

Fixed in `1ca0aa0` (test file only): 930001 now carries 2 matching items (joined rows 3 > contracts 2), rows insert in descending id order, the sort key moved from `price` to `ship_name` so the tie is on the aggregated item column, and TEST-4 partition assertions were added. The path-merge mutation now fails as it should. Test name and the plan's normative assertions are unchanged.

**Documented residual limit:** the tiebreaker-removal mutation still cannot be made red at this fixture size — `EXPLAIN` shows Postgres feeds the final sort from a `GroupAggregate` already sorted by `contract_id`, so ties emerge ascending regardless. Descending inserts, 3 contracts, item-column sorts, and forcing `HashAggregate` were all tried. The tiebreaker is genuinely covered by the pre-existing `test_contract_filters.py::test_pagination_sorted_by_ship_name_no_duplicates`, which does go red under that mutation; the docstring now says so instead of overclaiming. Asserting on compiled `ORDER BY` SQL text was considered and rejected as testing strings rather than behavior.

**Two annotation-level deviations:** `_needs_item_join` wraps its expression in `bool()` to honor the plan's normative `-> bool` (consumed only by `if`, unobservable); and the fetch helpers keep the plan's `-> list[Contract]` while returning a SQLAlchemy `Sequence` — adding `list(...)` would have been a real behavior change, so the statement was moved verbatim and the loose annotation kept.

## Discoveries

- **Concurrent `pdm run pytest` runs clobber the shared test database.** Isolation is per-run drop/recreate, not per-test rollback, so two agents running the suite at once produce spurious `IntegrityError` / `DROP TABLE` failures that mimic real defects. Recorded in the plan.
- **`_apply_contract_filters` measures exactly 10** — at the limit. The plan's `_apply_location_filters` contingency was correctly not applied (it triggers only above 10), but the next filter added will break the build.

## Review

Three review lenses (behavior preservation, test quality, complexity/API surface) across two rounds, each finding adversarially refuted by three independent verifiers with a 2-of-3 kill rule. Round 1: 5 candidates → 2 confirmed (both the vacuous-test defect, found independently). Round 2: 7 candidates → 0 confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)