### PR TITLE
refactor(api): extract a shared ESI transient-retry helper to clear _get_esi_object C901

### DIFF
--- a/app/backend/src/fastapi_app/core/esi_client_class.py
+++ b/app/backend/src/fastapi_app/core/esi_client_class.py
@@ -189,7 +189,47 @@ class ESIClient:
         path = f"/v1/contracts/public/items/{contract_id}/"
         return await self.get_esi_data_with_etag_caching(path)
 
-    async def _get_esi_object(self, path: str, cache_seconds: int = 86_400) -> dict[str, Any]:  # noqa: C901
+    async def _get_with_transient_retry(
+        self, path: str, headers: Optional[Dict[str, str]] = None
+    ) -> httpx.Response:
+        """GET with bounded retry on transient failures (5xx + network errors).
+
+        4xx responses return normally — callers decide what non-5xx statuses mean.
+        Exhausted retries surface as ESIRequestFailedError (status carried when the
+        failure was HTTP, absent for pure network errors).
+        """
+        max_retries = 3
+        backoff_factor = 0.5  # seconds
+        response = None
+        last_exception = None
+        for attempt in range(max_retries):
+            try:
+                response = await self.http_client.get(path, headers=headers)
+                if response.status_code < 500:
+                    last_exception = None
+                    break
+                last_exception = httpx.HTTPStatusError(
+                    f"Server error '{response.status_code}'", request=response.request, response=response
+                )
+                logger.warning(
+                    f"ESI request to {path} failed with status {response.status_code}. "
+                    f"Attempt {attempt + 1}/{max_retries}."
+                )
+            except (httpx.ReadTimeout, httpx.ConnectError) as e:
+                last_exception = e
+                logger.warning(f"Network error for {path} on attempt {attempt + 1}/{max_retries}: {e}")
+            if attempt < max_retries - 1:
+                await asyncio.sleep(backoff_factor * (2 ** attempt))
+
+        if last_exception is not None:
+            if isinstance(last_exception, httpx.HTTPStatusError):
+                raise ESIRequestFailedError(
+                    status_code=last_exception.response.status_code, message=str(last_exception)
+                )
+            raise ESIRequestFailedError(message=f"Network error for {path}: {last_exception}")
+        return response
+
+    async def _get_esi_object(self, path: str, cache_seconds: int = 86_400) -> dict[str, Any]:
         """GET a single-OBJECT ESI endpoint with a plain Valkey TTL cache.
 
         The paginated ETag helper is list-shaped: `full_data.extend(page)`
@@ -206,39 +246,10 @@ class ESIClient:
         except Exception as e:
             logger.warning(f"Object cache read failed for {path}: {e}")
 
-        # Bounded retry/backoff mirroring get_esi_data_with_etag_caching: retry
-        # only transient failures (5xx + network errors) so a blip on
+        # Transient failures (5xx + network) are retried so a blip on
         # /universe/types|groups doesn't silently un-enrich a run's ship contracts.
         # 4xx (e.g. 404) still falls straight through to raise_for_status below.
-        max_retries = 3
-        backoff_factor = 0.5  # seconds
-        response = None
-        last_exception = None
-        for attempt in range(max_retries):
-            try:
-                response = await self.http_client.get(path)
-                if response.status_code < 500:
-                    last_exception = None
-                    break
-                last_exception = httpx.HTTPStatusError(
-                    f"Server error '{response.status_code}'", request=response.request, response=response
-                )
-                logger.warning(
-                    f"ESI object request to {path} failed with status {response.status_code}. "
-                    f"Attempt {attempt + 1}/{max_retries}."
-                )
-            except (httpx.ReadTimeout, httpx.ConnectError) as e:
-                last_exception = e
-                logger.warning(f"Network error for {path} on attempt {attempt + 1}/{max_retries}: {e}")
-            if attempt < max_retries - 1:
-                await asyncio.sleep(backoff_factor * (2 ** attempt))
-
-        if last_exception is not None:
-            if isinstance(last_exception, httpx.HTTPStatusError):
-                raise ESIRequestFailedError(
-                    status_code=last_exception.response.status_code, message=str(last_exception)
-                )
-            raise ESIRequestFailedError(message=f"Network error for {path}: {last_exception}")
+        response = await self._get_with_transient_retry(path)
 
         response.raise_for_status()
         # A malformed 2xx body (e.g. an upstream HTML error page) must not escape as a raw

--- a/app/backend/src/fastapi_app/tests/core/test_esi_client.py
+++ b/app/backend/src/fastapi_app/tests/core/test_esi_client.py
@@ -123,3 +123,29 @@ async def test_get_esi_object_raises_after_exhausting_retries():
             await client.get_universe_type(587)
 
     assert get_mock.await_count == 3
+
+
+async def test_get_esi_object_survives_cache_read_failure(caplog):
+    """An unreachable cache degrades to a live fetch instead of failing the call."""
+    client = _client_with_response(TYPE_PAYLOAD)
+    client.redis_client.get = AsyncMock(side_effect=RuntimeError("valkey down"))
+
+    with caplog.at_level("WARNING"):
+        result = await client.get_universe_type(587)
+
+    assert result["name"] == "Tristan"
+    client.http_client.get.assert_awaited_once()
+    assert "Object cache read failed for /v3/universe/types/587/: valkey down" in caplog.text
+
+
+async def test_get_esi_object_survives_cache_write_failure(caplog):
+    """A cache write that blows up must not lose the object already fetched."""
+    client = _client_with_response(TYPE_PAYLOAD)
+    client.redis_client.set = AsyncMock(side_effect=RuntimeError("valkey down"))
+
+    with caplog.at_level("WARNING"):
+        result = await client.get_universe_type(587)
+
+    assert result["name"] == "Tristan"
+    client.redis_client.set.assert_awaited_once()
+    assert "Object cache write failed for /v3/universe/types/587/: valkey down" in caplog.text

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -71,7 +71,7 @@ notes and commit messages.
 | 1 — get_contracts | ✅ Merged | `69b0112`, `3d4e61e`, `1ca0aa0`, `7ae0576`, `63e5ddb`, `bca290b` → merge `e84aa8a` | PR #54, merged 2026-07-18; complexity 20 → 7; suite 358 → 362 |
 | 2 — _process_contracts | 🚧 PR #57 open | `455f586`, `6bd9f63`, `8962daf`, `656a383`, `bca8d00` | branch `claude/c901-process-contracts`; complexity 18 → 7; suite 362 → 365; `Review — data-integrity`, **Sam merges** |
 | 3 — run_aggregation | ⬜ Not started | — | blocked by Phase 2 (same file) |
-| 4 — _get_esi_object + shared retry helper | ⬜ Not started | — | introduces `_get_with_transient_retry` |
+| 4 — _get_esi_object + shared retry helper | 🚧 PR open | `4c4e158`, `402658a` | branch `claude/c901-esi-object`; complexity 16 → 9; introduces `_get_with_transient_retry` (8); `Review — data-integrity`, **Sam merges** |
 | 5 — get_esi_data_with_etag_caching | ⬜ Not started | — | blocked by Phase 4 (uses its helper); write its missing tests FIRST |
 
 ### Deviations
@@ -602,7 +602,14 @@ async def test_run_aggregation_orchestrates_fetch_limit_process_commit(monkeypat
 
 ## Phase 4 — `_get_esi_object` (complexity 16 → ≤ 10) + shared transient-retry helper
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 PR OPEN — branch `claude/c901-esi-object`, claimed 2026-07-18, rebased onto
+`origin/dev` at `c271f19`. Commits `4c4e158` (cache-failure characterization tests), `402658a`
+(shared helper + rewire). Gates: red gate observed (`C901 'ESIClient._get_esi_object' is too complex
+(16)`); after extraction `pdm run lint` exit 0, `--select=C901` clean, `_get_esi_object` 16 → 9, new
+`_get_with_transient_retry` 8; full suite 368 passed. `get_esi_data_with_etag_caching` verified
+**byte-identical** (method bodies extracted from both revisions and hash-compared — identical
+SHA-256, 4567 bytes) with its `# noqa: C901` intact, so Phase 5's characterization gate is
+unaffected. Classification `Review — data-integrity` — Sam merges.
 
 **Files:**
 - Modify: `app/backend/src/fastapi_app/core/esi_client_class.py`


### PR DESCRIPTION
Phase 4 of the [C901 complexity-refactor plan](docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md). Introduces the shared transient-retry helper and rewires **only** `_get_esi_object` onto it.

## Merge classification

`Review — data-integrity (ingestion pipeline refactor)`

Per plan ground rule 9 — this is the ESI transport feeding contract ingestion. **Sam merges; the agent does not self-merge.**

## What changed

| Commit | Change |
|---|---|
| `4c4e158` | Characterization tests for the two untested cache-degradation paths (read failure, write failure) |
| `402658a` | New `_get_with_transient_retry`; `_get_esi_object` rewired onto it; `# noqa: C901` removed |
| plan commit | Banners + byte-identity proof |

## Gates

- **Red gate observed before extraction:** `C901 'ESIClient._get_esi_object' is too complex (16)`
- **After:** `pdm run lint` exit 0; `--select=C901` clean
- **Complexity:** `_get_esi_object` **16 → 9**; new `_get_with_transient_retry` **8**
- **Suite:** **368 passed**

## The one authorized behavior change

Object-endpoint retry warnings now read `"ESI request to {path} failed with status ..."` instead of `"ESI object request to {path} failed with status ..."`.

Log text only. This is the delta the plan explicitly authorizes for this phase (ground rule 4) — deliberately *not* parameterized to preserve both strings, since that would be complexity for a log prefix. No test pinned the old string and no caller depends on it.

## `get_esi_data_with_etag_caching` is untouched — proven, not asserted

Phase 5's characterization-before-refactor gate depends on this method being byte-identical, so it was verified mechanically rather than by eyeballing the diff: the method body was extracted from the `e84aa8a` blob and from the committed file and hash-compared — **identical SHA-256, 4567 bytes both**. Its own `# noqa: C901` is intact. The helper was also placed *after* `get_contract_items` rather than above the ETag method, so even the ETag method's line numbers are unchanged.

## One open decision for the merger — codex raised a P1 I'm declining

Codex flagged that `_get_esi_object` now reaches `http_client.get(path, headers=None)` via the helper, where it previously called `http_client.get(path)` with no kwarg, and recommended omitting the kwarg when `headers is None`.

**Why I'm not applying it:**

1. **Zero production impact.** I verified `httpx.AsyncClient.get`'s `headers` parameter defaults to `None`, so the two calls are identical to real httpx. Production builds `ESIClient(settings=settings)` (`main.py:55`) with no injected client — it uses the managed real httpx client. The difference is observable only by mocks, and no current test observes it (existing assertions use `assert_awaited_once()` / `await_count`, without argument matching).
2. **The plan specifies this call shape.** Its normative helper code is literally `await self.http_client.get(path, headers=headers)`. Applying the remedy would be a deviation *from* the plan, not compliance with it.
3. **The remedy costs a branch** in a shared helper (8 → 9) purely for mock ergonomics.

The counter-argument, stated fairly: it *is* an observable difference at the injected-client seam that isn't the authorized delta, and a future test written as `assert_awaited_once_with(path)` would fail confusingly. If you'd rather have strict call-shape parity, say so and I'll add the conditional — it's a two-line change.

## Verification approach

Both new tests were mutation-verified, plus a third mutation the plan didn't ask for:

- Removing the cache-**read** `try/except` → read-failure test goes red (write test stays green)
- Removing the cache-**write** `try/except` → write-failure test goes red (read test stays green)
- Replacing both `logger.warning(...)` calls with `pass` → **both** tests go red on their `caplog` assertions

That third mutation is the one that proves the log assertions carry weight rather than being decorative — without it, each test could have been going red purely on the escaping exception.

The clean split in the first two also confirms the tests target independent branches rather than overlapping.

## Preservation note

The `json.loads(cached)` decode remains **inside** the cache-read `try/except`, preserving silent degradation to a live fetch on a corrupt cached value. Flagged because no test pins the corrupt-payload case (only the `get`-raises case), so moving that decode out would have been an undetected behavior change.

A comment clause above the old loop said the retry "mirrors" the ETag method; that clause became false (it now *shares*) and was dropped. The domain rationale it carried — why transient failures are retried on `/universe/types|groups` — was kept.

## Review

Three lenses × two rounds with 3-way adversarial refutation (6 candidates, 0 confirmed) plus cross-model `/codex review` at high effort. Codex independently confirmed the retry semantics (attempts, 5xx/network-only retry, backoff, final-attempt skip, 4xx passthrough, `last_exception` reset, status-carrying vs network error construction), the ETag method's byte-identity, the decode placement, and that both new tests are non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)