### PR TITLE
fix: in-memory scheduler jobstore + interval-derived aggregation lock TTL (Jul 23 production incident)

### DIFF
--- a/app/backend/src/fastapi_app/api/ops.py
+++ b/app/backend/src/fastapi_app/api/ops.py
@@ -41,10 +41,10 @@ async def _probe_cache(request: Request) -> tuple[bool, object]:
     The client comes straight off app.state, NOT the get_cache dependency — that
     dependency raises when startup init failed, which would replace the structured
     readiness body with a bare 503 and never re-probe. A missing client gets one
-    reinit attempt per call. Reachability note: a Valkey outage that persists through
-    startup crashes the process at scheduler.start() (RedisJobStore) before /ready ever
-    serves — platform restarts recover that case; this reinit covers the narrower blip
-    where init_cache's single ping failed but Valkey returned afterwards.
+    reinit attempt per call. Reachability note: startup tolerates a Valkey outage —
+    init_cache logs CRITICAL and leaves the client unset, and the scheduler's jobstore
+    is in-memory (DEPLOY-3) so scheduler.start() never touches the cache; this per-call
+    reinit is what recovers the cache client once Valkey returns.
     """
     try:
         async with asyncio.timeout(READINESS_CHECK_TIMEOUT_SECONDS):

--- a/app/backend/src/fastapi_app/core/scheduler.py
+++ b/app/backend/src/fastapi_app/core/scheduler.py
@@ -1,9 +1,7 @@
 import logging
 from datetime import datetime, timedelta  # Added for next_run_time
 
-from urllib.parse import urlparse
-
-from apscheduler.jobstores.redis import RedisJobStore
+from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 
@@ -17,15 +15,12 @@ logger = logging.getLogger(__name__)
 
 def create_scheduler(app: FastAPI, settings: Settings) -> AsyncIOScheduler:
     """Creates and configures the APScheduler instance."""
-    redis_url = urlparse(settings.CACHE_URL)
-    jobstores = {
-        "default": RedisJobStore(
-            host=redis_url.hostname,
-            port=redis_url.port,
-            db=int(redis_url.path.lstrip("/") or 0),
-            password=redis_url.password,
-        )
-    }
+    # In-memory jobstore, deliberately: the lifespan re-registers every job on
+    # boot (replace_existing=True), so persisting job records buys nothing —
+    # and a cache-backed store colocates them with a Valkey instance running
+    # allkeys-lru, where memory pressure silently evicts the jobs and the
+    # scheduler ticks nothing, with zero errors (DEPLOY-3).
+    jobstores = {"default": MemoryJobStore()}
     scheduler = AsyncIOScheduler(jobstores=jobstores)
     app.state.scheduler = scheduler
     return scheduler

--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -24,8 +24,11 @@ logger = logging.getLogger(__name__)
 
 # Lock key for Redis to ensure only one aggregation job runs at a time.
 AGGREGATION_LOCK_KEY = "hangar-bay:aggregation:lock"
-# Lock timeout in seconds. Should be longer than a typical aggregation run.
-AGGREGATION_LOCK_TIMEOUT = 1800  # 30 minutes
+# Margin added to the scheduler interval to form the lock TTL (see _lock_ttl_seconds):
+# the TTL must strictly exceed the interval so a run that outlasts its own interval
+# still holds the lock when the overlapping tick fires, and the margin keeps it held
+# through that tick's acquisition attempt.
+AGGREGATION_LOCK_TTL_MARGIN_SECONDS = 300
 # Freshness record for the last aggregation run (design spec §8.2): JSON
 # {finished_at, outcome, regions_ok, regions_failed, last_success_at}, no TTL —
 # overwritten each run; lost on cache restart, which self-heals within one tick.
@@ -149,6 +152,16 @@ class ContractAggregationService:
         self.esi_client = esi_client
         self.settings = settings  # Assign the injected settings
 
+    def _lock_ttl_seconds(self) -> int:
+        """Mutual-exclusion window for one aggregation run: the scheduler interval
+        plus a margin. A fixed TTL shorter than a real run expires mid-run, at which
+        point the next tick can legally start a concurrent run — deriving from the
+        interval keeps the window ahead of any run the schedule can overlap."""
+        return (
+            self.settings.AGGREGATION_SCHEDULER_INTERVAL_SECONDS
+            + AGGREGATION_LOCK_TTL_MARGIN_SECONDS
+        )
+
     @asynccontextmanager
     async def _concurrency_lock(self):
         """
@@ -156,13 +169,14 @@ class ContractAggregationService:
         Creates its own Redis client on-demand.
         """
         redis_client = aioredis.from_url(str(self.settings.CACHE_URL))
+        lock_ttl = self._lock_ttl_seconds()
         # Unique fencing token: the lock value identifies THIS runner so release
         # can verify ownership (see _RELEASE_LOCK_LUA) instead of blindly deleting.
         lock_token = uuid.uuid4().hex
         lock_acquired = False
         try:
             lock_acquired = await redis_client.set(
-                AGGREGATION_LOCK_KEY, lock_token, nx=True, ex=AGGREGATION_LOCK_TIMEOUT
+                AGGREGATION_LOCK_KEY, lock_token, nx=True, ex=lock_ttl
             )
             if not lock_acquired:
                 logger.warning("Contract aggregation job is already running. Skipping this run.")
@@ -190,7 +204,7 @@ class ContractAggregationService:
                         "Aggregation lock token mismatch on release: the %ss lock TTL "
                         "likely expired mid-run and was reacquired by another runner. "
                         "Leaving the current holder's lock intact.",
-                        AGGREGATION_LOCK_TIMEOUT,
+                        lock_ttl,
                     )
             await redis_client.close()  # Ensure redis client is closed
 

--- a/app/backend/src/fastapi_app/services/scheduled_jobs.py
+++ b/app/backend/src/fastapi_app/services/scheduled_jobs.py
@@ -26,7 +26,7 @@ async def run_aggregation_job(aggregation_service: ContractAggregationService):
 
 
 async def run_watchlist_matcher_job(matcher_service):
-    """Top-level, importable wrapper for the watchlist matcher (RedisJobStore pickles the reference)."""
+    """Scheduler job entrypoint for the watchlist matcher; never propagates exceptions."""
     logger.info("Executing scheduled job: run_watchlist_matcher_job")
     try:
         await matcher_service.run_matching()

--- a/app/backend/src/fastapi_app/services/watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/services/watchlist_matcher.py
@@ -49,8 +49,8 @@ def _render_message(type_name: str, contract_type: str, price, location: Optiona
 
 
 class WatchlistMatcherService:
-    """Picklable (no live clients at rest) so RedisJobStore can persist the job — mirrors
-    ContractAggregationService. `now_fn` stays None in production (a lambda would not pickle);
+    """Holds no live clients at rest — Redis/DB connections are created per run — mirroring
+    ContractAggregationService. `now_fn` stays None in production;
     tests inject a fixed clock for the retention boundary."""
 
     def __init__(self, settings: Settings, now_fn: Optional[Callable[[], datetime]] = None):

--- a/app/backend/src/fastapi_app/tests/core/test_scheduler.py
+++ b/app/backend/src/fastapi_app/tests/core/test_scheduler.py
@@ -1,0 +1,27 @@
+# ABOUTME: Tests for APScheduler construction — jobstore choice and app.state wiring.
+# ABOUTME: Pins the in-memory jobstore: scheduler state must never live in an evicting cache.
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.jobstores.redis import RedisJobStore
+from fastapi import FastAPI
+
+from fastapi_app.core.config import settings
+from fastapi_app.core.scheduler import create_scheduler
+
+
+def test_create_scheduler_uses_in_memory_jobstore():
+    """The lifespan re-registers every job on boot (replace_existing=True), so a
+    persistent jobstore adds nothing — while a Redis-backed one colocates the
+    scheduler's job records with a cache running allkeys-lru, where memory
+    pressure silently evicts them: no due jobs, no errors, no ticks (production
+    outage 2026-07-23, 3.6 days without a scheduler tick)."""
+    app = FastAPI()
+    scheduler = create_scheduler(app, settings)
+    store = scheduler._jobstores["default"]
+    assert isinstance(store, MemoryJobStore)
+    assert not isinstance(store, RedisJobStore)
+
+
+def test_create_scheduler_attaches_scheduler_to_app_state():
+    app = FastAPI()
+    scheduler = create_scheduler(app, settings)
+    assert app.state.scheduler is scheduler

--- a/app/backend/src/fastapi_app/tests/lock_double.py
+++ b/app/backend/src/fastapi_app/tests/lock_double.py
@@ -7,11 +7,15 @@ class FakeLockRedis:
 
     def __init__(self, store: dict):
         self.store = store
+        # Records the ex= (TTL seconds) each successful set carried, keyed like store —
+        # lets tests assert on the mutual-exclusion window, not just key presence.
+        self.set_ttls: dict = {}
 
     async def set(self, key, value, nx=False, ex=None):
         if nx and key in self.store:
             return None
         self.store[key] = value
+        self.set_ttls[key] = ex
         return True
 
     async def get(self, key):

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -283,6 +283,35 @@ async def test_lock_release_deletes_only_its_own_token():
         assert bg_agg.AGGREGATION_LOCK_KEY not in store  # released after
 
 
+async def test_lock_ttl_exceeds_the_scheduler_interval():
+    """The lock TTL is the mutual-exclusion window: if it is shorter than a real
+    run, it expires mid-run and the next scheduler tick legally starts a second
+    concurrent run (production 2026-07-23: a ~70-minute run overran a fixed
+    1800s TTL). The TTL must strictly exceed the tick interval so the one
+    overlapping tick always finds the lock held and skips."""
+    store: dict = {}
+    fake = _FakeLockRedis(store)
+    with patch.object(bg_agg.aioredis, "from_url", return_value=fake):
+        service = _make_service()
+        service.settings.AGGREGATION_SCHEDULER_INTERVAL_SECONDS = 3600
+        async with service._concurrency_lock():
+            pass
+    assert fake.set_ttls[bg_agg.AGGREGATION_LOCK_KEY] > 3600
+
+
+async def test_lock_ttl_follows_a_reconfigured_interval():
+    """The window must track the configured interval — a constant merely raised
+    above today's interval silently re-opens the gap when the interval grows."""
+    store: dict = {}
+    fake = _FakeLockRedis(store)
+    with patch.object(bg_agg.aioredis, "from_url", return_value=fake):
+        service = _make_service()
+        service.settings.AGGREGATION_SCHEDULER_INTERVAL_SECONDS = 7200
+        async with service._concurrency_lock():
+            pass
+    assert fake.set_ttls[bg_agg.AGGREGATION_LOCK_KEY] > 7200
+
+
 async def test_lock_release_does_not_delete_a_reacquired_lock(caplog):
     """If the TTL expires mid-run and a second runner reacquires the key, the
     first runner's finally must NOT delete the second runner's lock (fencing

--- a/app/backend/src/fastapi_app/tests/services/test_scheduled_jobs_watchlist.py
+++ b/app/backend/src/fastapi_app/tests/services/test_scheduled_jobs_watchlist.py
@@ -26,7 +26,8 @@ def test_add_watchlist_matcher_job_registers_expected_id():
 
 def test_matcher_service_is_picklable():
     import pickle
-    # RedisJobStore pickles the job func + args; the SERVICE itself must round-trip (a MagicMock
+    # The service must hold only inert, picklable state at rest — a pickle round-trip is the
+    # cheap detector for a live client or closure sneaking into the constructor (a MagicMock
     # settings or a lambda now_fn would break this — use the real settings singleton).
     from fastapi_app.core.config import settings as real_settings
     svc = WatchlistMatcherService(settings=real_settings, now_fn=None)

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -30,7 +30,7 @@ This document serves three audiences. Start here, then go directly to the sectio
 | 2 | [Data & Persistence](#section-2-data--persistence) | SQLAlchemy queries, pagination over joins | SQLA-1, SQLA-2 | §2.C |
 | 3 | [Environment & Dev Loop](#section-3-environment--dev-loop) | Settings/env loading, startup ingestion, dev-server hygiene | ENV-1, ENV-2, ENV-3, ENV-4, ENV-5, ENV-6, ENV-7, ENV-8 | §3.C |
 | 4 | [External Integrations (ESI)](#section-4-external-integrations-esi) | Calling EVE's ESI API — route versions, deprecations, upstream status | ESI-1 | §4.C |
-| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2 | §5.C |
+| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3 | §5.C |
 | — | [Orchestration](#orchestration) | Parallel subagent dispatch and output persistence | ORCH-1 | §Orchestration.C |
 | A | [Historical Changelog](#appendix-a-historical-changelog) | Provenance, validation dates, review process meta-observations | — | — |
 | B | [Unified Summary Table](#appendix-b-unified-summary-table) | All pitfalls at a glance, with severity and status | — | — |
@@ -288,10 +288,23 @@ This document serves three audiences. Start here, then go directly to the sectio
 
 ---
 
+### DEPLOY-3: Durable coordination state must not live in an evicting cache (`allkeys-lru`)
+
+**The Flaw:** APScheduler's job records lived in a `RedisJobStore` pointed at the production Valkey instance — the same instance configured `maxmemoryPolicy: allkeys-lru` (render.yaml; free tier ~25 MB) that absorbs the ESI ETag cache. State the system needs to KEEP was colocated with a cache explicitly licensed to delete any key under memory pressure.
+
+**Why It Matters:** Eviction of jobstore keys is a *silent, total* scheduler outage: missing keys mean "no due jobs", so nothing fires and nothing errors. On 2026-07-23 an uncapped aggregation run ETag-cached 155k+ contract items, drove the instance into LRU eviction, and the jobstore keys were evicted with the rest — last scheduler tick `01:34:45Z Jul 23`, zero jobs fired for 3.6 days, zero error lines, stale data served while `/ready` correctly reported `data_stale`. Restarts revive it only because the lifespan re-registers jobs at boot.
+
+**The Fix:** The scheduler uses an in-memory jobstore (`core/scheduler.py`; pinned by `tests/core/test_scheduler.py`): every job is re-registered on boot with `replace_existing=True`, so cache-backed persistence bought nothing while exposing scheduler state to eviction. The general rule: state whose loss is silent and must outlive cache pressure (job stores, durable queues, registries) never goes into an `allkeys-lru` instance — keep it in-process or in the database. Cross-run locks are the tolerable exception: they self-expire by design, and eviction merely widens a concurrency window the TTL already bounds — provided the TTL actually covers a real run (the aggregation lock TTL derives from the scheduler interval in `services/background_aggregation.py` for exactly that reason).
+
+**Where It Bit Us:** Production Render deployment, diagnosed 2026-07-26 from live logs: last tick logged `01:34:45Z` Jul 23, then 3.6 days of silence with the app serving stale data. The same logs surfaced the companion lock finding — a ~70-minute run overran the then-fixed 1800s lock TTL ("Aggregation lock token mismatch on release: the 1800s lock TTL likely expired mid-run…"), meaning the mutual-exclusion window was shorter than real run durations.
+
+---
+
 ### §5.C — Review Checklist
 
 - [ ] **`DATABASE_URL` reaches the engine driver-qualified** — the Settings validator normalizes `postgresql://`; no code assumes the platform sends `+asyncpg` (DEPLOY-1)
 - [ ] **Every production launch command pins `--workers 1`** — scaling proposals split the scheduler out instead of raising the worker count (DEPLOY-2)
+- [ ] **Nothing the app must retain lives in the evicting Valkey** — job stores and other silent-loss durable state stay out of `allkeys-lru` instances; cross-run lock TTLs cover a real run, not an unrelated constant (DEPLOY-3)
 
 ---
 
@@ -318,6 +331,10 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 ---
 
 # Appendix A: Historical Changelog
+
+## 2026-07-26 — DEPLOY-3 added: jobstore keys evicted by the allkeys-lru Valkey
+
+- Added DEPLOY-3 (durable coordination state must not share an `allkeys-lru` cache) from the Jul 23–26 production incident: LRU eviction deleted the `RedisJobStore` keys and the scheduler went silent for 3.6 days with zero errors. Fix shipped in the same PR: in-memory jobstore (`core/scheduler.py`) + aggregation lock TTL derived from the scheduler interval (`services/background_aggregation.py`), both TDD-pinned.
 
 ## 2026-07-19 — ENV-8 added: worktrees lack gitignored credential files
 
@@ -382,6 +399,7 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 | ESI-1 | Pin ESI route versions; avoid removed legacy/meta routes | LOW | VALIDATED | External Integrations (ESI) |
 | DEPLOY-1 | Managed platforms inject postgresql:// URLs; async stack needs +asyncpg | HIGH | VALIDATED | Deployment & Platform |
 | DEPLOY-2 | uvicorn stays --workers 1 (in-process scheduler) | MEDIUM | VALIDATED | Deployment & Platform |
+| DEPLOY-3 | Durable coordination state must not live in an evicting cache | HIGH | VALIDATED | Deployment & Platform |
 | ORCH-1 | Analysis Dispatches Must Persist Findings | HIGH | VALIDATED | Orchestration |
 
 Severity levels: `CRITICAL` (production data loss / security), `HIGH` (correctness bug under predictable conditions), `MEDIUM` (correctness bug under edge cases), `LOW` (cleanliness / clarity / dev-loop hazard).


### PR DESCRIPTION
## Summary

Fixes the Jul 23–26 production scheduler outage. Root cause: APScheduler's `RedisJobStore` keys lived in the production Valkey configured `maxmemoryPolicy: allkeys-lru`; on 2026-07-23 an uncapped aggregation run ETag-cached 155k+ contract items, LRU eviction deleted the jobstore keys, and the scheduler went silent — last tick `01:34:45Z Jul 23`, zero jobs for 3.6 days, zero error lines (missing keys = "no due jobs"), stale data served while `/ready` correctly reported `data_stale`.

- **`core/scheduler.py`** — jobstore switched to `MemoryJobStore`. The lifespan re-registers every job on boot (`replace_existing=True`), so Redis persistence provided nothing while exposing scheduler state to cache eviction (DEPLOY-3).
- **`services/background_aggregation.py`** — the aggregation lock TTL now derives from the scheduler interval (`AGGREGATION_SCHEDULER_INTERVAL_SECONDS + 300s margin`) instead of a fixed 1800s. Same incident's logs showed a ~70-minute run overrunning the 1800s TTL ("Aggregation lock token mismatch on release: the 1800s lock TTL likely expired mid-run…"), i.e. the mutual-exclusion window was shorter than real runs. No locking redesign — no heartbeat/renewal (M5 scope).
- **`docs/pitfalls/implementation-pitfalls.md`** — DEPLOY-3 added (entry, §5.C checklist item, TOC, Appendix A changelog, Appendix B row): never colocate durable coordination state with an evicting cache.
- **Comment sweep** — the four comments/docstrings that stated the RedisJobStore pickling contract (`api/ops.py`, `services/watchlist_matcher.py`, `services/scheduled_jobs.py`, `tests/services/test_scheduled_jobs_watchlist.py`) were rewritten to the invariants that remain (startup no longer crashes at `scheduler.start()` on a Valkey outage; job entrypoints stay top-level; services hold no live clients at rest).

## Test intent preserved, not deleted

`test_matcher_service_is_picklable` pinned a RedisJobStore-motivated property (jobstore pickles func + args). It is kept with its intent rewritten: the pickle round-trip now documents/detects "no live clients or closures at rest in the service", which remains a real design invariant of both job services.

## TDD evidence (RED before GREEN, mutation-verified per TEST-12)

**Jobstore (`tests/core/test_scheduler.py`), RED before the fix:**
```
>       assert isinstance(store, MemoryJobStore)
E       assert False
E        +  where False = isinstance(<RedisJobStore>, MemoryJobStore)
FAILED src/fastapi_app/tests/core/test_scheduler.py::test_create_scheduler_uses_in_memory_jobstore
```
**Mutation-verify** (production code flipped back to `RedisJobStore` post-green, then reverted):
```
FAILED src/fastapi_app/tests/core/test_scheduler.py::test_create_scheduler_uses_in_memory_jobstore
========================= 1 failed, 1 passed in 0.04s ==========================
```

**Lock TTL (`test_background_aggregation.py`), RED before the fix:**
```
>       assert fake.set_ttls[bg_agg.AGGREGATION_LOCK_KEY] > 7200
E       assert 1800 > 7200
FAILED ...::test_lock_ttl_exceeds_the_scheduler_interval
FAILED ...::test_lock_ttl_follows_a_reconfigured_interval
```
**Mutation-verify A** — `_lock_ttl_seconds()` mutated to a fixed `3900`: `test_lock_ttl_follows_a_reconfigured_interval` FAILED (kills "just raise the constant"). **Mutation-verify B** — mutated to return the bare interval (no margin): both TTL tests FAILED (pins strict `>`). Both mutations reverted; suite green after.

## Gates

- `pdm run lint` — clean
- `pdm run pytest` — **449 passed** (dedicated scratch DB `hangar_bay_tests_jobstore_fix`, serialized single run)

## Out-of-scope observation (not changed here)

`WATCHLIST_MATCH_LOCK_TTL_SECONDS` (900) exactly equals `WATCHLIST_MATCH_INTERVAL_SECONDS` (900) — the same TTL-not-greater-than-interval shape, though matcher runs are fast set-based SQL so exposure is low. Flagging for a follow-up decision rather than silently widening a setting's default.

## Merge classification

Review — production scheduler reliability & aggregation lock semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)