### PR TITLE
refactor(api): drop the unused get_aggregation_service provider

### DIFF
--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -7,11 +7,9 @@ from typing import Iterable, Iterator, List, Callable  # Added Callable
 from datetime import datetime, timezone
 
 import redis.asyncio as aioredis  # For on-demand client creation
-from fastapi import Depends
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..core.dependencies import get_cache, get_esi_client, get_settings
 from ..core.config import Settings  # Settings type for hinting
 from ..core.esi_client_class import ESIClient  # ESIClient class for type hint
 from ..core.exceptions import ESINotModifiedError  # Restored ESINotModifiedError
@@ -564,18 +562,3 @@ class ContractAggregationService:
             if is_ship and item["is_included"]:
                 ship_contract_ids.add(item["contract_id"])
         return ship_contract_ids
-
-
-# Dependency for getting the service
-async def get_aggregation_service(
-    # cache: Redis = Depends(get_cache), # Service no longer takes cache client directly
-    esi_client: ESIClient = Depends(get_esi_client),
-    settings: Settings = Depends(get_settings),  # Use the new get_settings dependency
-) -> ContractAggregationService:
-    """
-    FastAPI dependency to get an instance of the ContractAggregationService.
-    The service manages its own database sessions for scheduled tasks.
-    The global `settings` object from `..core.config` is used by default.
-    """
-    # If specific settings injection per request is needed later, that would require a `Depends(get_settings_func)`
-    return ContractAggregationService(esi_client=esi_client, settings=settings)

--- a/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
+++ b/docs/superpowers/plans/2026-07-18-c901-complexity-refactors.md
@@ -60,7 +60,21 @@ notes and commit messages.
 
 ## Execution Status
 
-**Overall:** In progress — Phase 1 shipped; Phase 2 claimed 2026-07-18.
+**Overall:** ✅ **COMPLETE — all five phases merged (2026-07-18/19).** `grep -rn "noqa: C901"` over
+`app/backend/src` on `origin/dev` returns **nothing**: the goal is met. Suite grew 358 → 445. Both
+authorized behavior changes shipped (Phase 4's retry-warning log prefix; Phase 5's str/bytes
+cached-etag normalization). Merge SHAs are in the per-phase rows below.
+
+**Follow-up shipped separately:** the dead `get_aggregation_service` provider flagged in Task 5.1 was
+removed after Sam's decision, in its own PR rather than inside a zero-behavior-change phase (removing a
+public module symbol is a behavior change). Deleting it also orphaned `from fastapi import Depends` and
+the entire `..core.dependencies` import, so `services/background_aggregation.py` no longer imports the
+web framework at all.
+
+**Deferred, NOT done here:** the ingestion-failure observability residual recorded under Discoveries
+(scheduler propagation, pre-lock failures producing no outcome record, `/ready` returning 200 while
+stale, and the non-atomic `_record_run_outcome` GET/SET). Those are behavior changes for the
+observability backlog.
 
 **Baseline at Phase 1 claim** (branch point `bfaf495`, fresh `origin/dev`): `pdm run pytest` = **358 passed**; `pdm run lint` = exit 0; `grep -rn "noqa: C901" src/` = the 5 expected sites.
 
@@ -855,7 +869,7 @@ valid regardless of Phase 4's outcome. The branch was rebased onto `dev` after P
 
 - [ ] **Step 1: Build fixtures.** Mirror the existing `_get_esi_object` test idiom in this file: `MagicMock` http/redis clients with `AsyncMock` methods (`_client_with_response` / `_client_with_get` helpers) — NOT `pytest_httpx` and NOT `tests/fake_redis.py`'s `FakeRedis`. Two contracts to respect:
   - **Redis values are BYTES on this path.** `ESIClient`'s managed client is `aioredis.from_url(...)` with default `decode_responses=False`, and the ETag code calls `cached_etag.decode()`. Stub `redis.get` to return `b"..."` (or `None`), never `str` — `FakeRedis` is str-valued (house `decode_responses=True` pattern) and would crash this path with `AttributeError` against the CURRENT code, which is exactly why it is the wrong double for characterization. (Task 5.2a later makes str clients tolerated; the characterization suite still runs on the bytes contract, which stays the production reality for this client.)
-  - **Wiring already verified (2026-07-18, plan-authoring session) — latent hazard, not live:** the shared cache client (`core/cache.py:45`, `decode_responses=True`, str-valued) never reaches the ETag path today. The aggregation service — the only ETag-method caller — is built at `main.py:55` as `ESIClient(settings=settings)` with no injected redis, so it uses the managed bytes-returning client; `get_esi_client` (which injects the str client) is consumed only by the watchlist API, whose calls (`get_universe_type`/`get_universe_group`/`resolve_names`) avoid the ETag path; and `get_aggregation_service` (`background_aggregation.py:458`) — the one wiring that WOULD combine the str client with the ETag path — has zero callers (dead code). Task 5.2a fixes the latent crash; flag the dead provider in this phase's PR body for Sam's removal decision (do NOT delete it yourself).
+  - **Wiring already verified (2026-07-18, plan-authoring session) — latent hazard, not live:** the shared cache client (`core/cache.py:45`, `decode_responses=True`, str-valued) never reaches the ETag path today. The aggregation service — the only ETag-method caller — is built at `main.py:55` as `ESIClient(settings=settings)` with no injected redis, so it uses the managed bytes-returning client; `get_esi_client` (which injects the str client) is consumed only by the watchlist API, whose calls (`get_universe_type`/`get_universe_group`/`resolve_names`) avoid the ETag path; and `get_aggregation_service` (`background_aggregation.py:458`) — the one wiring that WOULD combine the str client with the ETag path — has zero callers (dead code). Task 5.2a fixes the latent crash; flag the dead provider in this phase's PR body for Sam's removal decision (do NOT delete it yourself). **RESOLVED 2026-07-19: Sam chose deletion; the provider was removed in a separate follow-up PR after Phase 5 merged.** The 5.2a fix stays regardless — deleting the provider removed the only route to the hazard, the type-tolerant read removes the hazard class.
   - Monkeypatch `asyncio.sleep` inside retry tests so backoff is a no-op (mechanism assertion: count requests, don't time them).
 - [ ] **Step 2: Write these tests** (names are normative; bodies follow the existing file's idioms):
 


### PR DESCRIPTION
Follow-up to #68, per Sam's decision. Removes the dead `get_aggregation_service` provider that the C901 plan flagged but forbade the agent deleting inside a zero-behavior-change phase.

## Merge classification

`Routine — auto-merge on green CI`

Removal of a symbol with **zero callers**, verified below. No live code path changes. Sam explicitly authorized the merge when directing this follow-up.

## What it was, and why it mattered

```python
async def get_aggregation_service(
    esi_client: ESIClient = Depends(get_esi_client),
    settings: Settings = Depends(get_settings),
) -> ContractAggregationService:
    return ContractAggregationService(esi_client=esi_client, settings=settings)
```

Two Redis clients in this app disagree about types:

| Client | Built at | `decode_responses` | Yields |
|---|---|---|---|
| Shared cache client | `core/cache.py:45` | `True` | `str` |
| ESIClient's own managed client | `esi_client_class.py` `__aenter__` | unset → `False` | `bytes` |

The ETag path reads a cached etag and (before #68) called `.decode()` on it unconditionally — bytes-only.

- The **live** ingestion path (`main.py:55`) builds `ESIClient(settings=settings)` with no injected redis, so it creates the **bytes** client. Fine.
- `get_esi_client` injects the **str** client, but its only live consumer is `watchlist.py`, whose calls (`get_universe_type`, `get_universe_group`, `resolve_names`) never reach the ETag path.
- **`get_aggregation_service` was the single function that would bridge them**, handing a `get_esi_client`-built client to the service whose `get_public_contracts` / `get_contract_items` do reach it.

Wiring it into any route would have produced `AttributeError: 'str' object has no attribute 'decode'` on the first ETag cache hit.

## Why delete rather than keep

The optionality it appeared to offer isn't the optionality you'd want. An admin "trigger ingestion" endpoint would not use this shape — it would `await run_aggregation()` inside a request/response cycle: concurrency lock, engine, minutes of ESI work blocking an HTTP request. The real design enqueues or kicks the scheduler job. Meanwhile the provider is the obvious-looking hook, so a future change reaches for it naturally and silently gets the wrong cache-client semantics.

## Verification

- **Zero callers:** `grep -rn "get_aggregation_service" src/` returned exactly one hit before this change — its own definition. Zero after.
- **Orphaned imports removed:** `Depends` and all three `..core.dependencies` symbols (`get_cache`, `get_esi_client`, `get_settings`) were used *only* by this function. `Settings` and `ESIClient` are still used by the service class and are retained. **`services/background_aggregation.py` no longer imports FastAPI at all** — a background-ingestion module has no business depending on the web framework.
- **App still boots:** imported `fastapi_app.main` directly — `app = FastAPI`, `ContractAggregationService` present, `get_aggregation_service` absent.
- `pdm run lint` exit 0; **445 passed**, unchanged from `dev` (expected — the code was dead).

## The 5.2a fix stays

#68's type-tolerant cached-etag read is deliberately kept. This PR removes the only *route* to the hazard; that fix removes the *hazard class*. Defense in depth, not redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)