### PR TITLE
test(api): retract the PENDING_ITEMS stranding claim and pin recovery

### DIFF
--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -460,3 +460,51 @@ async def test_resolved_location_names_land_on_persisted_contract_rows(db_sessio
     assert row.start_location_name == "Jita IV - Moon 4 - Caldari Navy Assembly Plant"
     assert row.issuer_name == "Test Issuer"
     assert row.issuer_corporation_name == "Test Issuer Corp"
+
+
+async def test_failed_item_fetch_recovers_on_the_next_run(db_session: AsyncSession):
+    """A contract whose item fetch failed is retried by the NEXT run, with no sweep.
+
+    `_fetch_item_rows` gates only on contract type, never on item_processing_status,
+    so every run re-fetches items for every item_exchange/auction contract in the
+    batch. A contract left at PENDING_ITEMS by a transient ESI failure therefore
+    recovers on the following run without any retry machinery. Adding a status gate
+    as an "optimization" would strand those contracts permanently — this test is what
+    catches that.
+    """
+    service = _make_service()
+    service.esi_client.get_universe_type = AsyncMock(
+        return_value={"name": "Rifter", "group_id": 25, "market_group_id": 64}
+    )
+    service.esi_client.get_universe_group = AsyncMock(
+        return_value={"name": "Frigate", "category_id": 6}
+    )
+    contract = dict(_ship_contract_dict(910005))
+
+    # Run 1: the item fetch fails, so the contract is left at the model default.
+    service.esi_client.get_contract_items = AsyncMock(
+        side_effect=RuntimeError("simulated ESI items failure")
+    )
+    await service._process_contracts(db_session, [contract])
+
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 910005)
+        )
+    ).scalar_one()
+    assert row.item_processing_status == "PENDING_ITEMS"
+
+    # Run 2: ESI recovers. The same contract is re-fetched with no intervention.
+    service.esi_client.get_contract_items = AsyncMock(
+        return_value=[{"record_id": 31, "type_id": 587, "quantity": 1, "is_included": True}]
+    )
+    await service._process_contracts(db_session, [contract])
+
+    await db_session.refresh(row)
+    assert row.item_processing_status == "COMPLETED"
+    item_rows = (
+        await db_session.execute(
+            select(ContractItem).where(ContractItem.contract_id == 910005)
+        )
+    ).scalars().all()
+    assert len(item_rows) == 1

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -130,14 +130,35 @@ failures that look like real test defects. Reviewers doing mutation testing must
 their own `DATABASE_URL_TESTS` at a scratch database. This bit the Phase 1 review round (2026-07-18)
 and cost one reviewer several confusing runs before it was diagnosed.
 
-**Contracts stranded at `PENDING_ITEMS` are never re-driven (Phase 2, latent design gap).** When a
-contract's item fetch raises, `_fetch_item_rows` isolates the failure and omits that contract from
-`processed_contract_ids`, so it is marked neither COMPLETED nor ENRICHMENT_INCOMPLETE and keeps the
-model default `PENDING_ITEMS` (`models/contracts.py`). Nothing in the codebase selects on
-`PENDING_ITEMS` to retry those contracts, so a transient ESI item-fetch failure leaves a contract
-un-enriched until its next full re-ingest happens to succeed. This is CURRENT behavior and is locked
-by `test_item_fetch_failure_for_one_contract_does_not_abort_batch`; recorded here, not fixed
-(ground rule 4). Worth a decision on whether a retry sweep is wanted.
+**CORRECTED — contracts at `PENDING_ITEMS` recover on their own; no retry sweep is needed.** An
+earlier revision of this entry (and PR #57's body) claimed a transient item-fetch failure strands a
+contract "until its next full re-ingest happens to succeed", and asked whether a retry sweep was
+wanted. **That claim was wrong and is retracted.** Verified 2026-07-18 by reading the loop and then
+proving it empirically:
+
+- `_fetch_item_rows` gates ONLY on `contract["type"] not in ["item_exchange", "auction"]`. There is no
+  status gate. Every run re-fetches items for every eligible contract in the batch, so a contract left
+  at `PENDING_ITEMS` is retried by the very next aggregation run with no machinery at all.
+- `test_failed_item_fetch_recovers_on_the_next_run` pins this: run 1 fails the fetch (status stays
+  `PENDING_ITEMS`), run 2 succeeds (status becomes `COMPLETED`, items land). Mutation-verified — adding
+  a plausible once-per-contract skip strands the contract and turns the test red.
+
+**Decision: no retry sweep.** It would be machinery for a problem that does not exist, and it would key
+off a column that currently signals nothing to anyone (see the next entry).
+
+**`item_processing_status` is a write-only column.** Nothing reads it — not the API layer, not the
+frontend, not any query, not any retry logic. `grep` over `src/` outside tests finds only the model
+definition (`models/contracts.py:65`, which also carries `index=True`) and the three write sites in
+`background_aggregation.py`. So the column, and the index backing it, currently cost writes and space
+while informing no consumer. Not deleted here (out of scope, and it is plausibly intended for future
+ops/observability) — but if no reader is planned, the column and its index are dead weight.
+
+**`ESINotModifiedError` handlers are unreachable.** The exception is defined
+(`core/exceptions.py:19`), imported, and caught in TWO places (`background_aggregation.py:239` and
+`:373`) — but it is **raised nowhere in the codebase**. `get_esi_data_with_etag_caching` serves a 304
+from cache rather than raising. Both `except ESINotModifiedError:` arms are therefore dead code, and
+the `logger.info("Items for contract ... not modified.")` line can never fire. Relevant to Phase 5,
+whose 304 characterization tests will confirm the serve-from-cache path. Recorded, not removed.
 
 **Backend tests are excluded from flake8.** `app/backend/.flake8` line 24 carries
 `exclude = .venv,.git,__pycache__,docs,migrations,*/tests/*,src/alembic`,


### PR DESCRIPTION
Follow-up to [#57](https://github.com/scarson/hangar-bay/pull/57), which asked whether a retry sweep was wanted for contracts left at `PENDING_ITEMS`.

## Answer: no sweep. The premise was wrong.

PR #57's body and the plan's Discoveries claimed a transient item-fetch failure strands a contract "until its next full re-ingest happens to succeed", with nothing re-driving it. **That claim was mine, it was wrong, and this PR retracts it.**

`_fetch_item_rows` gates only on `contract["type"] not in ["item_exchange", "auction"]`. There is **no status gate**. Every aggregation run re-fetches items for every eligible contract in the batch, so a contract left at `PENDING_ITEMS` by a transient failure is retried by the very next run, with no machinery at all.

Verified empirically, not just by reading: `test_failed_item_fetch_recovers_on_the_next_run` drives run 1 with a failing fetch (status stays `PENDING_ITEMS`), then run 2 with a working one (status becomes `COMPLETED`, items land).

A retry sweep would have been machinery for a problem that does not exist — and worse, it would key off a column that signals nothing to anyone (below).

## What this PR adds

**A regression guard.** The test isn't just documentation — it defends the property my decision rests on. Mutation-verified: adding a plausible "don't re-fetch contracts we've already attempted" optimization strands the contract at `PENDING_ITEMS` and turns the test red. That's precisely the change that would silently convert today's self-healing behavior into permanent stranding.

**Two corrected/added findings in the plan's Discoveries:**

- **`item_processing_status` is write-only.** Nothing reads it — not the API, not the frontend, not any query, not any retry logic. `grep` over `src/` outside tests finds only the model definition (`models/contracts.py:65`, which carries `index=True`) and three write sites. The column and its backing index currently cost writes and space while informing no consumer. Not touched here — plausibly intended for future ops/observability — but if no reader is planned it's dead weight worth removing.
- **`ESINotModifiedError` handlers are unreachable.** It's defined, imported, and caught in two places (`background_aggregation.py:239`, `:373`), but **raised nowhere in the codebase** — `get_esi_data_with_etag_caching` serves a 304 from cache rather than raising. Both `except` arms are dead, and the `"Items for contract ... not modified."` log can never fire. Relevant to Phase 5, whose 304 characterization tests will confirm the serve-from-cache path. Recorded, not removed.

## Merge classification

`Routine — auto-merge on green CI`

No production code changes: one test added, plan documentation corrected. `git diff` touches only the test file and the plan.

Holding merge for your call anyway, since it corrects a claim you acted on — say the word and I'll merge on green, or merge it yourself.

## Gates

- `pdm run pytest` → **367 passed** (365 + this test + Phase 2's, on current `dev`)
- `pdm run lint` → exit 0
- Production source diff: empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)