### PR TITLE
fix(web): region filter list uses available viewport height on desktop

### DIFF
--- a/app/frontend/web/src/features/contracts/components/FilterRail.tsx
+++ b/app/frontend/web/src/features/contracts/components/FilterRail.tsx
@@ -127,7 +127,11 @@ export function FilterRail({
             onChange={(event) => setRegionQuery(event.target.value)}
           />
         </label>
-        <div className="max-h-52 overflow-y-auto rounded-sm border border-line bg-surface px-1.5 py-1">
+        {/* Desktop: size the region list to the viewport (30rem = rail content above
+            the list + margin/Clear-button reserve below), floored at the mobile cap
+            so short windows never shrink it. Mobile keeps the fixed cap — the rail
+            is a toggled panel there and 100vh-relative sizing would overflow it. */}
+        <div className="max-h-52 overflow-y-auto rounded-sm border border-line bg-surface px-1.5 py-1 lg:max-h-[max(13rem,calc(100vh-30rem))]">
           {visibleRegions.length === 0 ? (
             <p className="px-1 py-2 text-xs text-ink-faint">No region matches “{regionQuery}”</p>
           ) : (


### PR DESCRIPTION
The region listbox was capped at a fixed `max-h-52` (208 px), leaving large dead whitespace below it on desktop (Sam's report, screenshot in-session). Desktop now sizes it to the viewport: `max-h-[max(13rem,calc(100vh-30rem))]` — 30rem measured live on production (403 px of rail content above the list + margin/Clear-button reserve below), floored at the previous 208 px so short windows never regress. Mobile keeps the fixed cap (the rail is a toggled panel there; 100vh-relative sizing would overflow it).

Verified visually against production data (local Vite proxying prod, read-only): 1000 px viewport → 520 px list with 77 px reserve below; 660 px viewport → floor engages at exactly 208 px; mobile unchanged. eslint, tsc, and the vitest suite green.

## Merge classification
Routine