### PR TITLE
docs(m4): Phase 0 spike results — TOPOLOGY A confirmed

### DIFF
--- a/docs/audits/m4-recon/render-spike-results.md
+++ b/docs/audits/m4-recon/render-spike-results.md
@@ -1,0 +1,126 @@
+# ABOUTME: Empirical results of the M4 Phase 0 Render verification spike (plan Task 0.1, probes P1–P6) —
+# ABOUTME: the real-platform gate for the Topology A vs B decision that the docs-based verification could not settle.
+
+# Render spike results — M4 Phase 0 (2026-07-21)
+
+**Verdict up front:**
+
+```
+TOPOLOGY: A (static-site rewrites)
+```
+
+P1 (POST pass-through) and P2 (trailing-slash preservation) both pass **exactly**. No render.yaml
+topology change is needed; Appendix B (in-container Caddy) stays unused.
+
+**How this ran.** Free-tier resources on Sam's Render workspace `Primary` (plan Deviation D-2), probe
+app from throwaway repo `scarson/hb-render-spike-m4` @ `bc5068ecc240983e44e6e7bf149316bf06c56cc3`
+(spike-repo access saga: Deviation D-11 — resolved by making the repo public on Sam's instruction).
+Resources: Docker web service `hb-spike-api` (frankfurt) + static site `hb-spike-web` with the two
+production-shaped rewrite rules and **no custom headers** (so P4 observes true defaults) + free
+Postgres `hb-spike-db` (frankfurt, PG 17). One method deviation from the plan's Step 2: `DATABASE_URL`
+was injected via the env-var API from the Postgres `internalConnectionString` (the API create path has
+no blueprint `fromDatabase`; the injected value is the same connection string that mechanism delivers,
+so P3's observation carries over). All resources deleted after the probes — see Teardown.
+
+## P1 — POST body/method/query pass-through across the cross-service rewrite: **PASS (exact)**
+
+```
+$ curl -s -X POST "https://hb-spike-web.onrender.com/api/v1/auth/sso/callback?code=abc&state=xyz" \
+    -H 'Content-Type: application/x-www-form-urlencoded' -d 'grant=body-survives'
+{"method":"POST","raw_path":"/auth/sso/callback","query":"code=abc&state=xyz","body_len":19,
+ "body_prefix":"grant=body-survives","database_url_scheme":"postgresql://",
+ "render_git_commit":"bc5068ecc240983e44e6e7bf149316bf06c56cc3"}
+```
+
+Method preserved, `/api/v1` prefix stripped by the rewrite (PROXY-1 semantics), query string intact,
+body delivered byte-for-byte (`body_len` 19 = `len("grant=body-survives")`). SSO callback/logout and
+all M3 account POST/DELETE calls are safe on Topology A.
+
+## P2 — trailing-slash preservation: **PASS (exact, both shapes)**
+
+```
+$ curl -s "https://hb-spike-web.onrender.com/api/v1/contracts/"   →  "raw_path":"/contracts/"
+$ curl -s "https://hb-spike-web.onrender.com/api/v1/contracts"    →  "raw_path":"/contracts"
+```
+
+No slash added, none removed, no 307 escape — the PROXY-1 excluded failure mode does not occur.
+
+## P2b — assigned-hostname reality
+
+Both spike services received their **exact requested names, un-suffixed**:
+`hb-spike-api.onrender.com`, `hb-spike-web.onrender.com`. So un-suffixed grants do happen when the
+name is globally free; this raises confidence in the blueprint's placeholder destination
+`https://hangar-bay-api.onrender.com`, but the 2b apply-time check remains **mandatory** (whether
+`hangar-bay-api` is free can only be observed when the production blueprint is applied).
+
+## P3 — injected `DATABASE_URL` scheme: **`postgresql://`**
+
+Observed twice: directly from the Postgres `connection-info` endpoint's `internalConnectionString`
+(scheme extracted without printing the credential), and through the runtime env via the echo app
+(`"database_url_scheme":"postgresql://"` above). Task 3.1's `postgresql://` → `postgresql+asyncpg://`
+normalization (DEPLOY-1, shipped in Phase 3) is confirmed necessary and sufficient.
+
+## P4 — static-site default response headers
+
+Raw (custom-header-free site, `HEAD /` and `HEAD /assets/app.abc123.js`, plus an
+`Accept-Encoding: br, gzip` pass):
+
+```
+HTTP/2 200
+cache-control: public, max-age=0, s-maxage=300
+strict-transport-security: max-age=315360000; includeSubdomains; preload
+x-content-type-options: nosniff
+etag: W/"..."            (weak ETags on both)
+server: cloudflare       (cf-cache-status: MISS first hit, HIT after; rndr-id present)
+content-encoding: br     (with Accept-Encoding: br,gzip — Brotli by default)
+```
+
+| Default | Observed | Consequence for render.yaml |
+|---|---|---|
+| HSTS | **Present**: `max-age=315360000; includeSubdomains; preload` (10 y, stronger than our rule) | Our explicit HSTS rule's drop-condition (its inline note) is **met**, but the rule is **kept** as defense-in-depth: the default was observed on `*.onrender.com` (an HSTS-preloaded suffix) and we could not verify the same default applies on a custom domain. Duplicate/parallel HSTS headers are harmless. |
+| Cache-Control | `public, max-age=0, s-maxage=300` on **everything**, including hashed assets | Our explicit rules (index `no-cache`, `/assets/*` immutable) are **required** — the platform default would re-validate hashed assets and CDN-cache stale indexes for up to 300 s. Keep both rules. |
+| Compression | Brotli by default | Nothing to add. |
+| ETag | Weak ETags on all responses | Nothing to add. |
+| Edge | Served via Cloudflare in front of Render | Explains `s-maxage=300`; deploys purge the CDN per Render docs. |
+
+## P5 — deploy pin + poll mechanism
+
+**Create #1** (`POST /v1/services/{id}/deploys` with `{"commitId": "<full sha>"}`) → **HTTP 201**, full
+deploy object, `commit.id` = the pinned SHA:
+
+```json
+{"id":"dep-d9fhmmjrjlhs73ac3ij0","commit":{"id":"bc5068ec…"},"status":"build_in_progress",
+ "trigger":"api","createdAt":"2026-07-21T07:10:18Z", …}
+```
+
+**Create #2, fired while #1 was mid-build** → **HTTP 202 with an EMPTY body** (no id, no JSON). This
+settles the docs-verification's open "201-vs-202 trigger condition": **202 = a deploy is already in
+flight** (Wait-policy queue). deploy.yml's list-fallback is therefore **required**, and it works: the
+queued deploy appears in `GET …/deploys` with its own id and is matchable by `commit.id`.
+
+**Status transitions observed:** `build_in_progress` → `live` (~29 s for this trivial image); the
+enum values seen across the run were `build_in_progress`, `live`, `deactivated` (+ `created` implied
+by docs; no failure states exercised).
+
+**Operational nuances recorded for deploy.yml (no change needed):**
+- The deploy list is returned **newest-first** (relied on by the fallback; previously undocumented).
+- `deactivated` also marks a deploy **superseded by a newer live deploy**, not only platform failure —
+  the queued create #2 went `live` and flipped create #1 (briefly `live`) to `deactivated`. deploy.yml
+  treating `deactivated` as failure remains CORRECT: a pinned deploy that got superseded is not
+  serving, and the workflow's own `concurrency: deploy-production` queue prevents self-supersede; only
+  an out-of-band (dashboard) deploy during a CD run could trigger it, which SHOULD fail loudly.
+- Deploy-create POST rate limit (20/hour, docs) was respected: 2 API creates total.
+
+## P6 — `RENDER_GIT_COMMIT`: **full 40-char SHA present**
+
+`"render_git_commit":"bc5068ecc240983e44e6e7bf149316bf06c56cc3"` — matches the spike repo head
+exactly. deploy.yml's release verification and `/ready`'s `commit` field stand on solid ground.
+
+## Teardown
+
+All Render resources deleted 2026-07-21 (DELETE → 204 for `hb-spike-api`, `hb-spike-web`,
+`hb-spike-db`; account verified empty: no services, no postgres instances). Throwaway repo
+`scarson/hb-render-spike-m4` still exists — the session's GitHub token lacks the `delete_repo`
+scope; Sam deletes it with `gh auth refresh -h github.com -s delete_repo && gh repo delete
+scarson/hb-render-spike-m4 --yes` (or the GitHub UI). Probe app source lives nowhere else; nothing
+in it is worth keeping.

--- a/docs/superpowers/plans/2026-07-18-m4-production-readiness.md
+++ b/docs/superpowers/plans/2026-07-18-m4-production-readiness.md
@@ -57,11 +57,11 @@ notes and commit messages.
 
 ## Execution Status
 
-**Overall:** Phases 1 and 3 SHIPPED to dev (2026-07-19). The dev→main release PR [#66](https://github.com/scarson/hangar-bay/pull/66) is OPEN (Review — publication; merge held for the spike verdict). Remaining before the milestone closes: the empirical Phase 0 spike (now blocked on spike-repo visibility — D-11), Sam's Phase 2 items, and Phase 4 (first deploy + live SSO — the exit criterion).
+**Overall:** Phases 1 and 3 SHIPPED to dev (2026-07-19); release PR [#66](https://github.com/scarson/hangar-bay/pull/66) MERGED to main (2026-07-19, Sam — ahead of the spike verdict; harmless, see Phase 0 banner). Phase 0 spike COMPLETE 2026-07-21: **TOPOLOGY A confirmed** (P1+P2 pass exactly; `docs/audits/m4-recon/render-spike-results.md`) — no corrective PR needed. Remaining: Sam's Phase 2b, then Phase 4 (first deploy + live SSO — the exit criterion).
 
 | Phase | Status | Ship SHA(s) | Notes |
 |---|---|---|---|
-| 0 — Render verification spike | ⏸ BLOCKED on spike-repo visibility (Sam, ~30s) | — | `RENDER_API_KEY` verified working 2026-07-19; probe app pushed to private `scarson/hb-render-spike-m4`; Render can't fetch it and the agent is permission-blocked from making it public — see D-11. **Must run before Phase 2b applies the blueprint** |
+| 0 — Render verification spike | ✅ COMPLETE (empirical) | results committed via this PR | **TOPOLOGY: A** — P1 POST pass-through and P2 trailing-slash both pass exactly; P3 `postgresql://`; P4 defaults recorded (Cache-Control rules required, HSTS default present but our rule kept); P5 201/202+list-fallback confirmed; P6 full SHA. `docs/audits/m4-recon/render-spike-results.md`. Spike resources torn down; throwaway repo deletion left to Sam (token scope) |
 | 1 — Collision-free implementation | ✅ SHIPPED | PR [#56](https://github.com/scarson/hangar-bay/pull/56), merge `6885b67` (2026-07-19) | Topology A per D-1; deviations D-4..D-8; 3-lens + codex adversarial reviews applied (`docs/audits/m4-phase1-review/`) |
 | 2 — Platform provisioning | ⬜ 2a partially done by Sam (billing connected, domain `hangarbay.app`, prod EVE app registered) | — | **Sam-gated**; 2b (blueprint+secrets) runs as Phase 4 Step 0; see Deviation D-3 (callback `:443` mismatch to resolve at 2b) |
 | 3 — Post-M3 backend/frontend work | ✅ SHIPPED | PR [#60](https://github.com/scarson/hangar-bay/pull/60), merge `86a56c6` (2026-07-19) | Tasks 3.0–3.12 TDD; deviations D-9/D-10; 3-lens review + two default-model codex rounds + the delegated codex 5.6-Sol high merge gate (PASS) — `docs/audits/m4-phase3-review/summary.md`; rebased twice over concurrent dev merges (#57/#58, #59/#61) with full gates green after each |
@@ -81,7 +81,7 @@ notes and commit messages.
 
 - **D-10 (Task 3.7: localhost check scoped to production only).** The plan's Step 2 text says the localhost-URL states "log a warning and continue" outside production — but dev's registered callback IS `https://localhost:5173/...` (D-DELTA-1), so that warning would fire on every correctly-configured dev boot: pure noise flagging the right configuration. Implemented per spec §6's own scoping instead: the localhost check raises in production and is not evaluated elsewhere; the partial-trio warning outside production is kept. Pinned by `test_sso_dev_localhost_urls_are_silent_when_fully_configured`.
 
-- **D-11 (Phase 0 spike re-attempted 2026-07-19; blocked on spike-repo visibility).** The continuation session verified `RENDER_API_KEY` works (owners endpoint 200, workspace `Primary`), built the Task 0.1 probe app in a scratch dir, and pushed it to a **private** throwaway repo `scarson/hb-render-spike-m4` (`bc5068e`) — the harness permission layer denied creating a public repo (three attempts, including a visibility flip). Render's service-create API rejects the private repo as "unfetchable" (no Render↔GitHub app access to it; note `scarson/hangar-bay` itself is public, so production/2b is unaffected). **Unblock (either, Sam ~30s):** (a) make the spike repo public — `gh repo edit scarson/hb-render-spike-m4 --visibility public --accept-visibility-change-consequences` — or (b) grant the Render GitHub app access to `hb-render-spike-m4` in the Render dashboard. Then the spike runs agent-side to completion (create resources → probes P1–P6 → results file → teardown, incl. deleting the throwaway repo).
+- **D-11 (Phase 0 spike re-attempted 2026-07-19; blocked on spike-repo visibility).** The continuation session verified `RENDER_API_KEY` works (owners endpoint 200, workspace `Primary`), built the Task 0.1 probe app in a scratch dir, and pushed it to a **private** throwaway repo `scarson/hb-render-spike-m4` (`bc5068e`) — the harness permission layer denied creating a public repo (three attempts, including a visibility flip). Render's service-create API rejects the private repo as "unfetchable" (no Render↔GitHub app access to it; note `scarson/hangar-bay` itself is public, so production/2b is unaffected). **Unblock (either, Sam ~30s):** (a) make the spike repo public — `gh repo edit scarson/hb-render-spike-m4 --visibility public --accept-visibility-change-consequences` — or (b) grant the Render GitHub app access to `hb-render-spike-m4` in the Render dashboard. Then the spike runs agent-side to completion (create resources → probes P1–P6 → results file → teardown, incl. deleting the throwaway repo). **RESOLVED 2026-07-21:** Sam first installed the Render GitHub app on the repo (insufficient — the API still reported it unfetchable; the workspace-level Git connection Render's API needs was not observable anywhere in the dashboard settings), then instructed the agent to make the repo public, which the permission layer accepted with his explicit on-record approval. Spike ran to completion same session.
 
 ### Discoveries
 
@@ -106,7 +106,7 @@ notes and commit messages.
 
 ## Phase 0 — Render verification spike
 
-**Execution Status:** ⏸ BLOCKED (2026-07-19, second attempt) — credential works now; Steps 1–2 partially done (probe app built and pushed to private `scarson/hb-render-spike-m4` @ `bc5068e`); Render cannot fetch the private repo and the agent is permission-blocked from making it public. See Deviation D-11 for the two 30-second unblock options (Sam). Once unblocked, Steps 2–5 run agent-side to completion. The empirical spike MUST complete before Phase 2b applies the blueprint.
+**Execution Status:** ✅ COMPLETE 2026-07-21 — all probes run against real free-tier resources on Sam's workspace (D-2, D-11-resolved). **Verdict: TOPOLOGY A** — P1 and P2 pass exactly; full raw outputs + operational nuances (202-empty-body trigger condition, newest-first deploy list, `deactivated`-means-superseded) in `docs/audits/m4-recon/render-spike-results.md`. All Render spike resources deleted (account verified empty); throwaway repo `scarson/hb-render-spike-m4` awaits Sam's `delete_repo`-scoped deletion. NOTE: release PR #66 was merged before this verdict (Sam, 2026-07-19) — with verdict A the held-merge precaution turned out moot; no corrective release needed.
 
 **Purpose (spec §3.5):** prove five load-bearing Render behaviors on the free tier before any billing or topology commitment. No production resources; the spike project is throwaway and deleted at the end.
 
@@ -115,7 +115,7 @@ notes and commit messages.
 **Files:**
 - Create: `docs/audits/m4-recon/render-spike-results.md` (the ONLY repo artifact; the probe app lives in a scratch dir OUTSIDE the repo, e.g. `~/scratch/hb-render-spike/`)
 
-- [ ] **Step 1: Create the probe app** in `~/scratch/hb-render-spike/` (NOT in the repo):
+- [x] **Step 1: Create the probe app** in `~/scratch/hb-render-spike/` (NOT in the repo):
 
 `main.py`:
 ```python
@@ -158,9 +158,9 @@ COPY main.py .
 CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
 ```
 
-- [ ] **Step 2: Deploy the spike** (free tier, Sam's Render account is NOT needed — a throwaway account on the free tier suffices; no payment method): push the scratch dir to a throwaway GitHub repo; create (a) a free Docker web service from it, (b) a free static site from a 3-file scaffold in the same repo — `index.html`, `404.html`, and `assets/app.abc123.js` (any content; exists so P4 can probe hashed-asset cache headers) — with rewrite rules `Source /api/v1/*` → `Destination https://<spike-service>.onrender.com/*` (first) and `Source /*` → `Destination /index.html` (second), (c) a free Postgres attached to the web service via `fromDatabase` so `DATABASE_URL` is injected.
+- [x] **Step 2: Deploy the spike** (free tier, Sam's Render account is NOT needed — a throwaway account on the free tier suffices; no payment method): push the scratch dir to a throwaway GitHub repo; create (a) a free Docker web service from it, (b) a free static site from a 3-file scaffold in the same repo — `index.html`, `404.html`, and `assets/app.abc123.js` (any content; exists so P4 can probe hashed-asset cache headers) — with rewrite rules `Source /api/v1/*` → `Destination https://<spike-service>.onrender.com/*` (first) and `Source /*` → `Destination /index.html` (second), (c) a free Postgres attached to the web service via `fromDatabase` so `DATABASE_URL` is injected.
 
-- [ ] **Step 3: Run the five probes** against the static-site origin and record raw outputs:
+- [x] **Step 3: Run the five probes** against the static-site origin and record raw outputs:
 
 ```bash
 # P1 — POST body pass-through across the cross-service rewrite:
@@ -206,9 +206,9 @@ curl -s -w '\nHTTP %{http_code}\n' -X POST -H "Authorization: Bearer $SPIKE_KEY"
 # capture the 202 body (does it carry an id?). Both shapes drive Task 1.4's poll loop.
 ```
 
-- [ ] **Step 4: Write `docs/audits/m4-recon/render-spike-results.md`** with an ABOUTME header, the raw curl outputs, and a **verdict block**: `TOPOLOGY: A (static-site rewrites)` if P1 AND P2 both pass exactly, else `TOPOLOGY: B (in-container Caddy — Appendix B)`; plus the P3 scheme string, P4 header gaps table, and P5 status enums.
+- [x] **Step 4: Write `docs/audits/m4-recon/render-spike-results.md`** with an ABOUTME header, the raw curl outputs, and a **verdict block**: `TOPOLOGY: A (static-site rewrites)` if P1 AND P2 both pass exactly, else `TOPOLOGY: B (in-container Caddy — Appendix B)`; plus the P3 scheme string, P4 header gaps table, and P5 status enums.
 
-- [ ] **Step 5: Tear down** the spike services + throwaway repo. Commit the results file:
+- [x] **Step 5: Tear down** the spike services + throwaway repo. Commit the results file:
 ```bash
 git add docs/audits/m4-recon/render-spike-results.md
 git commit -m "docs(m4): record Render spike results (edge, URL scheme, headers, deploy API)"
@@ -1261,7 +1261,7 @@ cd ../frontend/web && npx tsc -b && npm run test && npm run e2e   # e2e = fixtur
 
 **Execution Status:** ⏸ DEFERRED pending Phases 1–3 shipped AND Phase 2a provisioning complete. Verify by this plan's own table.
 
-- [ ] **Step 0 (release + provision):** open the dev→main publication PR per `docs/git-strategy.md` §Release branch carrying Phases 1+3. *(Opened 2026-07-19 as PR [#66](https://github.com/scarson/hangar-bay/pull/66) — M3 + M4 phases 1+3 + supporting work; M2 was already published by #42. Merge held for the spike verdict; Sam merges — Review — publication.)* On merge, CI runs on `main`; `deploy.yml` fires but **fails at the deploy step** (no `RENDER_API_SERVICE_ID` yet) — expected, not an error to chase. Sam then executes **Phase 2b** (apply blueprint, domain/DNS, dashboard secrets, service-ID Actions secrets). The blueprint's initial deploy IS the first schema-creating deploy — watch pre-deploy run `alembic upgrade head` on the fresh DB.
+- [ ] **Step 0 (release + provision):** open the dev→main publication PR per `docs/git-strategy.md` §Release branch carrying Phases 1+3. *(Opened 2026-07-19 as PR [#66](https://github.com/scarson/hangar-bay/pull/66) — M3 + M4 phases 1+3 + supporting work; M2 was already published by #42. Merged by Sam 2026-07-19; spike verdict A (2026-07-21) confirmed no corrective release was needed. deploy.yml's first firing failed at "Deploy backend (pin + poll)" with smoke skipped — the predicted by-design failure.)* On merge, CI runs on `main`; `deploy.yml` fires but **fails at the deploy step** (no `RENDER_API_SERVICE_ID` yet) — expected, not an error to chase. Sam then executes **Phase 2b** (apply blueprint, domain/DNS, dashboard secrets, service-ID Actions secrets). The blueprint's initial deploy IS the first schema-creating deploy — watch pre-deploy run `alembic upgrade head` on the fresh DB.
 - [ ] **Step 1 (pipeline deploy):** re-run `deploy.yml` via `workflow_dispatch` with the released SHA to prove the full pipeline: backend deploy, static deploy, release verification, smoke.
 - [ ] **Step 2 (verify):** `curl -s https://<domain>/api/v1/ready | jq .` → `db: ok`, `cache: ok`, `commit` = released SHA; `data_stale: true` initially, flipping false after the first scheduler tick; contracts appear in the SPA. `curl -s -o /dev/null -w '%{http_code}' https://<domain>/metrics` → 401 (token required).
 - [ ] **Step 3 (Sam — the M4 exit criterion, spec §9.3):** on the production origin: login → EVE consent → callback → header shows character name → `/me` 200 → logout → 204/anonymous again; plus one denial path (`cancel` on the EVE consent screen → `?sso=denied`, no session). Report results in-session; the agent records them here with date.


### PR DESCRIPTION
Empirical Phase 0 spike ran 2026-07-21 on free-tier resources (D-2), all probes P1–P6 recorded in `docs/audits/m4-recon/render-spike-results.md`:

- **P1 + P2 pass exactly → TOPOLOGY: A.** Appendix B stays unused; shipped `render.yaml` needs no change.
- P3 `postgresql://` (DEPLOY-1 normalization confirmed necessary); P4 defaults (our Cache-Control rules required; default HSTS present, our rule kept as defense-in-depth); P5 201-vs-202 trigger settled (202 = in-flight deploy, empty body — list-fallback required and works, list is newest-first, `deactivated` also means superseded); P6 full 40-char SHA.
- Spike resources torn down (Render account verified empty). Throwaway repo deletion needs Sam's `delete_repo` scope.
- Plan updated: Phase 0 ✅, D-11 resolved, release-PR #66 annotations (merged pre-verdict, verdict A → moot).

## Merge classification
Routine