### PR TITLE
refactor(api): decompose the ESI etag pagination loop to clear the final C901

### DIFF
--- a/app/backend/src/fastapi_app/core/esi_client_class.py
+++ b/app/backend/src/fastapi_app/core/esi_client_class.py
@@ -98,7 +98,9 @@ class ESIClient:
             data_key = f"data:{paginated_path}"
 
             cached_etag = await self.redis_client.get(etag_key)
-            headers = {"If-None-Match": cached_etag.decode() if cached_etag else ""}
+            if isinstance(cached_etag, bytes):
+                cached_etag = cached_etag.decode()
+            headers = {"If-None-Match": cached_etag or ""}
 
             response = None
             last_exception = None

--- a/app/backend/src/fastapi_app/core/esi_client_class.py
+++ b/app/backend/src/fastapi_app/core/esi_client_class.py
@@ -80,7 +80,7 @@ class ESIClient:
         if self._managed_redis_client:
             await self._managed_redis_client.close()
 
-    async def get_esi_data_with_etag_caching(  # noqa: C901
+    async def get_esi_data_with_etag_caching(
         self, path: str, all_pages: bool = False, ignore_404: bool = False
     ) -> List[Dict[str, Any]]:
         """
@@ -89,8 +89,6 @@ class ESIClient:
         """
         full_data = []
         page = 1
-        max_retries = 3
-        backoff_factor = 0.5  # seconds
 
         while True:
             paginated_path = f"{path}?page={page}"
@@ -102,30 +100,7 @@ class ESIClient:
                 cached_etag = cached_etag.decode()
             headers = {"If-None-Match": cached_etag or ""}
 
-            response = None
-            last_exception = None
-
-            for attempt in range(max_retries):
-                try:
-                    response = await self.http_client.get(paginated_path, headers=headers)
-                    if response.status_code < 500:
-                        last_exception = None
-                        break
-                    last_exception = httpx.HTTPStatusError(
-                        f"Server error '{response.status_code}'", request=response.request, response=response
-                    )
-                    logger.warning(f"ESI request to {paginated_path} failed with status {response.status_code}. Attempt {attempt + 1}/{max_retries}.")
-                except (httpx.ReadTimeout, httpx.ConnectError) as e:
-                    last_exception = e
-                    logger.warning(f"Network error for {paginated_path} on attempt {attempt + 1}/{max_retries}: {e}")
-                if attempt < max_retries - 1:
-                    await asyncio.sleep(backoff_factor * (2 ** attempt))
-
-            if last_exception:
-                if isinstance(last_exception, httpx.HTTPStatusError):
-                    raise ESIRequestFailedError(status_code=last_exception.response.status_code, message=str(last_exception))
-                else:
-                    raise ESIRequestFailedError(message=f"Network error for {paginated_path}: {last_exception}")
+            response = await self._get_with_transient_retry(paginated_path, headers=headers)
 
             if response.status_code == 404 and ignore_404:
                 logger.debug(f"Received 404 for {paginated_path}, treating as end of pages.")
@@ -134,13 +109,10 @@ class ESIClient:
                 logger.debug(f"Received 204 for {paginated_path}, treating as end of pages.")
                 break
 
-            page_data = []
             if response.status_code == 304:
                 logger.debug(f"ETag cache hit for {paginated_path}. Serving data from cache.")
-                cached_data = await self.redis_client.get(data_key)
-                if cached_data:
-                    page_data = json.loads(cached_data)
-                    full_data.extend(page_data)
+                page_data = await self._read_etag_cached_page(data_key)
+                full_data.extend(page_data)
             else:
                 response.raise_for_status()
                 # ESI can return 200 OK with an empty body, which is not valid JSON.
@@ -152,34 +124,73 @@ class ESIClient:
 
                 if page_data:
                     full_data.extend(page_data)
-                    new_etag = response.headers.get("ETag")
-                    if new_etag:
-                        expires_header = response.headers.get("Expires")
-                        cache_duration_seconds = 600
-                        if expires_header:
-                            try:
-                                expire_time = parsedate_to_datetime(expires_header).replace(tzinfo=timezone.utc)
-                                current_time = datetime.now(timezone.utc)
-                                if expire_time > current_time:
-                                    cache_duration_seconds = int((expire_time - current_time).total_seconds())
-                            except Exception:
-                                pass
-                        await self.redis_client.set(etag_key, new_etag, ex=cache_duration_seconds)
-                        await self.redis_client.set(data_key, response.content, ex=cache_duration_seconds)
+                    await self._store_page_cache(etag_key, data_key, response)
 
-            if not all_pages:
-                break
-
-            if not page_data:
-                break
-
-            total_pages_header = response.headers.get("X-Pages")
-            if total_pages_header and page >= int(total_pages_header):
+            if self._last_page_reached(response, page, page_data, all_pages):
                 break
 
             page += 1
 
         return full_data
+
+    async def _read_etag_cached_page(self, data_key: str) -> list:
+        """Read a page body previously stored alongside its ETag.
+
+        An absent entry yields an empty page: a 304 whose cached body was evicted
+        does not fall back to a live fetch.
+        """
+        cached_data = await self.redis_client.get(data_key)
+        if not cached_data:
+            return []
+        return json.loads(cached_data)
+
+    def _cache_ttl_seconds(self, response: httpx.Response) -> int:
+        """Seconds to cache a page for, derived from its Expires header.
+
+        An absent, already-elapsed, or unparseable Expires yields 600.
+        """
+        expires_header = response.headers.get("Expires")
+        cache_duration_seconds = 600
+        if expires_header:
+            try:
+                expire_time = parsedate_to_datetime(expires_header).replace(tzinfo=timezone.utc)
+                current_time = datetime.now(timezone.utc)
+                if expire_time > current_time:
+                    cache_duration_seconds = int((expire_time - current_time).total_seconds())
+            except Exception:
+                pass
+        return cache_duration_seconds
+
+    async def _store_page_cache(
+        self, etag_key: str, data_key: str, response: httpx.Response
+    ) -> None:
+        """Store a page's ETag and raw body under a shared TTL.
+
+        A response carrying no ETag is not cached at all — without a validator the
+        stored body could never be revalidated by a later conditional request.
+        """
+        new_etag = response.headers.get("ETag")
+        if not new_etag:
+            return
+        cache_duration_seconds = self._cache_ttl_seconds(response)
+        await self.redis_client.set(etag_key, new_etag, ex=cache_duration_seconds)
+        await self.redis_client.set(data_key, response.content, ex=cache_duration_seconds)
+
+    def _last_page_reached(
+        self, response: httpx.Response, page: int, page_data: list, all_pages: bool
+    ) -> bool:
+        """Whether the pagination walk ends after this page.
+
+        Order is load-bearing: single-page mode and an empty page each terminate
+        before X-Pages is read, so an unparseable header on those responses never
+        reaches int() and stays inert.
+        """
+        if not all_pages:
+            return True
+        if not page_data:
+            return True
+        total_pages_header = response.headers.get("X-Pages")
+        return bool(total_pages_header and page >= int(total_pages_header))
 
     async def get_public_contracts(self, region_id: int) -> list[dict[str, Any]]:
         """Fetches all public contracts for a specific region, handling pagination."""

--- a/app/backend/src/fastapi_app/tests/core/test_esi_client.py
+++ b/app/backend/src/fastapi_app/tests/core/test_esi_client.py
@@ -516,3 +516,31 @@ async def test_malformed_200_json_propagates():
         await client.get_esi_data_with_etag_caching(ETAG_PATH)
 
     assert not isinstance(excinfo.value, ESIRequestFailedError)
+
+
+async def test_etag_path_tolerates_str_valued_redis_client():
+    """A `decode_responses=True` cache client hands back str, not bytes.
+
+    The conditional-request header must carry the cached etag through verbatim
+    for either representation, so the ETag path stays correct whichever cache
+    client it is wired to.
+    """
+    get_mock = AsyncMock(
+        return_value=_etag_response(
+            json_data=[{"contract_id": 1}],
+            content=b'[{"contract_id": 1}]',
+            headers={},
+        )
+    )
+    store = {ETAG_KEY_PAGE_1: "an-etag-as-str"}
+    http_client = MagicMock()
+    http_client.get = get_mock
+    redis_client = MagicMock()
+    redis_client.get = AsyncMock(side_effect=lambda key: store.get(key))
+    redis_client.set = AsyncMock()
+    client = ESIClient(settings=MagicMock(), http_client=http_client, redis_client=redis_client)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_args.kwargs["headers"]["If-None-Match"] == "an-etag-as-str"

--- a/app/backend/src/fastapi_app/tests/core/test_esi_client.py
+++ b/app/backend/src/fastapi_app/tests/core/test_esi_client.py
@@ -1,4 +1,4 @@
-"""Seam regression tests for ESIClient's single-object endpoints.
+"""Tests for ESIClient's fetch paths: single-object endpoints and the paginated ETag helper.
 
 Found live during the design phase: the paginated ETag helper accumulates with
 `full_data.extend(page_data)`, which flattens a dict payload into its KEYS —
@@ -6,8 +6,16 @@ so /universe/types/{id} came back as a list of field-name strings and killed
 the aggregation run. Unit tests with dict-returning mocks could never catch it
 (the mock bypassed the seam); these tests pin the client's actual return shape
 against a mocked HTTP layer instead.
+
+The second half of this file characterizes `get_esi_data_with_etag_caching` —
+conditional requests, the 304 cache-serve, TTL derivation, pagination
+termination, and error propagation — pinning observed behavior so the loop can
+be decomposed without drift.
 """
 
+import json
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -19,6 +27,10 @@ from fastapi_app.core.exceptions import ESIRequestFailedError
 pytestmark = pytest.mark.asyncio
 
 TYPE_PAYLOAD = {"type_id": 587, "name": "Tristan", "group_id": 25, "market_group_id": 1367}
+
+ETAG_PATH = "/v1/test/"
+ETAG_KEY_PAGE_1 = "etag:/v1/test/?page=1"
+DATA_KEY_PAGE_1 = "data:/v1/test/?page=1"
 
 
 def _ok_response(json_data, content: bytes = b"{}") -> MagicMock:
@@ -53,6 +65,44 @@ def _client_with_get(get_mock: AsyncMock) -> ESIClient:
     http_client.get = get_mock
     redis_client = MagicMock()
     redis_client.get = AsyncMock(return_value=None)
+    redis_client.set = AsyncMock()
+    return ESIClient(settings=MagicMock(), http_client=http_client, redis_client=redis_client)
+
+
+def _etag_response(
+    status_code: int = 200,
+    json_data=None,
+    content: bytes = b"[]",
+    headers: dict | None = None,
+) -> MagicMock:
+    """Build a response double for the paginated ETag path.
+
+    `headers` is always a real dict: on a bare MagicMock `response.headers.get("ETag")`
+    answers with a truthy mock, which silently fires the cache-write branch with a junk
+    etag and makes `int(X-Pages)` raise. Pass `headers={}` to mean "no headers".
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.content = content
+    response.headers = dict(headers or {})
+    response.request = MagicMock()
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _etag_client(get_mock: AsyncMock, cache: dict | None = None) -> ESIClient:
+    """Wire an ESIClient for the ETag path against a bytes-valued cache double.
+
+    The ETag path's production client is `aioredis.from_url(...)` with the default
+    `decode_responses=False`, and the cached-etag read calls `.decode()` — so seeded
+    values are bytes and an unseeded key reads back as None.
+    """
+    store = dict(cache or {})
+    http_client = MagicMock()
+    http_client.get = get_mock
+    redis_client = MagicMock()
+    redis_client.get = AsyncMock(side_effect=lambda key: store.get(key))
     redis_client.set = AsyncMock()
     return ESIClient(settings=MagicMock(), http_client=http_client, redis_client=redis_client)
 
@@ -149,3 +199,320 @@ async def test_get_esi_object_survives_cache_write_failure(caplog):
     assert result["name"] == "Tristan"
     client.redis_client.set.assert_awaited_once()
     assert "Object cache write failed for /v3/universe/types/587/: valkey down" in caplog.text
+
+
+async def test_etag_single_page_200_returns_data_and_stores_etag_and_body():
+    body = b'[{"contract_id": 1}]'
+    response = _etag_response(
+        json_data=[{"contract_id": 1}], content=body, headers={"ETag": "etag-v1"}
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 1}]
+    client.redis_client.set.assert_any_await(ETAG_KEY_PAGE_1, "etag-v1", ex=600)
+    client.redis_client.set.assert_any_await(DATA_KEY_PAGE_1, body, ex=600)
+
+
+async def test_etag_304_serves_cached_body():
+    get_mock = AsyncMock(return_value=_etag_response(status_code=304, headers={}))
+    client = _etag_client(
+        get_mock,
+        cache={ETAG_KEY_PAGE_1: b"etag-v1", DATA_KEY_PAGE_1: b'[{"contract_id": 42}]'},
+    )
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 42}]
+    assert get_mock.await_count == 1
+
+
+async def test_etag_304_with_missing_cache_returns_empty():
+    """A live etag whose cached body was evicted yields an empty page: the 304
+    branch never falls through to the live-fetch branch to recover the body.
+
+    The response double carries a body no real 304 would have, purely so a
+    fall-through would produce visibly different data than the [] pinned here.
+    """
+    live_body = [{"contract_id": 999}]
+    get_mock = AsyncMock(
+        return_value=_etag_response(
+            status_code=304,
+            json_data=live_body,
+            content=b'[{"contract_id": 999}]',
+            headers={},
+        )
+    )
+    client = _etag_client(get_mock, cache={ETAG_KEY_PAGE_1: b"etag-v1"})
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == []
+    assert get_mock.await_count == 1
+
+
+async def test_etag_sends_if_none_match_from_cached_etag():
+    warm_get = AsyncMock(return_value=_etag_response(json_data=[], headers={}))
+    warm_client = _etag_client(warm_get, cache={ETAG_KEY_PAGE_1: b'W/"deadbeef"'})
+
+    await warm_client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert warm_get.await_args.kwargs["headers"]["If-None-Match"] == 'W/"deadbeef"'
+
+    cold_get = AsyncMock(return_value=_etag_response(json_data=[], headers={}))
+    cold_client = _etag_client(cold_get)
+
+    await cold_client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert cold_get.await_args.kwargs["headers"]["If-None-Match"] == ""
+
+
+async def test_expires_header_sets_cache_ttl():
+    expires = format_datetime(
+        datetime.now(timezone.utc) + timedelta(seconds=90), usegmt=True
+    )
+    response = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-v1", "Expires": expires},
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    ttls = {call.kwargs["ex"] for call in client.redis_client.set.await_args_list}
+    assert len(ttls) == 1, f"etag and body must share one TTL, got {ttls}"
+    ttl = ttls.pop()
+    # HTTP dates are whole seconds, so the derived delta truncates just under 90.
+    assert 85 <= ttl <= 90, f"expected an Expires-derived TTL, got {ttl}"
+
+
+async def test_malformed_expires_falls_back_to_600():
+    response = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-v1", "Expires": "not-a-date"},
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    client.redis_client.set.assert_any_await(ETAG_KEY_PAGE_1, "etag-v1", ex=600)
+
+
+async def test_past_expires_falls_back_to_600():
+    """An already-elapsed Expires must not produce a zero or negative TTL."""
+    expires = format_datetime(
+        datetime.now(timezone.utc) - timedelta(seconds=90), usegmt=True
+    )
+    response = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-v1", "Expires": expires},
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    client.redis_client.set.assert_any_await(ETAG_KEY_PAGE_1, "etag-v1", ex=600)
+
+
+async def test_pagination_follows_x_pages():
+    page_1 = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-p1", "X-Pages": "2"},
+    )
+    page_2 = _etag_response(
+        json_data=[{"contract_id": 2}],
+        content=b'[{"contract_id": 2}]',
+        headers={"ETag": "etag-p2", "X-Pages": "2"},
+    )
+    get_mock = AsyncMock(side_effect=[page_1, page_2])
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
+
+    assert data == [{"contract_id": 1}, {"contract_id": 2}]
+    assert get_mock.await_count == 2
+    assert [call.args[0] for call in get_mock.await_args_list] == [
+        "/v1/test/?page=1",
+        "/v1/test/?page=2",
+    ]
+
+
+async def test_pagination_stops_on_empty_page():
+    """X-Pages claims a third page; the empty second page ends the walk anyway."""
+    page_1 = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-p1", "X-Pages": "3"},
+    )
+    page_2 = _etag_response(json_data=[], content=b"[]", headers={"X-Pages": "3"})
+    get_mock = AsyncMock(side_effect=[page_1, page_2])
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_count == 2
+
+
+async def test_404_with_ignore_404_ends_pagination_quietly():
+    page_1 = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-p1", "X-Pages": "3"},
+    )
+    page_2 = _etag_response(status_code=404, headers={})
+    get_mock = AsyncMock(side_effect=[page_1, page_2])
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(
+        ETAG_PATH, all_pages=True, ignore_404=True
+    )
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_count == 2
+    page_2.raise_for_status.assert_not_called()
+
+
+async def test_204_ends_pagination():
+    """204 is terminal regardless of ignore_404."""
+    page_1 = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-p1", "X-Pages": "3"},
+    )
+    page_2 = _etag_response(status_code=204, content=b"", headers={})
+    get_mock = AsyncMock(side_effect=[page_1, page_2])
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_count == 2
+    page_2.raise_for_status.assert_not_called()
+
+
+async def test_single_page_mode_ignores_x_pages():
+    response = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-v1", "X-Pages": "5"},
+    )
+    get_mock = AsyncMock(return_value=response)
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_count == 1
+
+
+async def test_retry_exhaustion_raises_esi_request_failed():
+    get_mock = AsyncMock(return_value=_server_error_response(503))
+    client = _etag_client(get_mock)
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(ESIRequestFailedError) as excinfo:
+            await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert excinfo.value.status_code == 503
+    assert get_mock.await_count == 3
+
+
+async def test_200_with_empty_body_treated_as_empty_page():
+    """ESI answers 200 with an empty body; the content guard keeps that off json()."""
+    response = _etag_response(
+        json_data=[{"contract_id": 1}], content=b"", headers={"ETag": "etag-v1"}
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == []
+    response.json.assert_not_called()
+    client.redis_client.set.assert_not_awaited()
+
+
+async def test_single_page_mode_never_reads_x_pages():
+    """Single-page mode breaks before X-Pages is parsed, so an unparseable value
+    is inert. Reordering the termination checks surfaces here as a ValueError."""
+    response = _etag_response(
+        json_data=[{"contract_id": 1}],
+        content=b'[{"contract_id": 1}]',
+        headers={"ETag": "etag-v1", "X-Pages": "garbage"},
+    )
+    get_mock = AsyncMock(return_value=response)
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 1}]
+    assert get_mock.await_count == 1
+
+
+async def test_empty_page_breaks_before_x_pages_is_parsed():
+    """An empty page ends the walk before X-Pages is parsed, so an unparseable
+    value is inert. Reordering the termination checks surfaces here as a ValueError."""
+    response = _etag_response(json_data=[], content=b"[]", headers={"X-Pages": "garbage"})
+    get_mock = AsyncMock(return_value=response)
+    client = _etag_client(get_mock)
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
+
+    assert data == []
+    assert get_mock.await_count == 1
+
+
+async def test_404_without_ignore_propagates_http_status_error():
+    """Unlike _get_esi_object, this path does not normalize a 4xx into
+    ESIRequestFailedError — raise_for_status escapes verbatim."""
+    response = _etag_response(status_code=404, headers={})
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Client error '404 Not Found'", request=response.request, response=response
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert not isinstance(excinfo.value, ESIRequestFailedError)
+
+
+async def test_redis_read_failure_propagates_on_etag_path():
+    """This path has no cache-failure guard: an unreachable cache fails the call
+    outright rather than degrading to a live fetch."""
+    get_mock = AsyncMock(return_value=_etag_response(json_data=[], headers={}))
+    client = _etag_client(get_mock)
+    client.redis_client.get = AsyncMock(side_effect=RuntimeError("valkey down"))
+
+    with pytest.raises(RuntimeError, match="valkey down"):
+        await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    get_mock.assert_not_awaited()
+
+
+async def test_malformed_cached_json_propagates():
+    get_mock = AsyncMock(return_value=_etag_response(status_code=304, headers={}))
+    client = _etag_client(
+        get_mock,
+        cache={ETAG_KEY_PAGE_1: b"etag-v1", DATA_KEY_PAGE_1: b"not-json"},
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+
+async def test_malformed_200_json_propagates():
+    body = "<html>bad gateway</html>"
+    response = _etag_response(content=body.encode(), headers={"ETag": "etag-v1"})
+    response.json.side_effect = json.JSONDecodeError("Expecting value", body, 0)
+    client = _etag_client(AsyncMock(return_value=response))
+
+    with pytest.raises(json.JSONDecodeError) as excinfo:
+        await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert not isinstance(excinfo.value, ESIRequestFailedError)

--- a/app/backend/src/fastapi_app/tests/core/test_esi_client.py
+++ b/app/backend/src/fastapi_app/tests/core/test_esi_client.py
@@ -14,6 +14,7 @@ be decomposed without drift.
 """
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -31,6 +32,21 @@ TYPE_PAYLOAD = {"type_id": 587, "name": "Tristan", "group_id": 25, "market_group
 ETAG_PATH = "/v1/test/"
 ETAG_KEY_PAGE_1 = "etag:/v1/test/?page=1"
 DATA_KEY_PAGE_1 = "data:/v1/test/?page=1"
+
+ESI_LOGGER = "fastapi_app.core.esi_client_class"
+
+
+def _debug_messages(caplog) -> list[str]:
+    """The ESI client's DEBUG records, filtered by level rather than substring.
+
+    Matching on `caplog.text` alone would let a record emitted at any other level
+    satisfy an assertion about a debug log.
+    """
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == ESI_LOGGER and record.levelno == logging.DEBUG
+    ]
 
 
 def _ok_response(json_data, content: bytes = b"{}") -> MagicMock:
@@ -215,17 +231,40 @@ async def test_etag_single_page_200_returns_data_and_stores_etag_and_body():
     client.redis_client.set.assert_any_await(DATA_KEY_PAGE_1, body, ex=600)
 
 
-async def test_etag_304_serves_cached_body():
+async def test_200_without_etag_header_is_not_cached():
+    """A page with data but no ETag is returned and neither key is written.
+
+    Caching a body with no validator would strand it: a later conditional request
+    has no etag to send, so the entry could never be revalidated — only served
+    stale or evicted.
+    """
+    response = _etag_response(
+        json_data=[{"contract_id": 1}], content=b'[{"contract_id": 1}]', headers={}
+    )
+    client = _etag_client(AsyncMock(return_value=response))
+
+    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+
+    assert data == [{"contract_id": 1}]
+    client.redis_client.set.assert_not_awaited()
+
+
+async def test_etag_304_serves_cached_body(caplog):
     get_mock = AsyncMock(return_value=_etag_response(status_code=304, headers={}))
     client = _etag_client(
         get_mock,
         cache={ETAG_KEY_PAGE_1: b"etag-v1", DATA_KEY_PAGE_1: b'[{"contract_id": 42}]'},
     )
 
-    data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
+    with caplog.at_level(logging.DEBUG, logger=ESI_LOGGER):
+        data = await client.get_esi_data_with_etag_caching(ETAG_PATH)
 
     assert data == [{"contract_id": 42}]
     assert get_mock.await_count == 1
+    assert (
+        "ETag cache hit for /v1/test/?page=1. Serving data from cache."
+        in _debug_messages(caplog)
+    )
 
 
 async def test_etag_304_with_missing_cache_returns_empty():
@@ -359,7 +398,7 @@ async def test_pagination_stops_on_empty_page():
     assert get_mock.await_count == 2
 
 
-async def test_404_with_ignore_404_ends_pagination_quietly():
+async def test_404_with_ignore_404_ends_pagination_quietly(caplog):
     page_1 = _etag_response(
         json_data=[{"contract_id": 1}],
         content=b'[{"contract_id": 1}]',
@@ -369,16 +408,21 @@ async def test_404_with_ignore_404_ends_pagination_quietly():
     get_mock = AsyncMock(side_effect=[page_1, page_2])
     client = _etag_client(get_mock)
 
-    data = await client.get_esi_data_with_etag_caching(
-        ETAG_PATH, all_pages=True, ignore_404=True
-    )
+    with caplog.at_level(logging.DEBUG, logger=ESI_LOGGER):
+        data = await client.get_esi_data_with_etag_caching(
+            ETAG_PATH, all_pages=True, ignore_404=True
+        )
 
     assert data == [{"contract_id": 1}]
     assert get_mock.await_count == 2
     page_2.raise_for_status.assert_not_called()
+    assert (
+        "Received 404 for /v1/test/?page=2, treating as end of pages."
+        in _debug_messages(caplog)
+    )
 
 
-async def test_204_ends_pagination():
+async def test_204_ends_pagination(caplog):
     """204 is terminal regardless of ignore_404."""
     page_1 = _etag_response(
         json_data=[{"contract_id": 1}],
@@ -389,11 +433,16 @@ async def test_204_ends_pagination():
     get_mock = AsyncMock(side_effect=[page_1, page_2])
     client = _etag_client(get_mock)
 
-    data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
+    with caplog.at_level(logging.DEBUG, logger=ESI_LOGGER):
+        data = await client.get_esi_data_with_etag_caching(ETAG_PATH, all_pages=True)
 
     assert data == [{"contract_id": 1}]
     assert get_mock.await_count == 2
     page_2.raise_for_status.assert_not_called()
+    assert (
+        "Received 204 for /v1/test/?page=2, treating as end of pages."
+        in _debug_messages(caplog)
+    )
 
 
 async def test_single_page_mode_ignores_x_pages():
@@ -412,15 +461,23 @@ async def test_single_page_mode_ignores_x_pages():
 
 
 async def test_retry_exhaustion_raises_esi_request_failed():
+    """Three attempts separated by two exponential backoff waits.
+
+    The delays are asserted from the patched sleep rather than from elapsed time:
+    a wall-clock assertion would both slow the suite and flake under load.
+    """
     get_mock = AsyncMock(return_value=_server_error_response(503))
     client = _etag_client(get_mock)
 
-    with patch("asyncio.sleep", new=AsyncMock()):
+    sleep_mock = AsyncMock()
+    with patch("asyncio.sleep", new=sleep_mock):
         with pytest.raises(ESIRequestFailedError) as excinfo:
             await client.get_esi_data_with_etag_caching(ETAG_PATH)
 
     assert excinfo.value.status_code == 503
     assert get_mock.await_count == 3
+    # Two waits, not three: the final attempt is not followed by a backoff.
+    assert [call.args[0] for call in sleep_mock.await_args_list] == [0.5, 1.0]
 
 
 async def test_200_with_empty_body_treated_as_empty_page():
@@ -468,8 +525,9 @@ async def test_empty_page_breaks_before_x_pages_is_parsed():
 
 
 async def test_404_without_ignore_propagates_http_status_error():
-    """Unlike _get_esi_object, this path does not normalize a 4xx into
-    ESIRequestFailedError — raise_for_status escapes verbatim."""
+    """With ignore_404 off, a 404 reaches raise_for_status and its
+    httpx.HTTPStatusError propagates unchanged — the status is not translated
+    into an ESI-level error, and nothing is cached for the failed page."""
     response = _etag_response(status_code=404, headers={})
     response.raise_for_status.side_effect = httpx.HTTPStatusError(
         "Client error '404 Not Found'", request=response.request, response=response
@@ -479,7 +537,9 @@ async def test_404_without_ignore_propagates_http_status_error():
     with pytest.raises(httpx.HTTPStatusError) as excinfo:
         await client.get_esi_data_with_etag_caching(ETAG_PATH)
 
-    assert not isinstance(excinfo.value, ESIRequestFailedError)
+    response.raise_for_status.assert_called_once()
+    assert excinfo.value.response.status_code == 404
+    client.redis_client.set.assert_not_awaited()
 
 
 async def test_redis_read_failure_propagates_on_etag_path():
@@ -507,15 +567,17 @@ async def test_malformed_cached_json_propagates():
 
 
 async def test_malformed_200_json_propagates():
+    """A decode failure escapes raw here, where _get_esi_object normalizes it to
+    ESIRequestFailedError. The undecodable body must not reach the cache."""
     body = "<html>bad gateway</html>"
     response = _etag_response(content=body.encode(), headers={"ETag": "etag-v1"})
     response.json.side_effect = json.JSONDecodeError("Expecting value", body, 0)
     client = _etag_client(AsyncMock(return_value=response))
 
-    with pytest.raises(json.JSONDecodeError) as excinfo:
+    with pytest.raises(json.JSONDecodeError):
         await client.get_esi_data_with_etag_caching(ETAG_PATH)
 
-    assert not isinstance(excinfo.value, ESIRequestFailedError)
+    client.redis_client.set.assert_not_awaited()
 
 
 async def test_etag_path_tolerates_str_valued_redis_client():

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -803,6 +803,35 @@ plan was written); after decomposition `pdm run lint` exit 0, `--select=C901` em
 `get_esi_data_with_etag_caching` 24 → 9 (`_cache_ttl_seconds` 5, `_last_page_reached` 3,
 `_read_etag_cached_page` 2, `_store_page_cache` 2); suite 435 passed.
 
+**Phase 5 mutation evidence (persisted per TEST-12).** Task 5.1's suite: seven mutations, each
+producing EXACTLY ONE failure (no collateral, so each test is pinned to its own named behavior rather
+than riding a shared crash) — reordering `not page_data` after the X-Pages parse and reordering
+`not all_pages` after it both raised `ValueError: invalid literal for int() ... 'garbage'`; a 304
+falling through to a live parse gave `assert [{'contract_id': 999}] == []`; a hardcoded 600 TTL gave
+`expected an Expires-derived TTL, got 600`; `max_retries` 3→2 gave `assert 2 == 3`; removing the
+empty-content guard gave `assert [{'contract_id': 1}] == []`; dropping `If-None-Match` gave
+`KeyError: 'If-None-Match'`. Task 5.2's four re-verified the suite grips the DECOMPOSED code
+(reorder `_last_page_reached`, flatten `_cache_ttl_seconds` to 600, stub `_read_etag_cached_page` to
+`[]`, no-op `_store_page_cache` — all red, all reverted). Task 5.2a verified BOTH directions: reverting
+the fix reddened the new str test, and inverting the `isinstance` reddened the existing bytes test
+(catching raw bytes leaking into the header). The post-review round added six more:
+
+| Mutation | Observed failure |
+|---|---|
+| remove the `if not new_etag: return` gate in `_store_page_cache` | `Expected set to not have been awaited. Awaited 2 times.` |
+| replace the backoff `await asyncio.sleep(...)` with `pass` | `assert [] == [0.5, 1.0]` |
+| delete the 404 debug log | `assert 'Received 404 for /v1/test/?page=2, treating as end of pages.' in []` |
+| delete the 204 debug log | `assert 'Received 204 for /v1/test/?page=2, treating as end of pages.' in []` |
+| delete the 304 debug log | `assert 'ETag cache hit for /v1/test/?page=1. Serving data from cache.' in []` |
+| hoist `_store_page_cache` above the JSON parse | `Expected set to not have been awaited. Awaited 2 times.` |
+
+**Two test-construction traps recorded for future readers of this file.** (1) `_ok_response` never
+sets `headers`, so on a bare `MagicMock` `response.headers.get("ETag")` returns a TRUTHY MagicMock and
+silently takes the cache-write branch with a garbage etag — every response double must set an explicit
+`headers` dict. (2) A `caplog.text` substring check passes on a record emitted at ANY level, so the
+mutation that matters (a log DOWNGRADED rather than deleted) slips through it; the suite uses a
+level-filtering helper asserting on `caplog.records` instead.
+
 **Task 5.3 live sanity check — PASSED (2026-07-19).** Dev server run against real ESI on this branch:
 `"Public contract aggregation run finished successfully and changes committed."` appeared, **100
 contracts / 152 contract_items** landed in `hangar_bay_dev` (100 is the configured dev limit), **zero**
@@ -869,8 +898,16 @@ test_empty_page_breaks_before_x_pages_is_parsed
     # checked before the X-Pages parse.
 test_404_without_ignore_propagates_http_status_error
     # ignore_404=False + a 404 response → httpx.HTTPStatusError from
-    # raise_for_status propagates — NOT ESIRequestFailedError. Pin this asymmetry
-    # vs _get_esi_object (which normalizes); do NOT "harmonize" it in the refactor.
+    # raise_for_status propagates — NOT ESIRequestFailedError.
+    # ⚠️ CORRECTION (2026-07-19): this task originally said to "pin this asymmetry
+    # vs _get_esi_object (which normalizes)". THAT CLAIM IS FALSE and was caught by
+    # codex review only after it had propagated into a test docstring and a PR body.
+    # BOTH paths call a bare response.raise_for_status() with no normalization
+    # (esi_client_class.py:117 and :267); _get_esi_object's own inline comment says
+    # "4xx (e.g. 404) still falls straight through to raise_for_status below".
+    # What _get_esi_object DOES normalize is the JSON-decode failure (ValueError →
+    # ESIRequestFailedError) and a non-dict body — not status codes. The test is
+    # still correct and worth keeping; only the rationale was wrong.
 test_redis_read_failure_propagates_on_etag_path
     # redis.get raising RuntimeError → RuntimeError propagates. Unlike
     # _get_esi_object, the ETag path has NO cache-failure guard — pin the

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -70,9 +70,9 @@ notes and commit messages.
 |---|---|---|---|
 | 1 — get_contracts | ✅ Merged | `69b0112`, `3d4e61e`, `1ca0aa0`, `7ae0576`, `63e5ddb`, `bca290b` → merge `e84aa8a` | PR #54, merged 2026-07-18; complexity 20 → 7; suite 358 → 362 |
 | 2 — _process_contracts | ✅ Merged | `455f586`, `6bd9f63`, `8962daf`, `656a383`, `bca8d00` → merge `c271f19` | PR #57, merged 2026-07-18; complexity 18 → 7; suite 362 → 365 |
-| 3 — run_aggregation | 🚧 PR open (v2) | `433eb9a`, `467f6f3` | branch `claude/c901-run-aggregation-v2` off `e80103a`; **redone against a rewritten base — see Deviations**; complexity 16 → 8 |
-| 4 — _get_esi_object + shared retry helper | 🚧 PR open | `4c4e158`, `402658a` | branch `claude/c901-esi-object`; complexity 16 → 9; introduces `_get_with_transient_retry` (8); `Review — data-integrity`, **Sam merges** |
-| 5 — get_esi_data_with_etag_caching | ⬜ Not started | — | blocked by Phase 4 (uses its helper); write its missing tests FIRST |
+| 3 — run_aggregation | ✅ Merged | `9cbafc8`, `433eb9a`, `467f6f3`, `516f8ed`, `939d561` → merge `727d84f` | PR #62, merged 2026-07-19; **redone against a base rewritten by PR #60 — see Deviations**; complexity 16 → 8; suite 416 → 423 |
+| 4 — _get_esi_object + shared retry helper | ✅ Merged | `4c4e158`, `402658a` → merge `e5d304d` | PR #59, merged 2026-07-19; complexity 16 → 9; introduced `_get_with_transient_retry` (8) |
+| 5 — get_esi_data_with_etag_caching | 🚧 PR #68 open | `e25883c`, `fc17fdf`, `7122d98` | branch `claude/c901-etag-caching`; complexity 24 → 9; **clears the last suppression**; `Review — data-integrity`, **Sam merges** |
 
 ### Deviations
 
@@ -796,7 +796,25 @@ async def _get_with_transient_retry(
 
 ## Phase 5 — `get_esi_data_with_etag_caching` (complexity 23 → ≤ 10)
 
-**Execution Status:** ⬜ NOT STARTED — MUST NOT start until Phase 4's PR is merged (uses `_get_with_transient_retry`).
+**Execution Status:** 🚧 PR OPEN — branch `claude/c901-etag-caching`. Commits `e25883c` (20-test
+characterization suite), `fc17fdf` (Task 5.2a str/bytes fix), `7122d98` (decomposition). Gates: red gate
+observed at **24** (not the plan's 23 — Task 5.2a's `isinstance` check added a decision point after the
+plan was written); after decomposition `pdm run lint` exit 0, `--select=C901` empty,
+`get_esi_data_with_etag_caching` 24 → 9 (`_cache_ttl_seconds` 5, `_last_page_reached` 3,
+`_read_etag_cached_page` 2, `_store_page_cache` 2); suite 435 passed.
+
+**Task 5.3 live sanity check — PASSED (2026-07-19).** Dev server run against real ESI on this branch:
+`"Public contract aggregation run finished successfully and changes committed."` appeared, **100
+contracts / 152 contract_items** landed in `hangar_bay_dev` (100 is the configured dev limit), **zero**
+`ERROR` lines in the log, and **134 `etag:*` keys** were written to Valkey — direct evidence that the
+extracted `_store_page_cache` and the conditional-GET path work against the live API, not just under
+mocks. Server stopped cleanly afterward.
+
+**Sequencing deviation:** Task 5.1's characterization suite was written while Phase 4's PR was still
+open, on a branch stacked on Phase 4 rather than off `dev`. This was safe because the suite targets
+`get_esi_data_with_etag_caching`, which Phase 4 left byte-identical by contract — so the tests were
+valid regardless of Phase 4's outcome. The branch was rebased onto `dev` after Phase 4 merged
+(`e5d304d`); the Phase 4 commits dropped out as already-applied and no conflict arose.
 
 **Files:**
 - Modify: `app/backend/src/fastapi_app/core/esi_client_class.py`


### PR DESCRIPTION
Phase 5 — the last phase of the [C901 complexity-refactor plan](docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md). Together with #62 this takes the codebase to **zero `# noqa: C901`**.

## Merge classification

`Review — data-integrity (ingestion pipeline refactor)`

This is the ingestion hot path (ESI conditional GETs, pagination, cache writes) and it carries the plan's second authorized behavior change. **Sam merges.**

## Why this was the riskiest phase

`get_esi_data_with_etag_caching` had **zero direct tests** before this PR. The characterization suite is therefore the bulk of the work, and it came first.

| Commit | Change |
|---|---|
| `e25883c` | 20-test characterization suite — written and passing against the **unrefactored** method |
| `fc17fdf` | Task 5.2a: tolerate str-valued cache clients (authorized behavior change, TDD'd) |
| `7122d98` | Decomposition into four private helpers; the final `# noqa: C901` removed |
| `dba79b5` | Plan banners, gates, live-check record |

## Gates

- **Red gate:** `C901 ... 'get_esi_data_with_etag_caching' is too complex (24)`
- **After:** `pdm run lint` exit 0; `--select=C901` empty
- **Complexity:** **24 → 9** (`_cache_ttl_seconds` 5, `_last_page_reached` 3, `_read_etag_cached_page` 2, `_store_page_cache` 2)
- **Suite:** **435 passed**

The red gate measured **24, not the plan's 23** — Task 5.2a's `isinstance` check added a decision point after the plan was written.

## Authorized behavior change (1 of the plan's 2)

**Task 5.2a — the ETag path now tolerates a str-valued cache client.** The cached-etag read called `.decode()` unconditionally, so a `decode_responses=True` client (`core/cache.py`, str-valued) would raise `AttributeError` on the first ETag cache hit.

Verified **latent, not live**: the aggregation service — the only caller of this method — is built at `main.py` with no injected redis and so uses the managed bytes-returning client; `get_esi_client` (which injects the str client) is consumed only by the watchlist API, whose calls avoid this path. Full TDD cycle: red gate (`AttributeError: 'str' object has no attribute 'decode'`), 3-line fix, green — then mutation-verified **both** directions (reverting the fix reddens the new test; inverting the isinstance reddens the existing bytes-path test, catching raw bytes leaking into the header).

## Dead provider — resolved, removal follows separately

`get_aggregation_service` (`background_aggregation.py:570`) has **zero callers** — verified: exactly one occurrence in all of `src/`, its own definition. It is the single wiring that would connect the str-valued cache client to this ETag path.

The mechanism, verified rather than assumed:

| Client | Built at | `decode_responses` | Yields |
|---|---|---|---|
| Shared cache client | `core/cache.py:45` | `True` | `str` |
| ESIClient's own managed client | `esi_client_class.py` `__aenter__` | unset → `False` | `bytes` |

The live ingestion path (`main.py:55`) constructs `ESIClient(settings=settings)` with **no** injected redis, so it builds the bytes-yielding client and `.decode()` works. `get_esi_client` (`core/dependencies.py:39`) instead injects the str-yielding shared client, but its only live consumer is `watchlist.py`, whose calls (`get_universe_type`, `get_universe_group`, `resolve_names`) never reach the ETag path. `get_aggregation_service` is the one function that would hand a `get_esi_client`-built client to the aggregation service, whose `get_public_contracts` / `get_contract_items` *do* reach it.

**Sam's decision: delete it**, in a **separate follow-up PR** rather than here. Removing a public module symbol is a behavior change and does not belong inside a zero-behavior-change refactor. Deleting it also orphans `from fastapi import Depends` and the whole `..core.dependencies` import — they are used by nothing else in that module — so the background-ingestion service will stop importing the web framework entirely.

**The 5.2a fix stays regardless.** Deleting the provider removes today's route to the hazard; the type-tolerant read removes the hazard class. Defense in depth, not redundancy.

## Live sanity check — passed

The plan's one intentional dev-server run, against **real ESI**:

- `"Public contract aggregation run finished successfully and changes committed."`
- **100 contracts / 152 contract_items** persisted (100 = configured dev limit)
- **zero** `ERROR` lines in the log
- **134 `etag:*` keys** written to Valkey

That last one matters: it is direct evidence the extracted `_store_page_cache` and the conditional-GET path work against the live API, not merely under mocks.

## Behavior preservation

Three asymmetries versus `_get_esi_object` in the same file are now **pinned by test**, because a well-meaning "harmonizing" refactor would silently erase them. This path does **not** normalize 4xx into `ESIRequestFailedError` (`raise_for_status` escapes verbatim), does **not** normalize JSON decode failures, and has **no** cache-failure guard — a redis outage fails the call outright and the HTTP request is never attempted.

The termination-order trap is also pinned: `all_pages` is checked before `page_data`, which is checked before `X-Pages` is ever parsed. Two tests feed `X-Pages: "garbage"` and pass only because `int()` is never reached. **`_last_page_reached` must evaluate `int(X-Pages)` lazily inside its third condition** — precomputing it reddens both tests even though returned data would be correct.

## Verification — 11 mutations across the phase

Every characterization test was mutation-verified per TEST-12. Task 5.1's seven each produced **exactly one** failure — no collateral — so each test is pinned to its own named behavior rather than riding on a shared crash. Task 5.2's four re-verified the suite still grips the *decomposed* code: reordering `_last_page_reached`, flattening `_cache_ttl_seconds` to 600, stubbing `_read_etag_cached_page` to `[]`, and no-op'ing `_store_page_cache` all went red and were reverted.

Two fixture traps worth knowing, both discovered by mutation rather than inspection: `_ok_response` never sets `headers`, so on a bare `MagicMock` `response.headers.get("ETag")` returns a **truthy MagicMock** and silently takes the cache-write branch; and the 304 cache-miss test needs a deliberately **unrealistic** mock (a 304 carrying a payload) as a tripwire, because a realistic empty-bodied 304 returns `[]` under both correct code and a fall-through mutant.

## Sequencing deviation

Task 5.1's suite was written while Phase 4's PR was still open, on a branch stacked on Phase 4 rather than off `dev`. Safe because the suite targets a method Phase 4 left byte-identical by contract, so it was valid regardless of Phase 4's outcome. Rebased onto `dev` after Phase 4 merged (`e5d304d`); the Phase 4 commits dropped out as already-applied, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
