### PR TITLE
ci: gate backend, frontend, and openapi-drift jobs on changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ on:
   # which the default activity types don't run on).
   pull_request:
 
-# Nothing here uses the token — pin it to read-only.
+# Read-only: the only token use is listing a PR's changed files in `changes`.
 permissions:
   contents: read
+  pull-requests: read
 
 # Rapid pushes to the same ref (stacked-PR rebases) supersede in-flight runs.
 concurrency:
@@ -23,7 +24,83 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    # Which lanes does this PR actually need? This gates the JOBS rather than the
+    # workflow, because a `paths-ignore` filter makes the checks vanish entirely —
+    # indistinguishable from "CI never ran", which docs/git-strategy.md §Merge
+    # authority instructs agents to treat as a failure. A job skipped by `if:`
+    # reports as skipped with a visible reason, and still satisfies a required
+    # status check if one is ever configured.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      backend: ${{ steps.classify.outputs.backend }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+    steps:
+      - name: Classify changed paths
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          run_everything() {
+            echo 'backend=true'  >> "$GITHUB_OUTPUT"
+            echo 'frontend=true' >> "$GITHUB_OUTPUT"
+          }
+
+          # Only pull_request narrows the lanes. Pushes to dev/main run everything:
+          # CI's success on main is what fires deploy.yml's workflow_run chain, so a
+          # narrowed push would strand production's reported commit behind main.
+          if [ "$EVENT_NAME" != 'pull_request' ]; then
+            echo "event=$EVENT_NAME — running every lane"
+            run_everything; exit 0
+          fi
+
+          # A failed or empty file list must never silently skip a lane.
+          if ! files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename'); then
+            echo '::warning::could not list the PR files — running every lane'
+            run_everything; exit 0
+          fi
+          if [ -z "$files" ]; then
+            echo '::warning::PR reports no changed files — running every lane'
+            run_everything; exit 0
+          fi
+
+          echo "changed files:"; printf '  %s\n' $files
+
+          backend=false
+          frontend=false
+          while IFS= read -r f; do
+            # `case` globs match `/`, so a trailing `*` covers a whole subtree.
+            case "$f" in
+              # Prose and agent/editor tooling — no build or test consumes these.
+              docs/*|design/*|plans/*|.claude/*|.windsurf/*|.beads/*|LICENSE) : ;;
+              app/backend/*)      backend=true ;;
+              app/frontend/web/*) frontend=true ;;
+              *.md)
+                # Root-level markdown is prose. Markdown nested anywhere else is
+                # unclassified and falls through to the conservative default —
+                # app/backend/pyproject.toml declares readme = "README.md", so a PR
+                # deleting that file breaks `pdm install` and must still run CI.
+                case "$f" in */*) backend=true; frontend=true ;; esac
+                ;;
+              # Anything unrecognized (root config, .github/*, render.yaml, or a new
+              # top-level directory) is assumed to matter. New paths fail safe into
+              # full CI rather than silently skipping it.
+              *) backend=true; frontend=true ;;
+            esac
+          done <<< "$files"
+
+          echo "backend=$backend"   | tee -a "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" | tee -a "$GITHUB_OUTPUT"
+
   backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -80,6 +157,8 @@ jobs:
         run: pdm run pytest
 
   frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -128,6 +207,10 @@ jobs:
   openapi-drift:
     # The committed openapi.json / schema.d.ts must match what the backend exports —
     # neither existing job runs the export chain, so drift was previously invisible.
+    # Straddles both lanes: the backend produces the schema, the frontend holds the
+    # committed copies and the generator that renders them.
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/git-strategy.md
+++ b/docs/git-strategy.md
@@ -358,7 +358,7 @@ If none of the above apply → `Routine`, auto-merge on green CI. When genuinely
 
 Requirements for a Routine PR to auto-merge:
 
-- Green CI. Skipped checks must be verifiably not-applicable to the changed files (e.g. a frontend check skipped because only backend files changed). Unexplained skips count as failures — investigate per §Handling CI failures; don't classify up as an escape hatch.
+- Green CI. Skipped checks must be verifiably not-applicable to the changed files (e.g. a frontend check skipped because only backend files changed). CI's `changes` job is what makes this verifiable: it classifies every path in the PR and gates the `backend`, `frontend`, and `openapi-drift` jobs on the result, printing the changed-file list and the resulting `backend=` / `frontend=` decision. A skipped lane is legitimate exactly when that log accounts for it — read the log, don't assume. Unexplained skips count as failures — investigate per §Handling CI failures; don't classify up as an escape hatch.
 - PR title + body accurately describe what was done; scope matches the original ask.
 - No dependency on a still-open `Review`-class PR. "Dependency" means: the PR imports, calls, or otherwise depends on code or types introduced by the open PR; the PRs modify overlapping files in ways that would conflict; or the PRs were authored to ship together as one logical change.
 


### PR DESCRIPTION
A `changes` job classifies every path in a pull request and gates the three lanes on the result. A docs-only PR now runs no build jobs; a backend-only PR skips the ~20-minute Playwright lane.

## Why gate the jobs, not the workflow

`paths-ignore` on the trigger makes the checks *vanish*, which is indistinguishable from "CI never ran" — a state `docs/git-strategy.md` §Merge authority instructs agents to treat as a failure. A job skipped by `if:` reports as skipped, with the `changes` job log explaining why, and still satisfies a required status check if one is ever configured. (Today there is none: the `main-branch-protections` ruleset requires a PR with 0 approvals plus deletion / non-fast-forward protection, and no `required_status_checks` rule.)

## Classification

| Changed path | backend | frontend |
|---|---|---|
| `docs/`, `design/`, `plans/`, `.claude/`, `.windsurf/`, `.beads/`, `LICENSE`, root `*.md` | — | — |
| `app/backend/**` | yes | — |
| `app/frontend/web/**` | — | yes |
| anything else (root config, `.github/**`, `render.yaml`, a new top-level dir) | yes | yes |

`openapi-drift` runs when either lane is dirty — the backend produces the schema, the frontend holds the committed copies and the generator.

Two deliberate choices:

- **Fail-safe default.** An unrecognized path marks both lanes dirty, so a new top-level directory runs full CI rather than silently skipping it.
- **`**/*.md` is not blanket-ignored.** Only root-level markdown is. `app/backend/pyproject.toml:10` declares `readme = "README.md"`, so a PR deleting that file breaks `pdm install` and must still run CI.

Only `pull_request` narrows the lanes. Pushes to `dev`/`main` run everything, because CI's success on `main` is what fires `deploy.yml`'s `workflow_run` chain — a narrowed push would strand production's reported commit behind `main`.

Uses `gh api .../pulls/N/files` rather than `dorny/paths-filter`: the repo currently runs only `actions/*` and `pdm-project/setup-pdm`, and this didn't seem worth new third-party supply-chain surface in CI. That needs `pull-requests: read`, added alongside the existing `contents: read`.

## Verification

The classifier's `run:` block was extracted programmatically from the workflow (byte-identical to what ships, asserted in the harness) and executed against a stubbed `gh`. 16 cases pass: docs-only, root markdown, agent tooling, backend-only, frontend-only, mixed, `app/backend/README.md`, `ci.yml` itself, `render.yaml`, a new top-level dir, nested non-app markdown, push events, `gh` API failure, and an empty file list.

Mutation-tested rather than assumed — two of my first three mutations were no-ops from a wrong `sed` indent and would have let me claim false confidence. Corrected results:

- Deleting the catch-all `*)` flips `infra/…`, `render.yaml`, and `ci.yml` from `bf` to `..` — the fail-safe is load-bearing.
- Making `push` take the pull_request path flips a docs-only push to `..` — the event guard is load-bearing.
- Neutering the `gh`-failure and empty-list guards changes **nothing**; the catch-all already covers both (an empty `<<<` heredoc yields one empty line, which hits `*)`). Removing all three together flips them to `..`, confirming the layering. Those two guards are genuinely redundant — kept because they emit a `::warning::` naming the reason, which the catch-all does not.

This PR touches `.github/workflows/ci.yml`, so it self-tests the run-everything path. It cannot exercise the skip path.

## Merge classification

`Review — architecture`. This changes the merge gate that the auto-merge policy itself rests on, and adds a token permission scope. A false skip is invisible by construction, and this PR's own CI run can only validate the run-everything path, not the skip path. Flagging for your eyes rather than self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
