### PR TITLE
test(e2e): deterministic page-2 synchronization in the pagination live-smoke

### DIFF
--- a/app/frontend/web/e2e/live-smoke.spec.ts
+++ b/app/frontend/web/e2e/live-smoke.spec.ts
@@ -83,9 +83,13 @@ test('pagination crosses a real page boundary when the dataset has one', async (
   const pageOneHrefs = new Set(
     await rowLinks(page).evaluateAll((links) => links.map((a) => a.getAttribute('href'))),
   )
+  const pageOneFirstHref = await rowLinks(page).first().getAttribute('href')
   await next.click()
   await expect(page).toHaveURL(/page=2/)
-  await expect(rowLinks(page).first()).toBeVisible()
+  // The list query keeps page 1's rows rendered as placeholderData until the
+  // page-2 fetch resolves (useContracts keepPreviousData), so first-row
+  // visibility alone samples stale rows — wait for the row set to change.
+  await expect(rowLinks(page).first()).not.toHaveAttribute('href', pageOneFirstHref ?? '')
   const pageTwoHrefs = await rowLinks(page).evaluateAll((links) => links.map((a) => a.getAttribute('href')))
 
   // Distinct parent entities across the boundary (SQLA-1 regression guard):


### PR DESCRIPTION
Root cause of the pagination live-smoke failures in all three CD smoke runs (Jul 26): `useContracts` uses `placeholderData: keepPreviousData`, so after clicking Next the table keeps rendering page 1's rows until the page-2 fetch resolves — the spec's first-row-visibility gate passed against those stale rows and sampled page 1's hrefs as "page 2", tripping the SQLA-1 no-overlap guard. Invisible on localhost latency; deterministic against real prod latency.

Fix per TEST-2 (deterministic synchronization, no sleeps, no weakened asserts): capture page 1's first href, and after Next + URL change, wait for the first row's href to differ before sampling (guaranteed to converge — the API's pages are overlap-free, verified directly: 0 overlapping ids across pages 1-2, deterministic ordering across repeated calls).

**Verification against real production (the exact condition that failed CD):** `3 passed` — including the pagination spec. API-level no-overlap evidence and CD run references: 29818466988, 30213901138, 30214274640.

## Merge classification
Routine