### PR TITLE
build(api): upgrade asyncpg to 0.31.0 (official PG18 support, cp314 wheels)

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install --no-cache-dir pdm
 COPY pyproject.toml pdm.lock ./
 RUN pdm export --prod -o requirements.txt --without-hashes
 
-# The locked asyncpg/httptools/uvloop versions publish no CPython 3.14 wheels, so they
+# The locked httptools/uvloop versions publish no CPython 3.14 wheels, so they
 # compile from source — this stage carries the compiler; the runtime stage stays slim.
 FROM python:3.14-slim AS build
 WORKDIR /app

--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:765a1de244802cc49c8229adb916d14ca39da16755747cb3457863914c646d53"
+content_hash = "sha256:5ed6379bf6fb76d3706c1946f53fb029d7bbb5d54bb01de43bba31cbdac6955e"
 
 [[metadata.targets]]
 requires_python = ">=3.14"
@@ -113,39 +113,31 @@ files = [
 
 [[package]]
 name = "asyncpg"
-version = "0.30.0"
-requires_python = ">=3.8.0"
+version = "0.31.0"
+requires_python = ">=3.9.0"
 summary = "An asyncio PostgreSQL driver"
 groups = ["default"]
 dependencies = [
     "async-timeout>=4.0.3; python_version < \"3.11.0\"",
 ]
 files = [
-    {file = "asyncpg-0.30.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5e0511ad3dec5f6b4f7a9e063591d407eee66b88c14e2ea636f187da1dcfff6a"},
-    {file = "asyncpg-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:915aeb9f79316b43c3207363af12d0e6fd10776641a7de8a01212afd95bdf0ed"},
-    {file = "asyncpg-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c198a00cce9506fcd0bf219a799f38ac7a237745e1d27f0e1f66d3707c84a5a"},
-    {file = "asyncpg-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3326e6d7381799e9735ca2ec9fd7be4d5fef5dcbc3cb555d8a463d8460607956"},
-    {file = "asyncpg-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:51da377487e249e35bd0859661f6ee2b81db11ad1f4fc036194bc9cb2ead5056"},
-    {file = "asyncpg-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bc6d84136f9c4d24d358f3b02be4b6ba358abd09f80737d1ac7c444f36108454"},
-    {file = "asyncpg-0.30.0-cp311-cp311-win32.whl", hash = "sha256:574156480df14f64c2d76450a3f3aaaf26105869cad3865041156b38459e935d"},
-    {file = "asyncpg-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:3356637f0bd830407b5597317b3cb3571387ae52ddc3bca6233682be88bbbc1f"},
-    {file = "asyncpg-0.30.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c902a60b52e506d38d7e80e0dd5399f657220f24635fee368117b8b5fce1142e"},
-    {file = "asyncpg-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aca1548e43bbb9f0f627a04666fedaca23db0a31a84136ad1f868cb15deb6e3a"},
-    {file = "asyncpg-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c2a2ef565400234a633da0eafdce27e843836256d40705d83ab7ec42074efb3"},
-    {file = "asyncpg-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1292b84ee06ac8a2ad8e51c7475aa309245874b61333d97411aab835c4a2f737"},
-    {file = "asyncpg-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5712350388d0cd0615caec629ad53c81e506b1abaaf8d14c93f54b35e3595a"},
-    {file = "asyncpg-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db9891e2d76e6f425746c5d2da01921e9a16b5a71a1c905b13f30e12a257c4af"},
-    {file = "asyncpg-0.30.0-cp312-cp312-win32.whl", hash = "sha256:68d71a1be3d83d0570049cd1654a9bdfe506e794ecc98ad0873304a9f35e411e"},
-    {file = "asyncpg-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a0292c6af5c500523949155ec17b7fe01a00ace33b68a476d6b5059f9630305"},
-    {file = "asyncpg-0.30.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05b185ebb8083c8568ea8a40e896d5f7af4b8554b64d7719c0eaa1eb5a5c3a70"},
-    {file = "asyncpg-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c47806b1a8cbb0a0db896f4cd34d89942effe353a5035c62734ab13b9f938da3"},
-    {file = "asyncpg-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b6fde867a74e8c76c71e2f64f80c64c0f3163e687f1763cfaf21633ec24ec33"},
-    {file = "asyncpg-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46973045b567972128a27d40001124fbc821c87a6cade040cfcd4fa8a30bcdc4"},
-    {file = "asyncpg-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9110df111cabc2ed81aad2f35394a00cadf4f2e0635603db6ebbd0fc896f46a4"},
-    {file = "asyncpg-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04ff0785ae7eed6cc138e73fc67b8e51d54ee7a3ce9b63666ce55a0bf095f7ba"},
-    {file = "asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590"},
-    {file = "asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e"},
-    {file = "asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851"},
+    {file = "asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44"},
+    {file = "asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5"},
+    {file = "asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2"},
+    {file = "asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2"},
+    {file = "asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218"},
+    {file = "asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d"},
+    {file = "asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b"},
+    {file = "asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3"},
+    {file = "asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735"},
 ]
 
 [[package]]

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Default template for PDM package"
 authors = [
     {name = "Samuel Carson", email = "samuel.carson@gmail.com"},
 ]
-dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.139.0", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.30.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=8.0.2", "cryptography>=49.0.0", "pyjwt[crypto]>=2.13.0"]
+dependencies = ["pydantic-settings>=2.9.1", "fastapi>=0.139.0", "uvicorn[standard]>=0.34.3", "python-dotenv>=1.1.0", "asyncpg>=0.31.0", "redis>=6.2.0", "SQLAlchemy[asyncio]>=2.0.41", "alembic>=1.16.1", "aiosqlite>=0.21.0", "httpx>=0.28.1", "psycopg2-binary>=2.9.10", "APScheduler>=3.11.0", "greenlet>=3.2.3", "async-timeout<5", "structlog>=25.4.0", "prometheus-fastapi-instrumentator>=8.0.2", "cryptography>=49.0.0", "pyjwt[crypto]>=2.13.0"]
 requires-python = ">=3.14"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## What changed

- Bumped `asyncpg` from 0.30.0 to 0.31.0 (latest stable on PyPI) in `app/backend/pyproject.toml`, with `pdm update asyncpg` regenerating `pdm.lock`. The lock diff touches only the asyncpg entry (version, `requires_python`, wheel list) plus the content hash — no other package moved.
- Updated the Dockerfile build-stage comment: it claimed asyncpg/httptools/uvloop all lack CPython 3.14 wheels, which is now false for asyncpg. The build stage itself is unchanged and stays — **httptools and uvloop still publish no cp314 wheels** and continue to compile from source.

## Why

asyncpg 0.31.0 adds official PostgreSQL 18 support; production Postgres is being recreated at PG18 in a parallel track. It also ships cp314 wheels (16 cp314 wheel entries now in the lock), so asyncpg installs from a wheel instead of compiling in the Docker build stage.

Checked for known regressions against SQLAlchemy 2.0.41 before bumping; none found in the asyncpg changelog or SQLAlchemy issue tracker.

## Verification

From `app/backend` in the worktree, against a dedicated scratch database (`hangar_bay_tests_asyncpg_bump`) to avoid shared-test-DB contention:

- `pdm run lint` — clean (flake8, no output)
- `pdm run pytest` — **445 passed in 24.07s**, zero failures, zero warnings
- `pdm run python -c "import asyncpg; print(asyncpg.__version__)"` → `0.31.0`

## Merge classification

Routine

🤖 Generated with [Claude Code](https://claude.com/claude-code)