### PR TITLE
chore: project-scoped Render MCP config (env-var expansion, no plaintext key)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "render": {
+      "type": "http",
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${RENDER_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `.mcp.json` wiring the hosted Render MCP server via `${RENDER_API_KEY}` header expansion per https://code.claude.com/docs/en/mcp — no secret value in the file. The key comes from the launching shell (1Password). Root `.env` confirmed gitignored (any-depth `.env` pattern).

## Merge classification

Routine

🤖 Generated with [Claude Code](https://claude.com/claude-code)