### PR TITLE
refactor(api): reduce _process_contracts complexity below the C901 budget

### DIFF
--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -55,6 +55,73 @@ def _chunk_ids(ids: Iterable[int]) -> Iterator[list[int]]:
         yield id_list[start : start + UPDATE_ID_CHUNK_SIZE]
 
 
+def _parse_esi_datetime(date_string: str | None) -> datetime | None:
+    """Parse ESI's ISO 8601 date strings into datetime objects."""
+    if date_string is None:
+        return None
+    # ESI dates are like "2024-05-20T14:47:32Z". The 'Z' means UTC.
+    # fromisoformat handles this correctly if we replace 'Z' with '+00:00'.
+    return datetime.fromisoformat(date_string.replace("Z", "+00:00"))
+
+
+def _collect_resolvable_ids(contracts: List[dict]) -> list[int]:
+    """Collect the unique issuer/corporation/location IDs resolvable to names."""
+    issuer_ids = {c['issuer_id'] for c in contracts}
+    corporation_ids = {c['issuer_corporation_id'] for c in contracts}
+    start_location_ids = {c.get('start_location_id') for c in contracts if c.get('start_location_id')}
+    end_location_ids = {c.get('end_location_id') for c in contracts if c.get('end_location_id')}
+
+    all_ids_to_resolve = list(
+        issuer_ids.union(corporation_ids).union(start_location_ids).union(end_location_ids)
+    )
+
+    # Player-owned structures have IDs > 10^11 and are not resolvable
+    # by the public /universe/names/ endpoint. We filter them out.
+    original_id_count = len(all_ids_to_resolve)
+    all_ids_to_resolve = [
+        id_ for id_ in all_ids_to_resolve if id_ < 100_000_000_000
+    ]
+    filtered_count = len(all_ids_to_resolve)
+    if original_id_count > filtered_count:
+        logger.info(f"Filtered out {original_id_count - filtered_count} unresolvable structure IDs.")
+    return all_ids_to_resolve
+
+
+def _build_contract_rows(contracts: List[dict], id_to_name_map: dict) -> list[dict]:
+    """Transform ESI contract payloads into Contract upsert rows, enriched with names."""
+    return [
+        {
+            "contract_id": c["contract_id"],
+            "issuer_id": c["issuer_id"],
+            "issuer_corporation_id": c["issuer_corporation_id"],
+            "start_location_id": c.get("start_location_id"),
+            "start_location_region_id": c.get("_hb_region_id"),
+            "end_location_id": c.get("end_location_id"),
+            "type": c["type"],  # Direct mapping - field names now match
+            "status": c.get("status", "unknown"),
+            "title": c.get("title"),
+            "for_corporation": c.get("for_corporation", False),
+            "date_issued": _parse_esi_datetime(c["date_issued"]),
+            "date_expired": _parse_esi_datetime(c["date_expired"]),
+            "date_completed": _parse_esi_datetime(c.get("date_completed")),
+            "price": c.get("price"),
+            "collateral": c.get("collateral", 0.0),  # Default to 0.0 if null
+            "reward": c.get("reward"),
+            "volume": c.get("volume"),
+            # Denormalized data for search performance
+            "start_location_name": id_to_name_map.get(c.get("start_location_id")),
+            "issuer_name": id_to_name_map.get(c.get('issuer_id')),
+            "issuer_corporation_name": id_to_name_map.get(c.get('issuer_corporation_id')),
+            # is_ship_contract and item_processing_status are deliberately
+            # ABSENT: they are maintained by item enrichment, and the upsert
+            # copies every mapped column on conflict — including them here
+            # decayed ship flags to False whenever items were ETag-304'd and
+            # skipped re-enrichment. Column defaults cover fresh inserts.
+        }
+        for c in contracts
+    ]
+
+
 class ConcurrencyLockError(Exception):
     """Custom exception for when the aggregation lock cannot be acquired."""
     pass
@@ -209,37 +276,12 @@ class ContractAggregationService:
                 await engine.dispose()
                 logger.info("Database engine disposed.")
 
-    async def _process_contracts(self, db_session: AsyncSession, contracts: List[dict]):  # noqa: C901
+    async def _process_contracts(self, db_session: AsyncSession, contracts: List[dict]):
         """
         Processes a list of contracts, fetches their items, and upserts them using the provided db_session.
         """
-        # Helper to parse ESI's ISO 8601 date strings into datetime objects.
-        def _parse_datetime(date_string: str | None) -> datetime | None:
-            if date_string is None:
-                return None
-            # ESI dates are like "2024-05-20T14:47:32Z". The 'Z' means UTC.
-            # fromisoformat handles this correctly if we replace 'Z' with '+00:00'.
-            return datetime.fromisoformat(date_string.replace("Z", "+00:00"))
-
         # Step 1: Collect all unique IDs from the current batch of contracts.
-        issuer_ids = {c['issuer_id'] for c in contracts}
-        corporation_ids = {c['issuer_corporation_id'] for c in contracts}
-        start_location_ids = {c.get('start_location_id') for c in contracts if c.get('start_location_id')}
-        end_location_ids = {c.get('end_location_id') for c in contracts if c.get('end_location_id')}
-
-        all_ids_to_resolve = list(
-            issuer_ids.union(corporation_ids).union(start_location_ids).union(end_location_ids)
-        )
-
-        # Player-owned structures have IDs > 10^11 and are not resolvable
-        # by the public /universe/names/ endpoint. We filter them out.
-        original_id_count = len(all_ids_to_resolve)
-        all_ids_to_resolve = [
-            id_ for id_ in all_ids_to_resolve if id_ < 100_000_000_000
-        ]
-        filtered_count = len(all_ids_to_resolve)
-        if original_id_count > filtered_count:
-            logger.info(f"Filtered out {original_id_count - filtered_count} unresolvable structure IDs.")
+        all_ids_to_resolve = _collect_resolvable_ids(contracts)
 
         # Step 2: Resolve all IDs to names in a single batch operation.
         id_to_name_map = {}
@@ -249,37 +291,7 @@ class ContractAggregationService:
             logger.info(f"Successfully resolved {len(id_to_name_map)} names.")
 
         # Step 3: Transform contracts into the format for the database model, enriching with names.
-        contract_values = [
-            {
-                "contract_id": c["contract_id"],
-                "issuer_id": c["issuer_id"],
-                "issuer_corporation_id": c["issuer_corporation_id"],
-                "start_location_id": c.get("start_location_id"),
-                "start_location_region_id": c.get("_hb_region_id"),
-                "end_location_id": c.get("end_location_id"),
-                "type": c["type"],  # Direct mapping - field names now match
-                "status": c.get("status", "unknown"),
-                "title": c.get("title"),
-                "for_corporation": c.get("for_corporation", False),
-                "date_issued": _parse_datetime(c["date_issued"]),
-                "date_expired": _parse_datetime(c["date_expired"]),
-                "date_completed": _parse_datetime(c.get("date_completed")),
-                "price": c.get("price"),
-                "collateral": c.get("collateral", 0.0),  # Default to 0.0 if null
-                "reward": c.get("reward"),
-                "volume": c.get("volume"),
-                # Denormalized data for search performance
-                "start_location_name": id_to_name_map.get(c.get("start_location_id")),
-                "issuer_name": id_to_name_map.get(c.get('issuer_id')),
-                "issuer_corporation_name": id_to_name_map.get(c.get('issuer_corporation_id')),
-                # is_ship_contract and item_processing_status are deliberately
-                # ABSENT: they are maintained by item enrichment, and the upsert
-                # copies every mapped column on conflict — including them here
-                # decayed ship flags to False whenever items were ETag-304'd and
-                # skipped re-enrichment. Column defaults cover fresh inserts.
-            }
-            for c in contracts
-        ]
+        contract_values = _build_contract_rows(contracts, id_to_name_map)
 
         batch_size = 500  # Number of contracts to process in each batch
         total_contracts = len(contract_values)
@@ -293,6 +305,43 @@ class ContractAggregationService:
 
         logger.info(f"Finished upserting all {total_contracts} contracts.")
 
+        all_items, processed_contract_ids = await self._fetch_item_rows(contracts)
+
+        # Enrich items with static type data BEFORE upserting so a single
+        # write carries names/categories, and collect which contracts hold an
+        # included ship (fills the gap that left is_ship_contract permanently
+        # False — "will be updated later" never happened; found during the
+        # /impeccable design phase when the ships-only default matched nothing).
+        ship_contract_ids = await self._enrich_items_and_find_ships(all_items)
+
+        if all_items:
+            logger.info(f"Preparing to upsert {len(all_items)} contract items in batches.")
+            BATCH_SIZE = 50  # Number of items to process in each batch
+            for i in range(0, len(all_items), BATCH_SIZE):
+                batch_items = all_items[i:i + BATCH_SIZE]
+                logger.info(f"Upserting batch of {len(batch_items)} contract items (items {i + 1}-{i + len(batch_items)} of {len(all_items)}).")
+                await bulk_upsert(db_session, ContractItem, batch_items)
+            logger.info(f"Finished upserting all {len(all_items)} contract items.")
+        else:
+            logger.info("No new contract items to process.")
+
+        for chunk in _chunk_ids(ship_contract_ids):
+            await db_session.execute(
+                update(Contract)
+                .where(Contract.contract_id.in_(chunk))
+                .values(is_ship_contract=True)
+            )
+        if ship_contract_ids:
+            logger.info(f"Flagged {len(ship_contract_ids)} contracts as ship contracts.")
+
+        await self._update_item_processing_status(db_session, processed_contract_ids, all_items)
+
+    async def _fetch_item_rows(self, contracts: List[dict]) -> tuple[list[dict], set[int]]:
+        """Fetch contract items from ESI, returning the item rows and the contract IDs reached.
+
+        A per-contract fetch failure is isolated: that contract is left out of the
+        processed set and the run continues.
+        """
         all_items: List[dict] = []
         processed_contract_ids: set[int] = set()
         for contract in contracts:
@@ -326,33 +375,15 @@ class ContractAggregationService:
             except Exception as e:
                 logger.error(f"Failed to fetch items for contract {contract['contract_id']}: {e}", exc_info=True)
 
-        # Enrich items with static type data BEFORE upserting so a single
-        # write carries names/categories, and collect which contracts hold an
-        # included ship (fills the gap that left is_ship_contract permanently
-        # False — "will be updated later" never happened; found during the
-        # /impeccable design phase when the ships-only default matched nothing).
-        ship_contract_ids = await self._enrich_items_and_find_ships(all_items)
+        return all_items, processed_contract_ids
 
-        if all_items:
-            logger.info(f"Preparing to upsert {len(all_items)} contract items in batches.")
-            BATCH_SIZE = 50  # Number of items to process in each batch
-            for i in range(0, len(all_items), BATCH_SIZE):
-                batch_items = all_items[i:i + BATCH_SIZE]
-                logger.info(f"Upserting batch of {len(batch_items)} contract items (items {i + 1}-{i + len(batch_items)} of {len(all_items)}).")
-                await bulk_upsert(db_session, ContractItem, batch_items)
-            logger.info(f"Finished upserting all {len(all_items)} contract items.")
-        else:
-            logger.info("No new contract items to process.")
-
-        for chunk in _chunk_ids(ship_contract_ids):
-            await db_session.execute(
-                update(Contract)
-                .where(Contract.contract_id.in_(chunk))
-                .values(is_ship_contract=True)
-            )
-        if ship_contract_ids:
-            logger.info(f"Flagged {len(ship_contract_ids)} contracts as ship contracts.")
-
+    async def _update_item_processing_status(
+        self,
+        db_session: AsyncSession,
+        processed_contract_ids: set[int],
+        all_items: list[dict],
+    ) -> None:
+        """Record per-contract item enrichment outcome on the Contract rows."""
         # item_processing_status must not imply enrichment SUCCESS: a contract
         # whose type/group resolution failed keeps NULL enrichment (the
         # graceful-degrade path), so a future consumer trusting 'COMPLETED' would

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -339,3 +339,77 @@ async def test_process_contracts_persists_bpc_flag_and_is_bpc_filter_matches(
     assert response.status_code == 200
     matched_ids = [c["contract_id"] for c in response.json()["items"]]
     assert 900201 in matched_ids
+
+
+async def test_item_fetch_failure_for_one_contract_does_not_abort_batch(db_session: AsyncSession):
+    """One contract's item fetch raising must not prevent the other contract's
+    items from landing, and the failed contract must never be marked processed."""
+    service = _make_service()
+
+    async def items_side_effect(contract_id):
+        if contract_id == 910001:
+            raise RuntimeError("simulated ESI items failure")
+        return [{"record_id": 21, "type_id": 587, "quantity": 1, "is_included": True}]
+
+    service.esi_client.get_contract_items = AsyncMock(side_effect=items_side_effect)
+    service.esi_client.get_universe_type = AsyncMock(
+        return_value={"name": "Rifter", "group_id": 25, "market_group_id": 64}
+    )
+    service.esi_client.get_universe_group = AsyncMock(
+        return_value={"name": "Frigate", "category_id": 6}
+    )
+    contracts = [
+        dict(_ship_contract_dict(910001)),
+        dict(_ship_contract_dict(910002)),
+    ]
+
+    await service._process_contracts(db_session, contracts)
+
+    item_rows = (
+        await db_session.execute(
+            select(ContractItem).where(ContractItem.contract_id == 910002)
+        )
+    ).scalars().all()
+    assert len(item_rows) == 1  # the healthy contract's items landed
+
+    failed_row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 910001)
+        )
+    ).scalar_one()
+    healthy_row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 910002)
+        )
+    ).scalar_one()
+    # The model default is 'PENDING_ITEMS' (models/contracts.py) — a contract
+    # whose item fetch failed keeps the default, it is NEVER marked COMPLETED
+    # or ENRICHMENT_INCOMPLETE (both require membership in processed ids).
+    assert failed_row.item_processing_status == "PENDING_ITEMS"
+    assert healthy_row.item_processing_status == "COMPLETED"
+
+
+async def test_structure_ids_are_excluded_from_name_resolution(db_session: AsyncSession, caplog):
+    """The resolvable-ID cut is `id < 100_000_000_000` (10^11): player-structure
+    IDs at or above 10^11 are unresolvable via /universe/names/ and are filtered
+    out of the resolve batch (name column stays NULL). Pin BOTH sides of the
+    boundary so an off-by-one in the extracted helper cannot slip through."""
+    caplog.set_level("INFO")  # the filter log is INFO; default capture level misses it
+    service = _make_service()
+    contract = dict(_ship_contract_dict(910003))
+    contract["start_location_id"] = 99_999_999_999       # last resolvable id
+    contract["end_location_id"] = 100_000_000_000        # first excluded id
+    contract["type"] = "courier"  # skip the item-fetch loop entirely
+
+    await service._process_contracts(db_session, [contract])
+
+    resolved_ids = service.esi_client.resolve_ids_to_names.await_args.args[0]
+    assert 99_999_999_999 in resolved_ids
+    assert 100_000_000_000 not in resolved_ids
+    assert "Filtered out 1 unresolvable structure IDs." in caplog.text
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 910003)
+        )
+    ).scalar_one()
+    assert row.start_location_name is None  # 99999999999 resolves to nothing in the stub map

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -396,9 +396,18 @@ async def test_structure_ids_are_excluded_from_name_resolution(db_session: Async
     boundary so an off-by-one in the extracted helper cannot slip through."""
     caplog.set_level("INFO")  # the filter log is INFO; default capture level misses it
     service = _make_service()
+
+    # Name whatever IDs actually reach the resolver. A static map would make the
+    # NULL assertion below pass for the wrong reason (id simply absent from the
+    # map); naming everything passed means a NULL name proves the id was FILTERED.
+    async def name_everything_passed(ids):
+        return {id_: f"Structure {id_}" for id_ in ids}
+
+    service.esi_client.resolve_ids_to_names = AsyncMock(side_effect=name_everything_passed)
+
     contract = dict(_ship_contract_dict(910003))
-    contract["start_location_id"] = 99_999_999_999       # last resolvable id
-    contract["end_location_id"] = 100_000_000_000        # first excluded id
+    contract["start_location_id"] = 100_000_000_000      # first excluded id
+    contract["end_location_id"] = 99_999_999_999         # last resolvable id
     contract["type"] = "courier"  # skip the item-fetch loop entirely
 
     await service._process_contracts(db_session, [contract])
@@ -412,7 +421,9 @@ async def test_structure_ids_are_excluded_from_name_resolution(db_session: Async
             select(Contract).where(Contract.contract_id == 910003)
         )
     ).scalar_one()
-    assert row.start_location_name is None  # 99999999999 resolves to nothing in the stub map
+    # Excluded from the resolve batch, so it can never acquire a name. Widening the
+    # cut to `<=` would name it "Structure 100000000000" and fail this assertion.
+    assert row.start_location_name is None
 
 
 async def test_resolved_location_names_land_on_persisted_contract_rows(db_session: AsyncSession):

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -413,3 +413,39 @@ async def test_structure_ids_are_excluded_from_name_resolution(db_session: Async
         )
     ).scalar_one()
     assert row.start_location_name is None  # 99999999999 resolves to nothing in the stub map
+
+
+async def test_resolved_location_names_land_on_persisted_contract_rows(db_session: AsyncSession):
+    """Resolved names reach all three denormalized columns on the persisted row.
+
+    `_build_contract_rows` takes `id_to_name_map` as an explicit parameter, so the
+    resolve step and the row build are wired together at the call site. Nothing else
+    in the suite asserts a POPULATED name, which leaves that wiring free to break
+    silently — an empty map would still produce rows, just nameless ones. This pins
+    all three lookups (start location, issuer, issuer corporation) through the full
+    build-and-upsert path.
+    """
+    service = _make_service()
+    service.esi_client.resolve_ids_to_names = AsyncMock(
+        return_value={
+            60003760: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+            1001: "Test Issuer",
+            2002: "Test Issuer Corp",
+        }
+    )
+    contract = dict(_ship_contract_dict(910004))
+    contract["start_location_id"] = 60003760
+    contract["issuer_id"] = 1001
+    contract["issuer_corporation_id"] = 2002
+    contract["type"] = "courier"  # skip the item-fetch loop entirely
+
+    await service._process_contracts(db_session, [contract])
+
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 910004)
+        )
+    ).scalar_one()
+    assert row.start_location_name == "Jita IV - Moon 4 - Caldari Navy Assembly Plant"
+    assert row.issuer_name == "Test Issuer"
+    assert row.issuer_corporation_name == "Test Issuer Corp"

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -69,7 +69,7 @@ notes and commit messages.
 | Phase | Status | Ship SHA(s) | Notes |
 |---|---|---|---|
 | 1 — get_contracts | ✅ Merged | `69b0112`, `3d4e61e`, `1ca0aa0`, `7ae0576`, `63e5ddb`, `bca290b` → merge `e84aa8a` | PR #54, merged 2026-07-18; complexity 20 → 7; suite 358 → 362 |
-| 2 — _process_contracts | 🚧 PR open | `455f586`, `6bd9f63`, `8962daf` | branch `claude/c901-process-contracts`; complexity 18 → 7; suite 362 → 365; `Review — data-integrity`, Sam merges |
+| 2 — _process_contracts | 🚧 PR #57 open | `455f586`, `6bd9f63`, `8962daf`, `656a383`, `bca8d00` | branch `claude/c901-process-contracts`; complexity 18 → 7; suite 362 → 365; `Review — data-integrity`, **Sam merges** |
 | 3 — run_aggregation | ⬜ Not started | — | blocked by Phase 2 (same file) |
 | 4 — _get_esi_object + shared retry helper | ⬜ Not started | — | introduces `_get_with_transient_retry` |
 | 5 — get_esi_data_with_etag_caching | ⬜ Not started | — | blocked by Phase 4 (uses its helper); write its missing tests FIRST |

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -60,14 +60,16 @@ notes and commit messages.
 
 ## Execution Status
 
-**Overall:** In progress — Phase 1 claimed 2026-07-18.
+**Overall:** In progress — Phase 1 shipped; Phase 2 claimed 2026-07-18.
 
 **Baseline at Phase 1 claim** (branch point `bfaf495`, fresh `origin/dev`): `pdm run pytest` = **358 passed**; `pdm run lint` = exit 0; `grep -rn "noqa: C901" src/` = the 5 expected sites.
 
+**Baseline at Phase 2 claim** (branch point `e84aa8a`, `origin/dev` after Phase 1 merged): `pdm run pytest` = **362 passed**; `pdm run lint` = exit 0; 4 `# noqa: C901` sites remain.
+
 | Phase | Status | Ship SHA(s) | Notes |
 |---|---|---|---|
-| 1 — get_contracts | 🚧 PR open | `69b0112`, `3d4e61e`, `1ca0aa0` | branch `claude/c901-get-contracts`; complexity 20 → 7; suite 358 → 362 |
-| 2 — _process_contracts | ⬜ Not started | — | same file as Phase 3; run before it |
+| 1 — get_contracts | ✅ Merged | `69b0112`, `3d4e61e`, `1ca0aa0`, `7ae0576`, `63e5ddb`, `bca290b` → merge `e84aa8a` | PR #54, merged 2026-07-18; complexity 20 → 7; suite 358 → 362 |
+| 2 — _process_contracts | 🚧 PR open | `455f586`, `6bd9f63`, `8962daf` | branch `claude/c901-process-contracts`; complexity 18 → 7; suite 362 → 365; `Review — data-integrity`, Sam merges |
 | 3 — run_aggregation | ⬜ Not started | — | blocked by Phase 2 (same file) |
 | 4 — _get_esi_object + shared retry helper | ⬜ Not started | — | introduces `_get_with_transient_retry` |
 | 5 — get_esi_data_with_etag_caching | ⬜ Not started | — | blocked by Phase 4 (uses its helper); write its missing tests FIRST |
@@ -108,6 +110,17 @@ statement was moved verbatim and the loose annotation kept. No caller performs l
 operations. `_fetch_page_joined`'s annotation is honest — its position-restoration step builds a real
 `list` — so this applies to the simple path only.
 
+**Phase 2 — one test added beyond the plan's task spec (`8962daf`).** Task 2.2 converted
+`id_to_name_map` from a closure-captured local into an explicit parameter of the new module-level
+`_build_contract_rows(contracts, id_to_name_map)`. That created a call-site wiring seam the plan did
+not anticipate and no test covered: mutating the call site to pass `{}` left the ENTIRE suite green,
+so name denormalization could break silently. Phase 1's review found the same defect class (and the
+plan-review notes flag "orchestration wiring tests" as recurring), so it was closed rather than
+deferred: one test pins all three denormalized columns (`start_location_name`, `issuer_name`,
+`issuer_corporation_name`) through the full build-and-upsert path, mutation-verified to go red when
+the map is emptied. Note the adversarial review round REFUTED this finding as a pre-existing coverage
+gap; that is half right — the gap predates the diff, but the wiring error it now permits does not.
+
 ### Discoveries
 
 **Concurrent pytest runs clobber the shared test database.** `pdm run pytest` drops and recreates the
@@ -116,6 +129,20 @@ rollback. Two agents running the suite simultaneously produce spurious `Integrit
 failures that look like real test defects. Reviewers doing mutation testing must serialize, or point
 their own `DATABASE_URL_TESTS` at a scratch database. This bit the Phase 1 review round (2026-07-18)
 and cost one reviewer several confusing runs before it was diagnosed.
+
+**Contracts stranded at `PENDING_ITEMS` are never re-driven (Phase 2, latent design gap).** When a
+contract's item fetch raises, `_fetch_item_rows` isolates the failure and omits that contract from
+`processed_contract_ids`, so it is marked neither COMPLETED nor ENRICHMENT_INCOMPLETE and keeps the
+model default `PENDING_ITEMS` (`models/contracts.py`). Nothing in the codebase selects on
+`PENDING_ITEMS` to retry those contracts, so a transient ESI item-fetch failure leaves a contract
+un-enriched until its next full re-ingest happens to succeed. This is CURRENT behavior and is locked
+by `test_item_fetch_failure_for_one_contract_does_not_abort_batch`; recorded here, not fixed
+(ground rule 4). Worth a decision on whether a retry sweep is wanted.
+
+**Backend tests are excluded from flake8.** `app/backend/.flake8` line 24 carries
+`exclude = .venv,.git,__pycache__,docs,migrations,*/tests/*,src/alembic`,
+so `pdm run lint` does NOT cover test code. Style in test files is convention-enforced only; do not
+assume a green lint says anything about new tests.
 
 **`_apply_contract_filters` measures exactly 10 — at the C901 limit.** The plan's contingency
 (`_apply_location_filters`) was correctly NOT applied, since the plan says do not preemptively split
@@ -144,7 +171,7 @@ Whoever adds it should apply the documented contingency at that time.
 
 ## Phase 1 — `get_contracts` (complexity 20 → ≤ 10)
 
-**Execution Status:** 🚧 PR OPEN — branch `claude/c901-get-contracts`, claimed 2026-07-18T22:21Z.
+**Execution Status:** ✅ MERGED 2026-07-18 — PR #54, merge commit `e84aa8a`, branch `claude/c901-get-contracts`.
 Commits `69b0112` (characterization tests), `3d4e61e` (extraction), `1ca0aa0` (mutation-sensitivity fix
 for the tiebreaker fixture — see Deviations). Gates: red gate observed
 (`C901 'get_contracts' is too complex (20)`); after extraction `pdm run lint` exit 0,
@@ -283,7 +310,14 @@ async def _fetch_page_simple(db: AsyncSession, query, filters, sort_column, desc
 
 ## Phase 2 — `_process_contracts` (complexity 18 → ≤ 10)
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 PR OPEN — branch `claude/c901-process-contracts`, claimed 2026-07-18T23:25Z off
+`origin/dev` at `e84aa8a`. Commits `455f586` (characterization tests), `6bd9f63` (extraction),
+`8962daf` (name-denormalization wiring test — see Deviations). Gates: red gate observed
+(`C901 'ContractAggregationService._process_contracts' is too complex (18)`); after extraction
+`pdm run lint` exit 0, `_process_contracts` no longer flagged by `--select=C901`, complexity 18 → 7
+(`_fetch_item_rows` 6, `_update_item_processing_status` 4, `_collect_resolvable_ids` 2,
+`_parse_esi_datetime` 2, `_build_contract_rows` 1); full suite 362 → 365 passed. `run_aggregation`
+keeps its own noqa for Phase 3, untouched. Classification `Review — data-integrity` — Sam merges.
 
 **Files:**
 - Modify: `app/backend/src/fastapi_app/services/background_aggregation.py`


### PR DESCRIPTION
Phase 2 of the [C901 complexity-refactor plan](docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md): pays down the `# noqa: C901` on `_process_contracts`, the ESI contract ingestion stage, with zero behavior change proven by characterization tests written before the extraction.

## Merge classification

`Review — data-integrity (ingestion pipeline refactor)`

Per plan ground rule 9. This modifies contract ingestion, database writes, and `item_processing_status` updates — a Domain trigger regardless of the refactor's intent to preserve behavior. **Sam merges; the agent does not self-merge.**

## What changed

| Commit | Change |
|---|---|
| `455f586` | Characterization tests: per-contract item-fetch failure isolation, and structure-ID filtering at both sides of the boundary |
| `6bd9f63` | Extraction of five helpers; `# noqa: C901` removed |
| `8962daf` | Wiring test pinning name denormalization (see Deviations) |
| `656a383` | Plan banners, deviations, discoveries |
| `bca8d00` | Made the structure-ID row assertion mutation-sensitive (codex finding) |

`_process_contracts` now delegates to `_collect_resolvable_ids`, `_build_contract_rows`, `_parse_esi_datetime` (module-level pure functions) and `_fetch_item_rows`, `_update_item_processing_status` (methods).

## Gates

- **Red gate observed before extraction:** `C901 'ContractAggregationService._process_contracts' is too complex (18)`
- **After:** `pdm run lint` exit 0; `_process_contracts` no longer flagged by `--select=C901`
- **Complexity:** 18 → **7** (`_fetch_item_rows` 6, `_update_item_processing_status` 4, `_collect_resolvable_ids` 2, `_parse_esi_datetime` 2, `_build_contract_rows` 1)
- **Suite:** 362 → **365 passed**
- `run_aggregation` keeps its own `# noqa: C901` for Phase 3 — untouched by this diff

## Behavior changes

**None.** The plan authorizes exactly two behavior changes across all five phases; both are in later phases. Preserved verbatim: statement order, all log strings, exception types, the `ESINotModifiedError` vs generic `Exception` handler ordering, `processed_contract_ids` membership semantics, the status set-subtraction, the structure-ID cut (`id < 100_000_000_000`), and both batch-size constants (contracts 500, items 50).

## Deviations from the plan

**One test added beyond the task spec (`8962daf`).** Task 2.2 converted `id_to_name_map` from a closure-captured local into an explicit parameter of the new module-level `_build_contract_rows`. That created a call-site wiring seam the plan didn't anticipate and nothing covered — mutating the call site to pass `{}` left the entire suite green, so name denormalization could break silently. Closed with a test pinning all three denormalized columns through the build-and-upsert path, mutation-verified.

Worth noting: the adversarial review round *refuted* this finding as a pre-existing coverage gap. That's half right — the gap predates the diff, but the wiring error it now permits does not. Overriding the refutation was a judgment call.

**One assertion strengthened after codex review (`bca8d00`).** The structure-ID test's persisted-row assertion checked `start_location_name` for the *resolvable* boundary ID, which the static stub map never named anyway — so it read `None` whether or not filtering worked. The excluded ID now sits in `start_location_id` and the stub names whatever IDs reach it, making a NULL name proof of filtering. Verified in isolation: widening the cut to `<=` now fails that assertion on its own.

## Verification approach

Every characterization test was mutation-verified — each one was proven to go red when the behavior it names is deliberately broken, then the mutation reverted (production diff empty). Mutations exercised: re-raising instead of isolating per-contract item-fetch failures; widening the structure-ID cut `<` → `<=`; emptying the name map at the call site.

## Review

Three lenses (behavior preservation, test quality, complexity/API surface) across two rounds, each finding adversarially refuted by three independent verifiers with a 2-of-3 kill rule: 6 candidates, 0 confirmed. Cross-model `/codex review` at high effort: **no P1 findings**, one P2 (addressed in `bca8d00`). Codex independently confirmed statement order, logs, exception ordering, processed-ID semantics, status set subtraction, the structure boundary, and the 500/50 batch sizes, and that `run_aggregation` is byte-equivalent within its function boundary.

## Discoveries (recorded in the plan, not fixed here)

- **Contracts stranded at `PENDING_ITEMS` are never re-driven.** When a contract's item fetch raises, it's omitted from `processed_contract_ids` and so marked neither COMPLETED nor ENRICHMENT_INCOMPLETE, keeping the model default. Nothing selects on `PENDING_ITEMS` to retry, so a transient ESI failure leaves a contract un-enriched until a later full re-ingest happens to succeed. This is current behavior and is now locked by test; **worth a decision on whether a retry sweep is wanted.**
- **Backend tests are excluded from flake8** (`app/backend/.flake8` line 24, `*/tests/*`), so `pdm run lint` says nothing about test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
