### PR TITLE
docs(strategy): M5 trust & shareability design + recon

### DIFF
--- a/docs/audits/m5-recon/expired-contracts-finding.md
+++ b/docs/audits/m5-recon/expired-contracts-finding.md
@@ -1,0 +1,46 @@
+# Expired Contracts Are Served As Browsable Results
+
+ABOUTME: Production finding — ~12% of served contracts have already expired, and the natural "expiring soonest" sort surfaces them first.
+ABOUTME: Discovered 2026-07-26 while scoping the trust & shareability milestone; measured against live production, not inferred.
+
+## The finding
+
+Nothing removes a contract once it leaves ESI's public list or passes its expiry, and the browse query never filters on expiry. `services/background_aggregation.py` has no prune or delete path for contracts, and `services/contract_service.py` references `date_expired` only as a **sortable field** — there is no `WHERE date_expired > now()` anywhere in the list path.
+
+Measured against production on 2026-07-26:
+
+- **51,365** contracts served in total
+- **~6,200 already expired and still browsable — ~12% of the dataset**
+- Oldest expiry still served: **2026-07-21T09:16:09Z** (five days stale)
+
+Method: binary search over pages of `/api/v1/contracts/?sort_by=date_expired&sort_direction=asc&size=100`, comparing each page's first `date_expired` against now. Crossover near page 63 of 514.
+
+## Why it matters, stated accurately
+
+This is **not** a case of the UI lying. `format.ts`'s `timeRemaining()` returns the string `'Expired'` for any past date, and that renders in the table's "Time left" column and on the detail page. A user looking at a specific row can see its state.
+
+The damage is relevance, and it is concentrated in one very natural path:
+
+- `ContractsPage.tsx`'s `DEFAULT_DIRECTION` maps `date_expired: 'asc'`, so **clicking the "Time left" column — the obvious "what's expiring soonest?" move for a deal hunter — sorts expired contracts to the top.** Verified: 20 of 20 results on that page are dead.
+- In any unsorted result set, roughly 1 in 8 rows is a contract that cannot be accepted.
+- The `total` count (51,365) overstates what is actually available, and pagination walks the user through the dead rows.
+
+For a product whose stated success criterion is that a user "finds a candidate ship in under a minute and **trusts the numbers**", a default view where an eighth of the rows are unavailable — and where the most natural sort returns nothing else — undercuts precisely the thing the product sells.
+
+## The `status` field is a separate, smaller instance of the same theme
+
+`Contract.status` is populated as `c.get("status", "unknown")` (`background_aggregation.py:108`) and is **always** the literal `"unknown"`, because ESI's *public* contracts route returns no status field — that exists only on character/corp contract routes. Verified against production: every row in a 100-item sample has `status: "unknown"`.
+
+The frontend never reads it (a grep for `.status` in the SPA finds only HTTP error statuses). It is dead weight in the API response and in the `ix_contracts_type_status` index.
+
+## Recommended direction (for the trust & shareability design)
+
+1. **Exclude expired contracts from list results by default** — a `date_expired > now()` predicate in the list query. This also corrects `total`.
+2. **Keep serving expired contracts on the detail page, clearly marked** — do not 404 them. This is load-bearing for link previews: a link pasted into Discord will routinely be clicked *after* the contract expires, and the preview and page must say so honestly rather than 404 or, worse, present it as available.
+3. **Stop exposing `status`** in the API response, since it carries no information. Removing the field is an OpenAPI change requiring a client regeneration; both sides are ours.
+
+Deliberately **not** recommended here: deleting expired rows. Filtering fixes correctness without losing history, and deletion interacts with saved searches and notifications that may reference those contracts.
+
+## Related follow-up, out of scope
+
+Expired contracts accumulate with no prune path, so the table grows without bound — 51k after roughly a week of ingestion, on a `basic-256mb` Postgres. Filtering at query time does not address storage growth. A retention policy deserves its own decision (there is precedent: `NOTIFICATION_RETENTION_DAYS` already prunes notifications).

--- a/docs/audits/m5-recon/expired-contracts-finding.md
+++ b/docs/audits/m5-recon/expired-contracts-finding.md
@@ -7,13 +7,30 @@ ABOUTME: Discovered 2026-07-26 while scoping the trust & shareability milestone;
 
 Nothing removes a contract once it leaves ESI's public list or passes its expiry, and the browse query never filters on expiry. `services/background_aggregation.py` has no prune or delete path for contracts, and `services/contract_service.py` references `date_expired` only as a **sortable field** — there is no `WHERE date_expired > now()` anywhere in the list path.
 
-Measured against production on 2026-07-26:
+Measured against production on 2026-07-26, in **two populations** — the distinction matters, and the first pass of this finding got it wrong:
 
-- **51,365** contracts served in total
-- **~6,200 already expired and still browsable — ~12% of the dataset**
-- Oldest expiry still served: **2026-07-21T09:16:09Z** (five days stale)
+| Population | Total | Expired | Share |
+|---|---|---|---|
+| All contracts | 51,365 | ~6,200 | ~12.1% |
+| **Ships-only — the default view users actually get** | **622** | **~53** | **~8.5%** |
 
-Method: binary search over pages of `/api/v1/contracts/?sort_by=date_expired&sort_direction=asc&size=100`, comparing each page's first `date_expired` against now. Crossover near page 63 of 514.
+The frontend defaults to ships-only (`filters.ts`, F002 Criterion 1.1), so the all-contracts figure describes a view a trial user never sees by default. **The corrected number is smaller but the finding is sharper:** the list page size is 50, and all 53 expired contracts sort ahead of every live one — so the entire first page of "expiring soonest" is dead, with some left over.
+
+Oldest expiry still served: **2026-07-21T09:16:09Z** (five days stale).
+
+Method: binary search over pages of `/api/v1/contracts/?sort_by=date_expired&sort_direction=asc&size=100`, comparing each page's first `date_expired` against now; run separately with and without `is_ship_contract=true`.
+
+## The larger half: sold contracts, which no expiry measurement can see
+
+Expiry is only the *visible* portion of the problem. A contract that is **accepted** disappears from ESI's public list, but nothing here tracks absence:
+
+- `Contract` has **no `last_seen_at` and no `updated_at` column** (verified in `models/contracts.py`).
+- The public contracts route never populates `date_completed`.
+- Ingestion upserts what it sees and never deletes.
+
+So a ship sold five minutes after ingestion keeps displaying as available for the rest of its contract duration — up to two weeks — carrying a future `date_expired` that passes any expiry filter. This is invisible to an API probe, because a sold contract's record is byte-identical to a live one; it surfaced only by reading the model and noticing the column that was not there.
+
+Detecting it requires stamping `last_seen_at` on upsert and filtering to contracts seen in the most recent **complete** run — where "complete" must mean a fully successful run, since a partial run that advanced the watermark would wrongly erase every contract in a failed region.
 
 ## Why it matters, stated accurately
 
@@ -35,7 +52,7 @@ The frontend never reads it (a grep for `.status` in the SPA finds only HTTP err
 
 ## Recommended direction (for the trust & shareability design)
 
-1. **Exclude expired contracts from list results by default** — a `date_expired > now()` predicate in the list query. This also corrects `total`.
+1. **Exclude expired contracts from list results by default** — a `date_expired > now()` predicate in the list query. This also corrects `total`. Note this is the *smaller* half: it does nothing about sold contracts, which need `last_seen_at` (see above).
 2. **Keep serving expired contracts on the detail page, clearly marked** — do not 404 them. This is load-bearing for link previews: a link pasted into Discord will routinely be clicked *after* the contract expires, and the preview and page must say so honestly rather than 404 or, worse, present it as available.
 3. **Stop exposing `status`** in the API response, since it carries no information. Removing the field is an OpenAPI change requiring a client regeneration; both sides are ours.
 

--- a/docs/audits/m5-recon/link-preview-latency-spike.md
+++ b/docs/audits/m5-recon/link-preview-latency-spike.md
@@ -39,28 +39,33 @@ Cold load (empty cache):
 | First data request issued | **3003 ms** |
 | First Contentful Paint | **3592 ms** |
 
-Warm load (assets HTTP-cached — the returning-user case):
+Warm load (assets HTTP-cached — the returning-user case). **Four samples, because the first one turned out to be the worst and was initially quoted as typical:**
 
-| Phase | Window |
-|---|---|
-| Document + all cached JS/CSS | 48 → **130 ms** |
-| Client bootstrap before any data request | 130 → **850 ms** (~720 ms) |
-| Contract API call | 851 → **1265 ms** (~414 ms) |
+| Sample | Assets done | First API request | Bootstrap gap | Time-to-content |
+|---|---|---|---|---|
+| 1 | 130 ms | 850 ms | 720 ms | 1265 ms |
+| 2 | ~44 ms | 887 ms | ~840 ms | 1091 ms |
+| 3 | 66 ms | 364 ms | **298 ms** | **711 ms** |
+| 4 | 46 ms | 299 ms | **253 ms** | **628 ms** |
 
-Measured on a 10-core / 16 GB machine, so the bootstrap gap is not weak-hardware noise — but it *was* measured in an automated browser, and absolute values on a real user's Chrome may differ. The **relative** comparison between routing approaches is unaffected, since client bootstrap is constant across them.
+**Honest range: a 253–840 ms bootstrap gap and 628–1265 ms time-to-content.** Samples 3 and 4 ran clean; samples 1 and 2 show contention. Sample 2 is instructive — two *cache-hit* modules (`format-*.js`, `useWatchlist-*.js`, both `transferSize === 0`) reported 825 ms durations, which reads as main-thread blocking or cache-read stalling rather than real work.
+
+**What the gap is, and is not.** It is not asset downloading: every JS/CSS file was a cache hit in every sample. It is the interval after the bundles are in hand and before `useQuery` issues its request — main-bundle execution, React mount, TanStack Router resolving the route, the route component rendering. The breakdown *within* that window was not instrumented (no `longtask` entries were captured), so no attribution between JS execution, framework init, and application logic is claimed here.
+
+Measured on a 10-core / 16 GB machine in an automated browser. A real user's Chrome may show less contention; the clean samples are probably closer to reality than the slow ones.
 
 ## What this means for the routing decision
 
-1. **Document delivery is the smallest component of time-to-content**, not the largest. Warm time-to-content is ~1265 ms, of which the document is ~48 ms. Optimizing document delivery to protect "fast is a feature" was aiming at the wrong term.
+1. **Document delivery is the smallest component of time-to-content**, not the largest. Against a clean warm baseline of ~630–710 ms, the document is ~35–48 ms. Optimizing document delivery to protect "fast is a feature" was aiming at the wrong term. This conclusion survives the corrected numbers — but by a smaller margin than the first draft claimed.
 
-2. **Routing contract pages through the backend costs ~200 ms of document delivery** (edge HIT → origin BYPASS) — real, but recoverable, see next point.
+2. **Routing contract pages through the backend costs ~200 ms of document delivery** (edge HIT → origin BYPASS). Against the originally-quoted 1265 ms baseline that is ~16%; against the clean ~650 ms baseline it is **closer to ~30%**. The first framing understated it, because it compared against the slowest observed sample.
 
 3. **Inlining contract data into the server-rendered shell removes the client's separate API call (~414 ms).** Net effect is roughly **300 ms faster than today**, not slower. This inverts the original objection. The backend already holds the data in-process for the OG tags, so inlining costs one query it was already making — unlike a Cloudflare Worker, which would need a second network fetch to get it.
 
-4. **Consequence for scoping, and it is a hard one:** OG tags and data inlining must ship *together*. Routing contract pages to the backend for tags alone, without inlining, ships a measurable ~200 ms regression. Either both, or neither.
+4. **Consequence for scoping.** Shipping tags without inlining costs entry loads ~200 ms — about 30% of a clean baseline. That is a real regression rather than a rounding error, though not obviously a blocking one; whether to couple the stages is a judgement call, and the corrected numbers make coupling more defensible than the first draft concluded.
 
 5. **Two larger performance findings fall out of this spike and are out of scope here**, recorded so they are not lost:
-   - **~720 ms of client bootstrap before the first data request** dominates warm time-to-content. This is the single largest lever on page speed and has nothing to do with link previews.
+   - **The bootstrap gap (253–840 ms) is the largest single term in warm time-to-content**, larger than the API call in the clean samples and far larger than document delivery. It has nothing to do with link previews and is the biggest available lever on page speed.
    - **Every SPA API call pays the ~161 ms origin penalty**, site-wide, on every page.
 
 ## Open question this spike could not resolve

--- a/docs/audits/m5-recon/link-preview-latency-spike.md
+++ b/docs/audits/m5-recon/link-preview-latency-spike.md
@@ -1,0 +1,74 @@
+# Link-Preview Routing — Latency Spike
+
+ABOUTME: Measured cost of routing contract-detail page loads through the backend (needed for per-URL link previews) against today's CDN-served SPA shell.
+ABOUTME: Read-only production measurements taken 2026-07-26; informs the routing decision in the trust & shareability design.
+
+## Why this spike ran
+
+Per-URL Open Graph previews require server-rendered meta tags — Discord's crawler does not execute JavaScript, and `app/frontend/web/index.html` carries no `og:*` tags at all. Render static sites cannot run server-side code and their route rules match **path only** (verified against Render's redirects/rewrites documentation: rules support `source` and `destination`, no header or User-Agent conditions), so a crawler-vs-human split cannot happen at Render's edge.
+
+That leaves approaches which route some traffic through a server. The objection to all of them was latency, on a product whose stated principles include "Fast is a feature." This spike measured that cost instead of assuming it.
+
+## Method
+
+Read-only GETs against production (`hangarbay.app`), 12 samples per target, plus real browser navigation timing via the Performance API on a live contract page. No code deployed. Contract detail page used: a live contract ID sampled from `/api/v1/contracts/`.
+
+## Results
+
+### Transport-level (curl, median TTFB)
+
+| Path | TTFB median | p90 | Notes |
+|---|---|---|---|
+| SPA shell via CDN (today) | **51.7 ms** | 68.5 ms | `cf-cache-status: HIT`, `age: 243` |
+| `index.html` via CDN | 55.1 ms | 82.8 ms | same object |
+| API via apex (`/api/v1/*` rewrite → backend) | **251.3 ms** | 398.7 ms | `cf-cache-status: BYPASS` |
+| API direct to backend origin (bare path, PROXY-1) | **90.3 ms** | 142.0 ms | — |
+
+**The external-rewrite hop costs ~161 ms median.** Confirmed independently on `/ready` (apex 0.31–0.57 s vs direct 0.13–0.22 s across 5 paired samples), so it is not an artifact of one endpoint.
+
+**Root cause is not a misconfiguration.** Both paths are Cloudflare-fronted (Render's own edge is Cloudflare — consistent with M4 Deviation D-12's note that proxying our DNS would stack a *second* such layer). The shell is an edge-cache HIT served near the client; the API is `BYPASS` and travels to the ohio origin every request. The gap is edge-hit versus origin round-trip — distance, not waste.
+
+### Page-level (browser Performance API, contract detail page)
+
+Cold load (empty cache):
+
+| Milestone | Time |
+|---|---|
+| Document TTFB | 65 ms |
+| DOMContentLoaded | 822 ms |
+| First data request issued | **3003 ms** |
+| First Contentful Paint | **3592 ms** |
+
+Warm load (assets HTTP-cached — the returning-user case):
+
+| Phase | Window |
+|---|---|
+| Document + all cached JS/CSS | 48 → **130 ms** |
+| Client bootstrap before any data request | 130 → **850 ms** (~720 ms) |
+| Contract API call | 851 → **1265 ms** (~414 ms) |
+
+Measured on a 10-core / 16 GB machine, so the bootstrap gap is not weak-hardware noise — but it *was* measured in an automated browser, and absolute values on a real user's Chrome may differ. The **relative** comparison between routing approaches is unaffected, since client bootstrap is constant across them.
+
+## What this means for the routing decision
+
+1. **Document delivery is the smallest component of time-to-content**, not the largest. Warm time-to-content is ~1265 ms, of which the document is ~48 ms. Optimizing document delivery to protect "fast is a feature" was aiming at the wrong term.
+
+2. **Routing contract pages through the backend costs ~200 ms of document delivery** (edge HIT → origin BYPASS) — real, but recoverable, see next point.
+
+3. **Inlining contract data into the server-rendered shell removes the client's separate API call (~414 ms).** Net effect is roughly **300 ms faster than today**, not slower. This inverts the original objection. The backend already holds the data in-process for the OG tags, so inlining costs one query it was already making — unlike a Cloudflare Worker, which would need a second network fetch to get it.
+
+4. **Consequence for scoping, and it is a hard one:** OG tags and data inlining must ship *together*. Routing contract pages to the backend for tags alone, without inlining, ships a measurable ~200 ms regression. Either both, or neither.
+
+5. **Two larger performance findings fall out of this spike and are out of scope here**, recorded so they are not lost:
+   - **~720 ms of client bootstrap before the first data request** dominates warm time-to-content. This is the single largest lever on page speed and has nothing to do with link previews.
+   - **Every SPA API call pays the ~161 ms origin penalty**, site-wide, on every page.
+
+## Open question this spike could not resolve
+
+**Can backend-rendered contract HTML be edge-cached?** The API path returns `cache-control: max-age=0` and shows `cf-cache-status: BYPASS`. If a backend HTML response carrying a short `s-maxage` (contract data changes about hourly, so 60–300 s is defensible) is honored by Render's edge, repeat views of the same contract return to ~50 ms and crawlers are served from cache — which would erase objection 2 entirely. It is unknown whether Render's edge caches rewrite-destination responses at all, or forces BYPASS regardless of origin headers.
+
+This is cheap to settle but **requires deploying a response header and observing `cf-cache-status`** — it cannot be answered from outside. It should be the first task of any implementation, because a positive result simplifies the design and a negative one does not block it.
+
+## Reproducing
+
+`curl -w '%{time_starttransfer}'` against the four targets above; browser timings via `performance.getEntriesByType('navigation'|'resource'|'paint')` on a loaded contract page. The measurement script used is not committed — it is 40 lines of `curl` invocations and is faster to rewrite than to maintain.

--- a/docs/audits/m5-recon/routing-review-fable.md
+++ b/docs/audits/m5-recon/routing-review-fable.md
@@ -1,0 +1,287 @@
+# Routing review — Discord unfurls for contract pages (independent opinion, Fable)
+
+Reviewer: Claude (Fable 5), 2026-07-26. Independent architectural read; the requester
+deliberately withheld their preference. Grounded against the repo (`render.yaml`, frontend
+route tree, `index.html`) and the measurements supplied in the brief.
+
+## Verdict
+
+**Option 1 — backend owns the contract routes — staged in three pieces, with a
+15-minute edge-cache probe run first.** Option 2 is disqualified by the stated
+requirements, not by taste. Option 3 is the technically cleverest answer and the wrong
+one for this project at this moment.
+
+One repo fact that strengthens Option 1 considerably: the frontend route tree is
+`contracts.index.tsx` (filtered search at `/contracts`) and `contracts.$contractId.tsx`
+(detail at `/contracts/:id`). **A single `/contracts*` rewrite covers both the primary
+and the secondary case.** The search page is not at `/`, so the blast radius of handing
+this prefix to the backend is exactly the two pages that need unfurls — nothing else.
+
+---
+
+## 1. Why Option 1
+
+### Option 2 is eliminated by the requirements, full stop
+
+Users copy URLs from the address bar. `/s/c/:id` links only exist if someone clicks a
+Share button, so the primary flow — paste `hangarbay.app/contracts/123` into Discord —
+produces no preview. The brief itself states this constraint; Option 2 fails it by
+construction. It also proliferates two URL shapes for the same resource, and the
+human-bounce page (JS or meta-refresh redirect) is visible jank for anyone who does
+click a share link. No implementation quality rescues a design that misses the main
+use case. Eliminated.
+
+### Option 1 vs Option 3 — the real contest
+
+Both satisfy the address-bar constraint. The decision turns on four axes:
+
+**Operational surface.** Option 1 adds zero services, zero deploy pipelines, zero
+credential sets. The route handler lives in `fastapi_app/api/`, is tested with the
+existing pytest suite under the existing TDD discipline, ships through the existing CD,
+and logs through the existing structlog → Alloy → Grafana Cloud path. Option 3 adds a
+Cloudflare Worker: wrangler tooling, a CF API token in CI, a third deploy pipeline the
+existing CD knows nothing about, and observability in a separate console. For a repo
+run by one person plus agents, whose entire prod stack is currently "two Render
+services and a database," a third platform for one HTML `<head>` is a poor trade —
+especially for a milestone explicitly framed as small polish before a trial.
+
+**Cache correctness by construction.** Option 1 serves the *same* HTML to every
+User-Agent. There is nothing UA-variant anywhere, so no `Vary: User-Agent` problem, no
+"crawler page cached and served to a human" failure class, and edge caching (if
+available — see §3c) is a pure win. Option 3's whole mechanism is UA-variant responses
+threaded through **three** cache layers (Render's edge on the rewrite, Cloudflare's
+cache on the Worker route, the Worker's subrequest to the shell). `Vary: User-Agent`
+is notoriously unreliable at CDNs; the only safe posture is `no-store` on everything
+the Worker emits, which forfeits edge caching entirely and still leaves you auditing
+whether Render's edge caches rewrite-destination responses regardless. Option 1 has no
+such audit to do.
+
+**Latency honesty.** Option 3's headline advantage — "humans keep CDN latency" — is
+partly unverified. The measured ~161 ms external-rewrite penalty is Render-edge proxy
+overhead *plus* the edge→ohio leg, in unknown proportion. Option 3's human path is
+Render edge → CF Worker → shell fetch; if a meaningful share of the 161 ms is Render's
+proxy overhead itself, Option 3 humans pay much of the penalty anyway, while inheriting
+all the new complexity. Nobody has measured a Render rewrite to a nearby Cloudflare
+destination. Option 3's central benefit is a hypothesis; Option 1's central cost
+(~200 ms median on entry-load documents) is measured and bounded.
+
+**Where the cost lands vs where the benefit lands.** The ~200 ms document penalty
+applies **only to full document loads** — pasted links, refreshes, first entry.
+In-app navigations are TanStack Router client-side transitions with no document request
+at all: unchanged. And the entry-load visitor is *exactly* the Discord-link-clicker
+this milestone serves — the same person who, once data inlining ships (§below), gets
+the ~300 ms net *improvement*. The cost and the compensating win land on the same
+request class. That symmetry is what makes Option 1 coherent rather than merely
+tolerable.
+
+### The staged shape (this is the recommendation, not an option-1 monolith)
+
+- **Stage 0 (an hour, ship immediately):** add *static* site-wide OG tags to
+  `app/frontend/web/index.html` — `og:site_name`, `og:title`, `og:description`,
+  `og:image` (a branded card), `twitter:card`. Today the file has none. Every pasted
+  link — homepage, watchlist, anything — gets a branded unfurl right away, and pages
+  the dynamic work never covers stay covered forever. This is the true minimum polish
+  and it de-risks the trial even if everything below slips.
+- **Probe (15 minutes, before committing to perf posture):** the edge-cache experiment
+  in §3c. Its outcome sets Stage 1's cache headers, nothing else — Stage 1 proceeds
+  either way.
+- **Stage 1 (the milestone's core):** Render rewrite `/contracts*` → FastAPI (rules
+  *before* the SPA catch-all — same ORDER-MATTERS pattern already commented in
+  `render.yaml`). FastAPI fetches the built shell from the static origin
+  (`hangar-bay-web`'s `.onrender.com` hostname, **not** the apex — see §2, loop
+  hazard), holds it in a process-global cache, revalidates with `If-None-Match` per
+  request (ohio → CF edge conditional GET is tens of ms; a 304 costs almost nothing),
+  and keeps the last-known-good copy as stale-if-error. It injects escaped
+  `og:title` / `og:description` / `og:image` (EVE image CDN by type ID, absolute URL)
+  into `<head>` and returns the shell to *everyone* — no UA sniffing.
+- **Stage 2 (fast-follow, measured before/after):** inline dehydrated contract data
+  (one `<script>` with the query payload; frontend seeds TanStack Query from it).
+  This converts the entry-load penalty into the measured ~300 ms net win. Its benign
+  failure mode — query-key mismatch — degrades to today's behavior (client refetches).
+- **Stage 3 (optional, still same architecture):** the filtered-search secondary case.
+  Same rewrite already routes `/contracts?type=...`; backend maps filter params to a
+  summary string and a count. Count needs a query per crawler hit — cache it in Valkey
+  keyed by normalized filter, short TTL. Defer freely; no new decisions required.
+
+---
+
+## 2. Risks and failure modes, per option
+
+### Option 1 (chosen — these must be engineered for, not hand-waved)
+
+1. **Deploy-skew / stale-shell 404s — the 3am scenario.** Frontend deploys new hashed
+   assets; a backend-cached stale shell references bundles the static origin no longer
+   serves → white page on contract routes. Mitigation is the per-request
+   `If-None-Match` revalidation above. Note the repo's *existing* exposure: the
+   `Cache-Control: no-cache` header rule in `render.yaml` matches only the literal
+   path `/index.html`; SPA-fallback documents on deep links ride Render's default
+   `s-maxage=300` (which is exactly why the brief measured a `cf-cache-status: HIT`
+   shell). So the site already tolerates a ≤5-minute stale-shell window after every
+   frontend deploy. The bar for Stage 1: **no worse than that window**; ETag
+   revalidation beats it.
+2. **Availability coupling.** Today a dead backend still serves the shell; the SPA
+   renders its own error state. After Stage 1, `/contracts*` documents fail entirely
+   when FastAPI is down (Render rewrites have no fallback rule). Partial mitigation:
+   the handler serves the cached shell with *generic* tags when the DB/lookup fails —
+   so only a fully-down FastAPI process takes the pages out. Accept for a friendly-corp
+   trial; monitor; note that `healthCheckPath: /ready` already gates deploys for
+   zero-downtime.
+3. **XSS via contract data.** Contract titles are player-authored text going into
+   meta-tag attribute values. Escape with quoting (`html.escape(quote=True)`);
+   integer-validate the type ID before building the image URL. This is the one
+   security-review item in the milestone.
+4. **Single-instance backend absorbs document traffic.** The API is deliberately
+   pinned to one instance (scheduler disk pin, starter plan) and also runs ingestion.
+   Corp-trial page traffic is trivial; flag it as a capacity note for later, not a
+   blocker now.
+5. **Render route-matching details to verify at apply time:** (a) whether
+   `source: /contracts/*` matches bare `/contracts` — if not, add both rules;
+   (b) the API hostname is flagged in `render.yaml` as a placeholder
+   ("Render suffixes service hostnames when a name is taken") — use the verified
+   actual hostname; (c) query strings must pass through the rewrite (they do for
+   `/api/v1/*` today, but confirm on the new rule).
+6. **404 / expired contracts.** Serve the shell with generic tags (and ideally a real
+   404 status) so dead links unfurl as "Hangar Bay" rather than a stale ship. Cheap;
+   do it in Stage 1.
+7. **Discord caches unfurls server-side** for a long time per URL. Price edits won't
+   refresh an already-posted embed. Not a bug in any option — set expectations with
+   the corp.
+
+### Option 2
+
+Already eliminated (§1). Additional notes for completeness: two URL shapes for one
+resource leak into bookmarks and chat history; the human bounce is either a JS redirect
+(blank flash, breaks no-JS) or meta-refresh (slow, ugly); and it quietly teaches users
+that "real" links don't unfurl, which is the opposite of the goal.
+
+### Option 3
+
+1. **UA-variant responses across three cache layers** — the dominant correctness risk,
+   detailed in §1. Safe posture is `no-store` everywhere, which deletes the option's
+   performance rationale and still requires verifying Render's edge behavior on
+   rewrite responses.
+2. **Request loop.** The Worker must fetch the shell from the static site's
+   `.onrender.com` hostname. Fetching `hangarbay.app/contracts/...` re-enters the
+   `/contracts/*` rewrite → Worker → repeat. Trivial to avoid, catastrophic to miss,
+   and easy to reintroduce in a refactor ("just use the canonical domain").
+3. **UA allowlist rot.** Discordbot is stable, but the corp will eventually paste
+   links into Slack, Telegram, forums. Each unfurler has its own UA; misses are
+   *silent* (no preview, no error, nothing in logs you're watching). An allowlist is
+   permanent gardening.
+4. **Third deploy surface.** Wrangler config, CF API token in CI, Worker versioning,
+   a separate dashboard for logs/errors. The 3am debugging session spans Render's
+   edge, Cloudflare's cache, and the Worker console to answer "which layer mangled
+   this response?"
+5. **Unmeasured human-path latency** (§1) — the option's core benefit is unverified.
+6. **Policy erosion.** The apex was kept DNS-only *deliberately* to avoid stacking
+   Cloudflare on Render's Cloudflare. Option 3 re-stacks them for one path through a
+   side door: Render-CF-edge → CF Worker → Render-CF-edge (shell fetch). It doesn't
+   violate the letter of the earlier decision, but it recreates exactly the
+   multi-layer cache/purge topology that decision existed to avoid.
+
+Option 3 is the right architecture in a different context: a team already running
+Workers, or a scale where human CDN latency on entry loads is sacred and measured to
+survive the rewrite hop. Neither holds here.
+
+---
+
+## 3. Scrutiny of the reasoning in the brief
+
+### (a) "Inlining data makes pages net faster despite the ~200 ms document penalty" — **arithmetically sound, with three caveats**
+
+Warm-cache arithmetic: today content lands ~1265 ms (doc 48 → bootstrap gap to ~850 →
+API to ~1265). With the document served from ohio (~250 ms median) carrying inlined
+data: ~250 + ~720 bootstrap ≈ **~970-1000 ms, no API wait — ~265-300 ms net faster**.
+Cold loads are dominated by JS download, but inlining still removes the serial
+~400-600 ms data leg for a smaller relative win. Caveats:
+
+1. **Both penalty and benefit apply only to entry loads.** Client-side navigations
+   never request a document — unchanged either way. This *narrows* the claim but also
+   targets it perfectly: the Discord-link visitor is an entry load.
+2. **p90 is thinner.** Doc p90 through the rewrite is ~399 ms; the p90 win shrinks and
+   could occasionally invert against today's p90 tail. Median case is solidly positive.
+3. **The gain is conditional on hydration actually matching** the client's query keys
+   and serialization. The failure mode is benign (client refetches; you keep the
+   penalty, lose the win) but *silent* — Stage 2 needs an e2e assertion that no
+   contract API request fires on a hard load of a contract page.
+
+Also note the ~720 ms bootstrap gap is the single largest number on the warm path and
+belongs on a perf backlog independent of this milestone — no routing option touches it.
+
+### (b) "OG tags and inlining must ship together or the change is a net regression" — **overstated; reject the coupling**
+
+OG-only (Stage 1) costs ~200 ms median (~330 ms p90) on entry-load documents for
+`/contracts*` — against a ~1.3 s warm time-to-content and ~3.6 s cold FCP — and buys
+the milestone's entire stated goal. Calling that "a net regression" prices the feature
+at zero; it isn't a regression, it's a purchase, and a cheap one. Meanwhile "must ship
+together" bundles HTML serving + shell caching + tag injection + dehydration +
+frontend hydration + e2e verification into one atomic change — larger blast radius,
+harder rollback, exactly what a small milestone shouldn't do. Ship Stage 1, measure,
+ship Stage 2 within days. (The claim is also falsified in general by Option 3's
+existence, which decouples the two entirely — but that's not why to reject it here.)
+
+### (c) "Would Render's edge honor `s-maxage` on a rewrite destination?" — **unknown; weak positive evidence; 15-minute empirical answer**
+
+The measured API responses show `cf-cache-status: BYPASS`, not `DYNAMIC`. In
+Cloudflare vocabulary BYPASS means the *origin response's headers* (no-store /
+no-cache / private / Set-Cookie) suppressed caching — i.e. the edge looked at the
+headers and obeyed them — whereas DYNAMIC means "not cache-eligible, didn't even
+consider it." BYPASS is therefore weak evidence the edge *would* cache a permissive
+response. But Render's zone config is theirs, undocumented for this case, and could
+change without notice. The test: add a trivial endpoint (or header on one) returning
+`Cache-Control: public, s-maxage=60` plus a timestamp; hit it through the apex rewrite
+several times; if the timestamp freezes and `cf-cache-status` flips to HIT, it's
+honored. Two follow-ups regardless of outcome: **only Option 1 can safely exploit
+this** (UA-invariant responses; Option 3 would be caching UA-variant HTML), and even
+if honored, treat it as an optimization with a short TTL, never a correctness
+dependency — it's Render's internal behavior, not a contract.
+
+### One more framing error worth naming
+
+The brief presents Option 1's shell-fetch coupling as novel risk. It's actually the
+*same* staleness class the site already lives with (the `s-maxage=300` deep-link shell,
+per §2.1) — Stage 1 with ETag revalidation makes the window smaller than today's, not
+larger. Risk assessments should be measured against the existing baseline, not against
+an imagined zero-staleness world.
+
+---
+
+## 4. Scope judgment
+
+The staged Option 1 fits a small polish milestone **because it's severable**:
+
+- **Stage 0** (static OG tags) is an hour and worth doing even if the milestone ended
+  there — it's the floor for "links look intentional in Discord."
+- **Stage 1** is the milestone's real body: one Render route rule + one FastAPI
+  endpoint + shell cache with ETag revalidation + escaped tag injection + tests. A
+  bounded lake — every edge case (404, expired contract, escaping, shell-fetch
+  failure, revalidation) is enumerable and testable in pytest. Days, not weeks.
+- **Stage 2** (inlining) is the piece that flirts with "architecture project." Keep it
+  a fast-follow with its own PR and its own before/after measurement; if the trial
+  date arrives first, ship without it — the trial needs unfurls, not 300 ms.
+- **Stage 3** (search summaries) is deferrable indefinitely without foreclosing
+  anything; the routing already carries it.
+
+What does *not* fit the milestone: Option 3 in any form (new platform for a polish
+milestone), and any attempt to fix the 720 ms bootstrap gap "while we're in there."
+
+**Do not skip Stage 0 in the excitement over Stage 1.** It's the highest
+value-per-hour line item in this document.
+
+---
+
+## Summary of verify-at-apply checklist (Stage 1)
+
+1. Run the §3c edge-cache probe; set Stage 1 `Cache-Control` accordingly
+   (`no-cache` if unhonored/uncertain; `public, s-maxage=30-60` if honored).
+2. Confirm `source: /contracts/*` matches bare `/contracts`; add a second rule if not.
+3. Use the API service's *actual* assigned hostname (render.yaml flags the placeholder).
+4. Backend fetches the shell from the static site's `.onrender.com` hostname, never
+   the apex.
+5. Rewrite rules ordered before the `/*` SPA fallback (existing PROXY-1 pattern).
+6. `html.escape(..., quote=True)` on all injected tag content; integer-validate type
+   IDs in image URLs.
+7. pytest: tags present and escaped for a real contract; generic tags on unknown ID;
+   shell served from stale cache when the static origin errors.
+8. After Stage 2 only: e2e asserting zero contract-API requests on a hard load of a
+   hydrated contract page.

--- a/docs/audits/m5-recon/spec-review-fable.md
+++ b/docs/audits/m5-recon/spec-review-fable.md
@@ -1,0 +1,110 @@
+# Adversarial Review — M5 Trust & Shareability Design
+
+ABOUTME: Adversarial design review of `docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md`, checked against the live codebase in this worktree.
+ABOUTME: Findings ranked BLOCKER / MAJOR / MINOR; every code claim was verified against actual files, not taken on faith.
+
+Reviewed 2026-07-26. Files checked: `contract_service.py`, `api/contracts.py`, `api/ops.py`, `schemas/contracts.py`, `schemas/common.py`, `models/contracts.py`, `services/watchlist_matcher.py`, `services/saved_search_service.py`, `services/background_aggregation.py`, `render.yaml`, `routes/index.tsx`, `index.html`, `ContractsPage.tsx`, `Pagination.tsx`, `format.ts`, `filters.ts`, `e2e/fixtures/contracts.ts`, both pitfalls docs, F002.
+
+---
+
+## BLOCKER
+
+### B-1. The `/contracts*` rewrite collides with the existing JSON API at the backend's bare paths — the spec never mentions it
+
+The backend already mounts a JSON router at bare `/contracts` (`api/contracts.py`: `APIRouter(prefix="/contracts")`, with `GET /contracts/` = list and `GET /contracts/{contract_id}` = detail). The existing rewrite `source: /api/v1/*` → `destination: https://hangar-bay-api.onrender.com/*` strips the prefix, so the SPA's API call `GET /api/v1/contracts/123` arrives at the backend as `GET /contracts/123`.
+
+The spec's proposed rewrite sends apex `GET /contracts/123` (a document navigation) to the backend, and its own sentence — "The backend serves these routes at bare paths, per PROXY-1 — the handler must not assume an `/api/v1` prefix" — mandates that the HTML handler live at `/contracts/{id}`. **That is the exact path the JSON detail endpoint already occupies.** Both request classes arrive at one origin, one path, indistinguishable except by headers. Concrete failures, pick one:
+
+- If the JSON route wins route matching, Discord's crawler receives JSON. Stage 1 is dead on arrival.
+- If the HTML route wins, every SPA detail-page API call receives an HTML document and the detail page breaks site-wide.
+- Bonus: apex `/contracts/` (trailing slash) maps to backend `/contracts/`, the JSON **list** endpoint — a user reloading a trailing-slash URL gets a raw JSON dump as their page. FastAPI's `redirect_slashes` makes bare `/contracts` reachable the same way.
+
+The fix is not hard — mount the document handler under a distinct backend prefix (e.g. `/pages/contracts/*`) and write the rewrite destination to target it — but the spec must specify it, because it contradicts the spec's own "bare paths per PROXY-1" instruction as written, and PROXY-1's "keep paths verbatim" framing needs a deliberate, documented carve-out for document routes. Content-negotiating on `Accept` inside one route is the wrong answer (FastAPI doesn't route on headers; crawler Accept headers are unreliable). This is the single largest omission in the design and it invalidates the Stage 1 section as specified.
+
+### B-2. Unverified Render glob: `/contracts*` (no slash) as a rewrite source
+
+Every existing rule uses segment-style globs (`/api/v1/*`, `/*`). Whether Render accepts a mid-segment suffix glob `/contracts*`, and whether it matches the bare path `/contracts`, `/contracts/123`, and (undesirably) `/contractsanything`, is asserted, not verified. The spike verified Render's docs for the *absence* of header matching but not this. If `/contracts*` is invalid or matches only literally, the routing design silently doesn't cover the list page or covers wrong paths. Cheap to settle; must be settled before the spec's routing section can be trusted. (This interacts with M-2: `/contracts/*` vs `/contracts` + `/contracts/*` is also the scoping lever for excluding the list page.)
+
+---
+
+## MAJOR
+
+### M-1. Availability coupling is understated: recreate deploys make it a *routine* outage, not a tail risk
+
+`render.yaml`'s disk pin exists "ONLY to pin max-1-instance + **recreate deploys**". Recreate strategy means every backend deploy has a stop-start window. Today that window costs nothing on the document path — the CDN keeps serving the shell. After Stage 1, **every backend deploy takes down document serving for `/contracts*`** — which, given `/` is just a client-side redirect to `/contracts`, is effectively every reload, bookmark, and shared link on the site. The risk section frames coupling as "a hard process-down is accepted" — an exceptional event — when the design actually converts each merge-to-main into a small scheduled document outage. Either accept that explicitly (with the deploy frequency named), serve a static fallback from the edge on 5xx (Render rewrites don't do failover — so probably not available), or scope the rewrite smaller (M-2).
+
+### M-2. Stage 1 routes the *list page* — the effective homepage — through the backend for zero Stage-1 benefit
+
+`/contracts*` covers bare `/contracts`, i.e. the main list view every user lands on and reloads. Stage 1 only injects per-contract tags; list-page tags are Stage 3, "deferrable indefinitely." So from day one the highest-traffic document pays ~200 ms and the new availability coupling (M-1) while receiving nothing until a stage the spec may never ship. The spec sells the wide prefix as "no extra blast radius"; it is precisely extra blast radius. The alternative — rewrite only `/contracts/*` (detail pages), leave bare `/contracts` on the static fallback with Stage 0 tags until Stage 3 exists — is never discussed. It should be, and it is probably the right call for a trial-scale milestone.
+
+### M-3. Sold/delisted contracts are the other half of the trust hole, and the spec doesn't acknowledge the boundary
+
+Contracts leave ESI's public list when accepted (sold), not only when expired. Nothing prunes or flags them locally — no `last_seen` tracking exists in the model, and the public route never populates `date_completed`. A ship sold on day 1 of a 4-week contract remains in list results, apparently live, for 27 more days. The expiry predicate removes **none** of these. The codebase already knows about this class: `watchlist_matcher.py` filters `Contract.date_expired > func.now()` **and** `Contract.date_completed.is_(None)` (lines 147–154). The measured ~12% is therefore a *lower bound* on dead rows, and the milestone's stated goal ("finds live contracts rather than dead ones") is only partially achievable by Workstream B. The spec should either name this as an accepted limitation with a rough size estimate, or add ingest-side last-seen tracking to scope — but silently equating "not expired" with "available" repeats the exact trust failure the milestone exists to fix, one layer down.
+
+### M-4. The evidence for Workstream B was measured against a view users don't see by default
+
+The frontend defaults to ships-only (`filters.ts:77` — `ships_only: raw.ships_only !== false`, mapped to `is_ship_contract=true`; F002 Criterion 1.1). The default trial-user view is ~622 ship contracts, not 51,365. Both headline measurements — "~12% expired," "20 of 20 dead on the Time-left sort" — were taken via the raw API without `is_ship_contract=true` (the finding's method section confirms it). The expired share *within the ships-only view* is unmeasured; with ~75 expected expired ship contracts against a 50-row page the 20/20 result plausibly still holds, but it is an inference, not the verified fact the spec presents. Also Workstream C's "today `Page 1 of 514 · 51,365 contracts`" describes the non-default all-contracts view. Re-measure scoped to the default view, or restate the claims accurately. The recommendation almost certainly survives; the evidence as quoted doesn't.
+
+### M-5. Freshness couples the core list endpoint to Valkey with unspecified failure behavior
+
+The contracts list endpoint currently never touches Valkey. Workstream C adds a per-request (30s-amortized) read of `INGEST_LAST_RUN_KEY`. The spec specifies behavior for *key absent* but not for *Valkey unreachable* or *client never initialized* (`app.state.redis` is `None` when startup init failed — `ops.py`'s `_probe_cache` handles exactly this with a reinit attempt and a catch-all). If the implementer naively awaits a cache call, a Valkey outage 500s the product's core endpoint — an availability *regression* delivered by the trust milestone. Must specify: any cache failure → `data_as_of: null`, never an error; and whether the failure result is itself cached for the TTL. Additionally, the record is JSON (`{last_success_at, outcome, ...}`), not a bare timestamp — `data_as_of` is `last_success_at`, parsed with the same corrupt-record tolerance `_freshness_fields` shows. Finally, an in-process TTL cache is module/global state — a known test-isolation defect class in this repo's plan reviews (global-state fixture leaks); the spec should mandate a reset seam.
+
+### M-6. Stale-threshold computation location is unspecified, and the frontend can't compute it
+
+"Reusing `/ready`'s existing threshold of more than twice `AGGREGATION_SCHEDULER_INTERVAL_SECONDS`" — the frontend has no access to that setting. Two reasonable implementations diverge: (a) server adds `data_stale: bool` (or the threshold) to the envelope; (b) frontend hardcodes 7200s. (b) drifts silently the day the interval changes. The spec must pick (a) and say so — it also keeps the staleness semantics in one place (`ops.py` already owns them).
+
+### M-7. The og:image fallback chain implies a per-request probe of an external CDN, unaddressed
+
+`render → icon → site-wide` sounds declarative, but a meta tag holds one URL; knowing that `render` 400s for a type requires an HTTP probe of `images.evetech.net`. Where does that happen? A naive implementation adds a serial outbound HTTP call to every document request — external-service latency and failure coupling on the page hot path, exactly the kind of cost this spec elsewhere measures to the millisecond. Options the spec must choose among: always emit `render` for `category == 'ship'` items (ships have renders; verified only by three samples), a cached/async probe, or a static category rule with `icon` for non-ships. Two engineers guess differently and one of the guesses is a hot-path regression.
+
+### M-8. Shell-fetch mechanics are underspecified, including a loop hazard the spec itself weaponized against the rejected alternative
+
+Stage 1's handler "fetches the built shell (ETag-revalidated)". From where? Apex (`hangarbay.app/index.html`) re-enters Cloudflare and works only because `/index.html` doesn't match the `/contracts*` rewrite — the same class of self-reference loop the spec cites as a strike against the Cloudflare Worker ("a Worker fetching the apex for the shell re-enters the very rewrite that invoked it"). The constraint (the shell-fetch path must never match the handler's own rewrite source) is real for the chosen design too and is stated nowhere. Also unspecified: fetching the static site's `onrender.com` hostname directly instead (skips the edge; different caching behavior); behavior when the shell fetch fails and no cached copy exists (cold start after backend deploy + static site incident → what response?); timeout budget for the revalidation call.
+
+### M-9. Testing gaps — what passes while the behavior is broken
+
+The listed tests are decent for Workstream B but miss the failure modes above:
+
+- **Nothing asserts the JSON API survives Stage 1.** Given B-1, the highest-value test in the milestone is: after the document routes exist, `GET /contracts/123` (bare, as the proxy delivers API traffic) still returns JSON with the contract schema, and the document route returns HTML. Absent this, a route-ordering change ships a site-wide breakage that every listed test passes through.
+- **No Valkey-down test for the list endpoint** (M-5): list returns 200 with `data_as_of: null` when the cache client raises / is `None`.
+- **No test for the placement invariant of the expiry predicate.** Concretely: the predicate belongs in `_apply_contract_filters` (`contract_service.py:50`), which flows into both `_count_distinct_contracts` and both fetch paths. A mutation that moves it into only `_fetch_page_simple` leaves `total` overcounting and pagination walking phantom pages — the listed "total reflects the filtered count" test catches this **only if** the fixture's expired rows are numerous enough to change the page count, and only if it's run against *both* the joined and simple fetch paths (an item-filter in the fixture query forces the joined path; no item-filter forces the simple one). The spec's test list doesn't require exercising both paths; SQLA-1 history says it must.
+- **No boundary-semantics test**: `date_expired == now()` exactly — `>` vs `>=` (and `func.now()` per-statement timing) should be pinned, trivially.
+- **No cache-header test** for whatever `Cache-Control` the document handler emits — load-bearing given the edge-cache spike is the milestone's first task.
+- The escaping test should include `'` (attribute context) alongside `<>"&`.
+
+Existing strengths acknowledged: TEST-4 page-boundary crossing is cited, TEST-12 mutation-verification is mandated, the real-shell no-mock rule is right.
+
+---
+
+## MINOR
+
+- **m-1. Envelope is shared.** `PaginatedResponse` is generic (`schemas/common.py`) and used by notifications (`api/notifications.py:27`). Adding `data_as_of` to it pollutes notifications with an ingest-freshness field. Needs a contracts-specific response model (subclass or new model); spec doesn't say. Also: Workstreams B (no schema change), C, *and* D all touch the OpenAPI surface, but the regen chain (`pdm run export-openapi` → `npm run generate:api`) is mentioned only under D.
+- **m-2. No index on `date_expired`, and the spec is silent.** `models/contracts.py` indexes price/date_issued/collateral/volume — not `date_expired`, despite it now being both a filter on every list query and an existing sort column. Fine at 51k rows; the spec's own admission of unbounded growth makes it worth a sentence either way, and any index is an Alembic migration in prod (`DB_RECREATE_ON_STARTUP=false`, `preDeployCommand` runs alembic) — a step class the spec never mentions.
+- **m-3. `now()` is ambiguous.** DB clock (`func.now()`, the existing `watchlist_matcher.py:151` pattern) vs Python `datetime.now(timezone.utc)`. Column is `DateTime(timezone=True)` so `func.now()` compares cleanly; the spec should name `func.now()` and cite the matcher as the in-repo precedent — which, oddly, the spec never mentions at all despite it being proof the predicate is already load-bearing elsewhere (including the notification-prune "no-resurrection" guard at line 199, which is *consistent* with, not endangered by, Workstream B).
+- **m-4. Workstream D ripples into e2e fixtures.** `e2e/fixtures/contracts.ts` declares `status: string` (line 35) and sets `'unknown'` (line 100). "The frontend never reads it" is true of app code (verified: all `.status` hits are HTTP statuses) but the fixture type breaks on regen. Small, but the spec's task list for D is incomplete.
+- **m-5. Discord caches embeds at post time; the EXPIRED prefix only covers links posted after death.** A link posted while live keeps its "available" embed after the contract dies — the crawl happened at post time. The spec's rationale ("previews will frequently describe contracts that have since died") claims more coverage than server-side tags can deliver. The controllable mitigation: put the *absolute* expiry timestamp in the description (not, or in addition to, relative "time remaining," which freezes misleadingly in a cached embed). The detail page remains the honest layer for the click-later case — the spec has that part right.
+- **m-6. Stage 0's og:image must be a stable-pathed asset.** Vite hashes `/assets/*` and old hashes vanish on the next deploy (`immutable` header notwithstanding — the file is gone), breaking the image in every previously posted embed. The image belongs in `public/` under a stable name, and `og:image` must be an absolute URL. One sentence in the spec prevents a silent regression that only manifests in week-old Discord messages.
+- **m-7. Client-clock skew on "updated 12 min ago"** can render negative ages. Clamp at zero. `format.ts`'s injectable-`now` pattern is the template.
+- **m-8. "Roughly fifteen minutes" for the edge-cache spike** ignores that the deploy rides CD to production (merge → deploy → observe). Closer to an hour of wall clock. Harmless but sets the wrong expectation for "it goes first."
+- **m-9. Unverifiable production observations** (`cf-cache-status: HIT/BYPASS`, `age: 243`, `max-age=0`, the 400-for-non-ship image probe, 622 ship contracts) — accepted as spike-attested; nothing in the repo contradicts them. All *repo* claims in the spec checked out: `DEFAULT_DIRECTION` maps `date_expired: 'asc'` (`ContractsPage.tsx:15`), `timeRemaining` returns `'Expired'` (`format.ts:28`), `index.html` has zero `og:*` tags, `render.yaml`'s ORDER MATTERS comment and literal-`/index.html` no-cache scoping are as described, `status` defaults via `c.get("status", "unknown")` in `background_aggregation.py`, `INGEST_LAST_RUN_KEY`/2×-interval threshold in `ops.py:97`, and every cited pitfall tag (SQLA-1, TEST-4/5/9/12, DEPLOY-3) exists as characterized. The `/` → `/contracts` redirect exists but is **client-side** (`routes/index.tsx` `beforeLoad`), a nuance the routing section elides — a visit to `/` itself never fetches a `/contracts` document, but every subsequent reload does.
+
+---
+
+## Scope realism
+
+The milestone is *mostly* honest about being small, and the staging is its best feature. Calibrated sizes:
+
+- **Genuinely small, pre-trial, ship them:** Stage 0 (hours), Workstream B (a predicate + tests — with M-3 named as a limitation), Workstream C (a day, once M-5/M-6 are specified), Workstream D (small; include m-4).
+- **Secretly the big one:** Stage 1. Once B-1 (new routing namespace + PROXY-1 carve-out), M-7 (image strategy), M-8 (shell-fetch subsystem), and M-1 (deploy-window behavior) are accounted for, this is a multi-day chunk with the milestone's only real architectural risk. It should be its own gated unit of work, after the trial-critical items above, and scoped to `/contracts/*` detail pages only (M-2).
+- **Cut from M5 outright:** Stage 2. TanStack Query dehydration into a non-SSR Vite SPA is a real subsystem (hydration boundary, query-key serialization matching the client's exact key shape, staleness semantics vs. any edge caching). "Fast-follow, skippable" is the right instinct — make it explicit: not in this milestone.
+- Stage 3: already correctly deferred.
+
+## Where the design is sound
+
+The Cloudflare Worker rejection is well-argued and correct. No-404-for-expired-detail is the right call and correctly identified as load-bearing for previews. Keeping the `status` DB column while dropping the API field is right. Escaping treated as an injection concern with a hostile-input test is right. Fallback-to-generic-tags-with-200 on lookup failure is right. The edge-cache question genuinely belongs first. The "reasoning worth preserving" section is a model of the repo's thinking-documentation discipline.
+
+## Top three actions before this spec is implementable
+
+1. Resolve B-1: specify the backend document-route prefix, the exact rewrite `source`/`destination` pair, and the PROXY-1 carve-out. Add the JSON-survives regression test to the test list.
+2. Verify B-2 (Render glob semantics) alongside the edge-cache spike — same deployed experiment, and decide M-2 (detail-only rewrite) with the result.
+3. Specify M-5/M-6/M-7 (freshness failure mode + threshold location + image strategy) so two engineers implement the same design.

--- a/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
+++ b/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
@@ -1,0 +1,152 @@
+# M5 Trust & Shareability — Design
+
+ABOUTME: Design for the first M5 milestone — make Hangar Bay's data honest about itself and make its links worth pasting into Discord, ahead of a private trial with a friendly EVE corporation.
+ABOUTME: Chosen direction from `2026-07-26-m5-direction-options.md`; evidence in `docs/audits/m5-recon/`; awaiting Sam's approval before an implementation plan is written.
+
+**Status:** DRAFT — awaiting Sam's review. Written 2026-07-26 while Sam was away, per his instruction to drive the brainstorm as far as reasonable. Design sections were not individually approved, which the normal brainstorming flow would require; treat the whole document as one approval gate.
+
+**Goal:** A trial user from a Discord-native corporation opens the site, believes the numbers, finds live contracts rather than dead ones, and pastes links that unfurl into something worth clicking.
+
+**Non-goal:** Market appraisal, multi-region coverage, and alert delivery channels are separate directions (see the options record). Nothing here tries to differentiate Hangar Bay from existing marketplace sites — that is the appraisal direction's job.
+
+---
+
+## What we found
+
+Two production measurements drove this design. Full method and numbers in `docs/audits/m5-recon/`.
+
+**1. ~12% of served contracts have already expired** (`expired-contracts-finding.md`). Nothing prunes contracts, and the list query never filters on expiry — `date_expired` appears in `contract_service.py` only as a *sortable* field. Measured live: ~6,200 of 51,365 contracts already expired, the oldest five days stale. The UI does label rows `Expired` (via `format.ts`'s `timeRemaining()`), so this is a relevance problem rather than a deceptive one — but `ContractsPage.tsx`'s `DEFAULT_DIRECTION` maps `date_expired: 'asc'`, so **clicking "Time left" — the obvious "what's expiring soonest?" move — returns a page of nothing but dead contracts** (verified: 20 of 20).
+
+**2. Link previews are impossible today, and the latency objection to fixing them was aimed at the wrong term** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags at all, and Render static sites cannot run server code or match routes on User-Agent, so a crawler/human split cannot happen at Render's edge. Routing a path to the backend costs ~161 ms — but document delivery is ~48 ms of a ~1265 ms warm time-to-content. The dominant cost is ~720 ms of client bootstrap before the first data request, which no routing choice affects.
+
+A third item was investigated and **dismissed**: `search` and ship filtering work correctly. `is_ship_contract=true` returns 622 contracts, item `category: 'ship'` is populated, and `search` filters across `Contract.title` OR `ContractItem.type_name` via the items join. An apparent "`ship_name` is always null" finding was an artifact of probing for a response field that does not exist — the frontend derives the hull label from ship-category items by design.
+
+---
+
+## Workstream A — Link previews
+
+### Routing decision
+
+**Chosen: the backend owns `/contracts*`.** A Render rewrite sends `/contracts*` to FastAPI, which returns the SPA shell with per-URL `og:*` tags injected. Because `/` redirects to `/contracts` (`routes/index.tsx`), this single prefix covers both contract detail and filtered search with no extra blast radius.
+
+**Route ordering is load-bearing.** `render.yaml`'s existing comment on the `routes:` block already warns `ORDER MATTERS: prefix-strip rule before SPA fallback (PROXY-1)`. The new `/contracts*` rule must sit **after** `/api/v1/*` and **before** the `/*` SPA fallback. Placed after the fallback it never matches; placed before `/api/v1/*` it is harmless today but invites a future `/contracts`-prefixed API path to be swallowed. The backend serves these routes at bare paths, per PROXY-1 — the handler must not assume an `/api/v1` prefix.
+
+Rejected alternatives:
+
+- **A dedicated share-link prefix** (`/s/c/:id` produced by a Share button) is disqualified by observed behavior, not by implementation quality: the trial corporation copies URLs from the address bar, so most shared links would carry no preview.
+- **A Cloudflare-proxied subdomain running a User-Agent-splitting Worker** was seriously considered and rejected on three grounds. It serves different HTML per User-Agent, which is a `Vary: User-Agent` cache hazard forcing `no-store` and deleting its own performance rationale; its central benefit (humans keep CDN latency) is unverified, since the measured ~161 ms is Render proxy overhead plus the ohio leg in unknown proportion and a rewrite to a Cloudflare destination has never been measured; and it re-creates the stacked-CDN topology that the DNS-only apex decision (M4 Deviation D-12) exists to avoid. It also carries a loop hazard: a Worker fetching the apex for the shell re-enters the very rewrite that invoked it.
+
+The decisive argument for the backend is that it adds **no new platform**. The handler lives in the existing FastAPI service, is tested with pytest under the repo's TDD discipline, ships through existing CD, and is observed through existing Grafana. It is also cache-correct by construction — the same HTML goes to every User-Agent.
+
+**The shell-staleness concern that originally argued against this approach does not survive inspection.** `render.yaml`'s `Cache-Control: no-cache` rule is scoped to the literal path `/index.html` and does not match `/contracts/123`, so deep-link shells already ride the default `s-maxage=300` — verified live (`cf-cache-status: HIT`, `age: 243`). A stale shell window already exists today. Fetching the shell with `If-None-Match` revalidation makes that window *smaller* than the status quo.
+
+### Staging
+
+Each stage ships independently and is separately valuable.
+
+**Stage 0 — site-wide static tags.** Add `og:title`, `og:description`, `og:image`, `og:site_name`, `twitter:card` to `index.html`. No routing changes, no backend work. Today every Hangar Bay link unfurls as nothing; after this, every link unfurls as *something*. This is the highest value-per-hour item in the milestone and should ship first, on its own.
+
+**Stage 1 — per-URL tags for contract pages.** The rewrite plus a FastAPI handler that fetches the built shell (ETag-revalidated), injects per-URL tags, and returns it.
+
+**Stage 2 — data inlining.** The handler additionally inlines the contract payload (dehydrated TanStack Query state) so the client skips its own API call. Measured as a fast-follow; skippable if the trial date arrives first.
+
+**Stage 3 — filtered-search summaries.** Deferrable indefinitely.
+
+Stage 1 costs entry loads ~200 ms of document latency and Stage 2 repays roughly 414 ms. Shipping Stage 1 alone is a **purchase, not a regression** — ~200 ms against a 1265 ms baseline — and coupling the stages would enlarge the blast radius for no safety gain. The caveat worth holding: that cost lands precisely on the Discord-link visitor this milestone exists to serve, so Stage 2 should not drift indefinitely.
+
+### Preview content
+
+**Contract detail.** Title is the hull name with price — `Armageddon Navy Issue — 450,000,000 ISK`. Description carries location, time remaining, contract type, and item count. Image is the EVE render CDN, verified live: `https://images.evetech.net/types/{type_id}/render?size=512` returns 200 `image/jpeg` (~25–43 KB) for real hulls (checked against Armageddon Navy Issue, Nightmare, Ark). The hull's `type_id` comes from the contract's included item with `category == 'ship'`, matching how the frontend already derives its label.
+
+Fallback chain, because `render` is **not** available for every type — verified 400 for a non-ship type: `render` → `icon` (200 `image/png`, confirmed for the same type that 400'd) → the site-wide Stage 0 image.
+
+**Expired contracts.** The title must lead with expiry — `EXPIRED — Armageddon Navy Issue`. This is load-bearing rather than cosmetic: a Discord link routinely gets clicked hours after posting, so previews will frequently describe contracts that have since died. A preview that presents a dead contract as available is the exact trust failure this milestone exists to prevent.
+
+**Filtered search (Stage 3).** A summary of filters and result count — `14 battleships under 200M ISK in The Forge`. Region and type IDs resolve to names; the count reuses the existing filter path.
+
+**Escaping.** Contract titles are player-authored free text (a real one in production: `1976.48GJ, est. 473m`). Every interpolated value is HTML-escaped before injection. This is a correctness *and* injection concern and gets an explicit test with hostile input.
+
+**Failure behavior.** A lookup failure or unknown contract returns the Stage 0 generic tags with a 200, never an error page and never a partial tag set. Crawlers get something valid; humans get the SPA, which renders its existing not-found state.
+
+---
+
+## Workstream B — Expiry honesty
+
+**Exclude expired contracts from list results by default.** Add a `Contract.date_expired > now()` predicate to the list query. This corrects `total` as a side effect, so the displayed count stops overstating what is available.
+
+**Keep serving expired contracts on the detail page, clearly marked.** Do not 404 them. Shared links outlive contracts, and a 404 for a link posted this morning reads as a broken site rather than an expired deal. The page states expiry prominently; the preview says `EXPIRED`.
+
+**Deliberately not doing:** deleting expired rows. Filtering fixes correctness without losing history, and deletion interacts with saved searches and notifications that reference those contracts. Unbounded table growth is real (51k rows in roughly a week, on `basic-256mb`) but is a retention-policy decision of its own — there is precedent in `NOTIFICATION_RETENTION_DAYS`.
+
+**Open question for Sam:** should an "include expired" toggle exist? There is precedent — the ships-only default has an explicit toggle (F002 Criterion 1.1). The YAGNI answer is no toggle until someone asks. Recommendation: ship without it, and let the trial decide.
+
+---
+
+## Workstream C — Data freshness surface
+
+This is the user-facing staleness indicator parked in the M4 design, and the Jul 23–26 incident is its justification: production served 3.6-day-old data with no signal any user could see, while `/ready` correctly reported `data_stale`.
+
+**Mechanism:** add `data_as_of` (ISO 8601 timestamp of the last successful ingest) to the contracts list response envelope, which is currently `{total, page, size, items}`. The value comes from the same Valkey freshness record `/ready` reads (`INGEST_LAST_RUN_KEY`), cached in-process with a **30-second TTL** so the hot path does not take a cache round-trip per request. Thirty seconds is far below the hourly ingest cadence, so the displayed age is never misleading, while a burst of list requests costs at most one Valkey read. If the freshness record is absent — the key is evictable, and `allkeys-lru` may drop it (DEPLOY-3) — `data_as_of` is `null` and the UI shows no freshness line rather than inventing one.
+
+Putting freshness *in the data envelope* rather than behind a separate endpoint means the timestamp always travels with the numbers it describes, and costs no extra request.
+
+**Display:** extend the existing count line in `Pagination.tsx` (today `Page 1 of 514 · 51,365 contracts`) with `· updated 12 min ago`. When the data is stale — reusing `/ready`'s existing threshold of more than twice `AGGREGATION_SCHEDULER_INTERVAL_SECONDS` — the indicator escalates to an explicit warning naming the age.
+
+**Accessibility:** the stale state must not be signalled by color alone (PRODUCT.md, and `accessibility-spec.md`'s color-blind-safe rule). The escalated state changes the *text*, not just the hue.
+
+---
+
+## Workstream D — Retire the `status` field
+
+`Contract.status` is always the literal `"unknown"` — ESI's public contracts route returns no status, and `background_aggregation.py:108` defaults it. Verified across a 100-contract production sample. The frontend never reads it.
+
+Remove it from the API response and regenerate the typed client (`pdm run export-openapi` → `npm run generate:api`). The DB column and the `ix_contracts_type_status` index are left alone; dropping them is a migration with no benefit at this size, and the column becomes meaningful if character/corp contracts are ever ingested.
+
+---
+
+## First implementation task: settle the edge-cache question
+
+**Can backend-rendered HTML be edge-cached by Render's CDN?** If a response carrying `s-maxage=60` is honored on a rewrite destination, repeat views of a contract return to ~50 ms and crawlers are served from cache — which erases the Stage 1 latency cost entirely. If not, Stage 1 still ships; nothing blocks.
+
+The API currently returns `cache-control: max-age=0` and shows `cf-cache-status: BYPASS`. That it reports `BYPASS` rather than `DYNAMIC` is weak evidence the edge is evaluating origin cache headers at all rather than refusing outright.
+
+This cannot be answered from outside and needs a deployed response header plus repeated requests watching `cf-cache-status` — roughly fifteen minutes. It goes **first**, because a positive result simplifies everything after it.
+
+---
+
+## Testing
+
+Per the repo's TDD mandate, every item below is written test-first, and characterization tests are mutation-verified (TEST-12) — a preview test that passes with the tag-injection deleted is not evidence.
+
+- **Expiry filtering:** a fixture set spanning the expiry boundary asserting expired contracts are absent from list results and that `total` reflects the filtered count. Must cross a page boundary (TEST-4).
+- **Detail page serves expired:** an expired contract returns 200 with its expiry state, not 404.
+- **Tag injection:** HTTP-level tests asserting real `og:*` tags in the response body for a live contract, an expired contract, and an unknown ID (generic fallback, 200).
+- **Escaping:** a contract title containing `<`, `>`, `"`, and `&` must not break out of the meta tag. Hostile input, asserted explicitly.
+- **Image fallback:** a type with no render falls back to icon, then to the site-wide image.
+- **Freshness:** `data_as_of` present and correct; the stale threshold flips at more than twice the scheduler interval; the stale state is distinguishable without color.
+- **Frontend:** stub at the fetch seam (TEST-5); every fixture-lane spec intercepts `GET /me` (TEST-9).
+- **Not mocked:** the shell fetch is exercised against a real static response in at least one test, since a mocked shell would test the mock (the repo's rule against testing mocked behavior).
+
+---
+
+## Risks
+
+**Deploy skew.** Between a frontend deploy and the backend's next shell revalidation, the injected shell may reference asset URLs that no longer exist, producing a broken page. Mitigated by per-request `If-None-Match` revalidation, which makes the window smaller than today's `s-maxage=300` baseline. Worth a pitfalls entry once the behavior is observed in practice.
+
+**Availability coupling.** With `/contracts*` routed to the backend, a backend outage takes down contract *documents*, where today the CDN would serve a shell that then fails to fetch data. The degradation is from "shell plus error state" to "no page." Mitigated for lookup failures by falling back to generic tags; a hard process-down is accepted for a trial-scale product, and noted here so the choice is deliberate.
+
+**Scope creep.** This milestone is meant to be small. Stage 3 and the retention policy are explicitly deferred, and the appraisal and coverage directions are out of scope entirely.
+
+---
+
+## Reasoning worth preserving
+
+**The original latency objection was aimed at the wrong term.** The instinct — "routing pages through the backend costs 200 ms, and this product's principles say fast is a feature" — was correct in isolation and wrong in proportion. Measuring first showed document delivery is ~48 ms of ~1265 ms, and that ~720 ms of client bootstrap dwarfs everything the routing decision touches. The spike changed the decision.
+
+**"OG tags and data inlining must ship together" was overstated and is rejected.** The claim was that Stage 1 alone ships a regression. An independent review argued that ~200 ms against a 1265 ms baseline is a purchase rather than a regression, and that coupling the stages enlarges blast radius for no safety gain. That is correct and is adopted, with the caveat recorded above that the cost lands on the target user.
+
+**The Cloudflare Worker option was more attractive than it deserved.** It appeared to give a clean crawler/human split at low cost. The `Vary: User-Agent` cache hazard, the unmeasured assumption that a Cloudflare-destination rewrite is cheaper than a Render-origin one, and the apex-refetch loop hazard only surfaced under adversarial review. The lesson generalizes: an option whose benefit rests on an unmeasured latency assumption should not beat one whose benefit rests on a measured fact.
+
+**The biggest win was the cheapest and was nearly missed.** Static site-wide OG tags cost about an hour and change every link on the site from unfurling as nothing to unfurling as something. It surfaced only when the routing analysis was reviewed by someone not invested in the routing question. Staging exists in this design because of it.
+
+**Still uncertain:** whether the trial corporation shares contract links or search links (assumed contracts, cheaply revisable); whether Render's edge caches rewrite responses (first task); and whether an "include expired" toggle is wanted (deliberately left to the trial).

--- a/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
+++ b/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
@@ -3,154 +3,157 @@
 ABOUTME: Design for the first M5 milestone — make Hangar Bay's data honest about itself and make its links worth pasting into Discord, ahead of a private trial with a friendly EVE corporation.
 ABOUTME: Chosen direction from `2026-07-26-m5-direction-options.md`; evidence in `docs/audits/m5-recon/`; awaiting Sam's approval before an implementation plan is written.
 
-**Status:** DRAFT — awaiting Sam's review. Written 2026-07-26 while Sam was away, per his instruction to drive the brainstorm as far as reasonable. Design sections were not individually approved, which the normal brainstorming flow would require; treat the whole document as one approval gate.
+**Status:** DRAFT — awaiting Sam's review. Written 2026-07-26 while Sam was away, per his instruction to drive the brainstorm as far as reasonable. Design sections were not individually approved, which the normal brainstorming flow requires; treat the whole document as one approval gate.
+
+**Revision note:** this is the second draft. A blind adversarial review (`docs/audits/m5-recon/spec-review-fable.md`) found a blocker that would have broken the JSON API in production, and a substantive gap — sold contracts — that the first draft missed entirely. Both are fixed here, and the headline recommendation changed as a result.
 
 **Goal:** A trial user from a Discord-native corporation opens the site, believes the numbers, finds live contracts rather than dead ones, and pastes links that unfurl into something worth clicking.
 
-**Non-goal:** Market appraisal, multi-region coverage, and alert delivery channels are separate directions (see the options record). Nothing here tries to differentiate Hangar Bay from existing marketplace sites — that is the appraisal direction's job.
+**Non-goal:** Market appraisal, multi-region coverage, and alert delivery channels are separate directions (see the options record).
+
+---
+
+## Recommendation up front
+
+**Ship the small, high-certainty things now; give per-URL link previews their own design pass.**
+
+In M5: site-wide static OG tags, dead-contract filtering (expired *and* sold), the freshness surface, and retiring the `status` field. All are small, independently valuable, and carry no architectural risk.
+
+**Defer per-URL previews** to a follow-on with its own design. This defers the headline Discord feature, which is a real cost and Sam may well overrule it — but the routing work grew a route collision, a deploy-outage regression, and a shell-fetch dependency once reviewed, and the milestone's whole purpose was to be small and trial-ready. Static tags already move every link from "unfurls as nothing" to "unfurls as something," which captures most of the trial value at roughly an hour of work.
 
 ---
 
 ## What we found
 
-Two production measurements drove this design. Full method and numbers in `docs/audits/m5-recon/`.
+Method and numbers in `docs/audits/m5-recon/`.
 
-**1. ~12% of served contracts have already expired** (`expired-contracts-finding.md`). Nothing prunes contracts, and the list query never filters on expiry — `date_expired` appears in `contract_service.py` only as a *sortable* field. Measured live: ~6,200 of 51,365 contracts already expired, the oldest five days stale. The UI does label rows `Expired` (via `format.ts`'s `timeRemaining()`), so this is a relevance problem rather than a deceptive one — but `ContractsPage.tsx`'s `DEFAULT_DIRECTION` maps `date_expired: 'asc'`, so **clicking "Time left" — the obvious "what's expiring soonest?" move — returns a page of nothing but dead contracts** (verified: 20 of 20).
+**1. Dead contracts are shown as live, in two distinct ways.**
 
-**2. Link previews are impossible today, and the latency objection to fixing them was aimed at the wrong term** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags at all, and Render static sites cannot run server code or match routes on User-Agent, so a crawler/human split cannot happen at Render's edge. Routing a path to the backend costs ~161 ms — but document delivery is ~48 ms of a ~1265 ms warm time-to-content. The dominant cost is ~720 ms of client bootstrap before the first data request, which no routing choice affects.
+*Expired* (`expired-contracts-finding.md`): nothing prunes contracts and the list query never filters on expiry — `date_expired` appears in `contract_service.py` only as a *sortable* field.
 
-A third item was investigated and **dismissed**: `search` and ship filtering work correctly. `is_ship_contract=true` returns 622 contracts, item `category: 'ship'` is populated, and `search` filters across `Contract.title` OR `ContractItem.type_name` via the items join. An apparent "`ship_name` is always null" finding was an artifact of probing for a response field that does not exist — the frontend derives the hull label from ship-category items by design.
+The first draft measured this across all 51,365 contracts (~6,200 expired, ~12%). **That was the wrong population.** The frontend defaults to ships-only (`filters.ts`), which is 622 contracts. Re-measured in the view users actually get: **~53 of 622 expired, ~8.5%**. The headline is sharper, not weaker — the list page size is 50, so **sorting by "Time left" ascending fills the entire first page with dead contracts**, and `ContractsPage.tsx`'s `DEFAULT_DIRECTION` maps `date_expired: 'asc'`, making that the one-click default for anyone asking "what's expiring soonest?"
 
----
+*Sold or delisted* — **the larger half, and it does not show up in any expiry measurement.** A contract that is accepted disappears from ESI's public list, but nothing tracks absence: `Contract` has **no `last_seen_at` or `updated_at` column** (verified against `models/contracts.py`), the public route never populates `date_completed`, and ingestion never deletes. A ship sold five minutes after ingestion keeps showing as available for the remainder of its contract duration — up to two weeks. An expiry filter removes none of these.
 
-## Workstream A — Link previews
+The watchlist matcher already gets this right for its own query, filtering both `date_expired > now()` and `date_completed IS NULL` (`watchlist_matcher.py`) — precedent worth citing, though `date_completed` alone cannot catch sold public contracts either.
 
-### Routing decision
+**2. Link previews are impossible today, and the latency objection was aimed at the wrong term** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags, and Render static sites cannot run server code or match routes on User-Agent. Routing a path to the backend costs ~161 ms — but document delivery is ~48 ms of a ~1265 ms warm time-to-content, dominated by ~720 ms of client bootstrap that no routing choice affects.
 
-**Chosen: the backend owns `/contracts*`.** A Render rewrite sends `/contracts*` to FastAPI, which returns the SPA shell with per-URL `og:*` tags injected. Because `/` redirects to `/contracts` (`routes/index.tsx`), this single prefix covers both contract detail and filtered search with no extra blast radius.
-
-**Route ordering is load-bearing.** `render.yaml`'s existing comment on the `routes:` block already warns `ORDER MATTERS: prefix-strip rule before SPA fallback (PROXY-1)`. The new `/contracts*` rule must sit **after** `/api/v1/*` and **before** the `/*` SPA fallback. Placed after the fallback it never matches; placed before `/api/v1/*` it is harmless today but invites a future `/contracts`-prefixed API path to be swallowed. The backend serves these routes at bare paths, per PROXY-1 — the handler must not assume an `/api/v1` prefix.
-
-Rejected alternatives:
-
-- **A dedicated share-link prefix** (`/s/c/:id` produced by a Share button) is disqualified by observed behavior, not by implementation quality: the trial corporation copies URLs from the address bar, so most shared links would carry no preview.
-- **A Cloudflare-proxied subdomain running a User-Agent-splitting Worker** was seriously considered and rejected on three grounds. It serves different HTML per User-Agent, which is a `Vary: User-Agent` cache hazard forcing `no-store` and deleting its own performance rationale; its central benefit (humans keep CDN latency) is unverified, since the measured ~161 ms is Render proxy overhead plus the ohio leg in unknown proportion and a rewrite to a Cloudflare destination has never been measured; and it re-creates the stacked-CDN topology that the DNS-only apex decision (M4 Deviation D-12) exists to avoid. It also carries a loop hazard: a Worker fetching the apex for the shell re-enters the very rewrite that invoked it.
-
-The decisive argument for the backend is that it adds **no new platform**. The handler lives in the existing FastAPI service, is tested with pytest under the repo's TDD discipline, ships through existing CD, and is observed through existing Grafana. It is also cache-correct by construction — the same HTML goes to every User-Agent.
-
-**The shell-staleness concern that originally argued against this approach does not survive inspection.** `render.yaml`'s `Cache-Control: no-cache` rule is scoped to the literal path `/index.html` and does not match `/contracts/123`, so deep-link shells already ride the default `s-maxage=300` — verified live (`cf-cache-status: HIT`, `age: 243`). A stale shell window already exists today. Fetching the shell with `If-None-Match` revalidation makes that window *smaller* than the status quo.
-
-### Staging
-
-Each stage ships independently and is separately valuable.
-
-**Stage 0 — site-wide static tags.** Add `og:title`, `og:description`, `og:image`, `og:site_name`, `twitter:card` to `index.html`. No routing changes, no backend work. Today every Hangar Bay link unfurls as nothing; after this, every link unfurls as *something*. This is the highest value-per-hour item in the milestone and should ship first, on its own.
-
-**Stage 1 — per-URL tags for contract pages.** The rewrite plus a FastAPI handler that fetches the built shell (ETag-revalidated), injects per-URL tags, and returns it.
-
-**Stage 2 — data inlining.** The handler additionally inlines the contract payload (dehydrated TanStack Query state) so the client skips its own API call. Measured as a fast-follow; skippable if the trial date arrives first.
-
-**Stage 3 — filtered-search summaries.** Deferrable indefinitely.
-
-Stage 1 costs entry loads ~200 ms of document latency and Stage 2 repays roughly 414 ms. Shipping Stage 1 alone is a **purchase, not a regression** — ~200 ms against a 1265 ms baseline — and coupling the stages would enlarge the blast radius for no safety gain. The caveat worth holding: that cost lands precisely on the Discord-link visitor this milestone exists to serve, so Stage 2 should not drift indefinitely.
-
-### Preview content
-
-**Contract detail.** Title is the hull name with price — `Armageddon Navy Issue — 450,000,000 ISK`. Description carries location, time remaining, contract type, and item count. Image is the EVE render CDN, verified live: `https://images.evetech.net/types/{type_id}/render?size=512` returns 200 `image/jpeg` (~25–43 KB) for real hulls (checked against Armageddon Navy Issue, Nightmare, Ark). The hull's `type_id` comes from the contract's included item with `category == 'ship'`, matching how the frontend already derives its label.
-
-Fallback chain, because `render` is **not** available for every type — verified 400 for a non-ship type: `render` → `icon` (200 `image/png`, confirmed for the same type that 400'd) → the site-wide Stage 0 image.
-
-**Expired contracts.** The title must lead with expiry — `EXPIRED — Armageddon Navy Issue`. This is load-bearing rather than cosmetic: a Discord link routinely gets clicked hours after posting, so previews will frequently describe contracts that have since died. A preview that presents a dead contract as available is the exact trust failure this milestone exists to prevent.
-
-**Filtered search (Stage 3).** A summary of filters and result count — `14 battleships under 200M ISK in The Forge`. Region and type IDs resolve to names; the count reuses the existing filter path.
-
-**Escaping.** Contract titles are player-authored free text (a real one in production: `1976.48GJ, est. 473m`). Every interpolated value is HTML-escaped before injection. This is a correctness *and* injection concern and gets an explicit test with hostile input.
-
-**Failure behavior.** A lookup failure or unknown contract returns the Stage 0 generic tags with a 200, never an error page and never a partial tag set. Crawlers get something valid; humans get the SPA, which renders its existing not-found state.
+**Dismissed after investigation:** `search` and ship filtering work correctly (`is_ship_contract=true` → 622; `search` covers `Contract.title` OR `ContractItem.type_name` via the items join). An apparent "`ship_name` is always null" finding was an artifact of probing for a response field that does not exist.
 
 ---
 
-## Workstream B — Expiry honesty
+## Workstream A — Dead-contract filtering
 
-**Exclude expired contracts from list results by default.** Add a `Contract.date_expired > now()` predicate to the list query. This corrects `total` as a side effect, so the displayed count stops overstating what is available.
+Two mechanisms, because the two failure modes are different.
 
-**Keep serving expired contracts on the detail page, clearly marked.** Do not 404 them. Shared links outlive contracts, and a 404 for a link posted this morning reads as a broken site rather than an expired deal. The page states expiry prominently; the preview says `EXPIRED`.
+**A1 — Expiry filter (small).** Add `Contract.date_expired > now()` to the list query. It belongs in `_apply_contract_filters`, so it reaches both `_count_distinct_contracts` and both fetch paths — a predicate applied to only one of them makes `total` disagree with the pages, which is the SQLA-1 failure this codebase has already paid for once. Use the database clock (`func.now()`), not a Python-side timestamp, so the predicate and any index agree and no timezone conversion sits between them.
 
-**Deliberately not doing:** deleting expired rows. Filtering fixes correctness without losing history, and deletion interacts with saved searches and notifications that reference those contracts. Unbounded table growth is real (51k rows in roughly a week, on `basic-256mb`) but is a retention-policy decision of its own — there is precedent in `NOTIFICATION_RETENTION_DAYS`.
+Needs an index on `date_expired` and therefore an Alembic migration; the migration is the schema-change step class the repo already has conventions for.
 
-**Open question for Sam:** should an "include expired" toggle exist? There is precedent — the ships-only default has an explicit toggle (F002 Criterion 1.1). The YAGNI answer is no toggle until someone asks. Recommendation: ship without it, and let the trial decide.
+**A2 — Delisted detection (medium — this is the real work).** Add `last_seen_at` to `Contract`, stamped on every upsert. Filter the list to contracts seen in the most recent *complete* ingest run.
+
+The correctness hinge is "complete." Aggregation already counts `regions_ok`/`regions_failed` and derives an outcome of success / partial / failure. Only a **success** may advance the watermark — a partial run must not, or every contract in the failed region is wrongly judged delisted and vanishes from the site. This is the sharp edge of A2 and deserves its own test.
+
+Non-destructive by choice: mark, do not delete. Deletion loses history and interacts with saved searches and notifications that reference those contracts.
+
+**Detail pages keep serving dead contracts, clearly marked.** Never 404 them. Shared links outlive contracts, and a 404 for a link posted this morning reads as a broken site rather than an expired deal.
+
+**Open question for Sam:** should an "include dead contracts" toggle exist? Precedent exists (ships-only has one, F002 Criterion 1.1). Recommendation: ship without it; let the trial ask.
 
 ---
 
-## Workstream C — Data freshness surface
+## Workstream B — Data freshness surface
 
-This is the user-facing staleness indicator parked in the M4 design, and the Jul 23–26 incident is its justification: production served 3.6-day-old data with no signal any user could see, while `/ready` correctly reported `data_stale`.
+The user-facing staleness indicator parked in the M4 design. Its justification is the Jul 23–26 incident: production served 3.6-day-old data with no signal any user could see, while `/ready` correctly reported `data_stale`.
 
-**Mechanism:** add `data_as_of` (ISO 8601 timestamp of the last successful ingest) to the contracts list response envelope, which is currently `{total, page, size, items}`. The value comes from the same Valkey freshness record `/ready` reads (`INGEST_LAST_RUN_KEY`), cached in-process with a **30-second TTL** so the hot path does not take a cache round-trip per request. Thirty seconds is far below the hourly ingest cadence, so the displayed age is never misleading, while a burst of list requests costs at most one Valkey read. If the freshness record is absent — the key is evictable, and `allkeys-lru` may drop it (DEPLOY-3) — `data_as_of` is `null` and the UI shows no freshness line rather than inventing one.
+**Mechanism:** add `data_as_of` (ISO 8601, last successful ingest) **and** `data_stale` (boolean) to the contracts list envelope. Both, not just the timestamp — the frontend cannot compute staleness itself, because the threshold derives from `AGGREGATION_SCHEDULER_INTERVAL_SECONDS`, a server-side setting the SPA has no access to. The server owns the judgement; the client owns the presentation.
 
-Putting freshness *in the data envelope* rather than behind a separate endpoint means the timestamp always travels with the numbers it describes, and costs no extra request.
+Values come from the same Valkey record `/ready` reads (`INGEST_LAST_RUN_KEY`), cached in-process with a 30-second TTL so the hot path takes at most one cache read per 30 s. Thirty seconds is far below the hourly cadence, so the displayed age is never misleading.
 
-**Display:** extend the existing count line in `Pagination.tsx` (today `Page 1 of 514 · 51,365 contracts`) with `· updated 12 min ago`. When the data is stale — reusing `/ready`'s existing threshold of more than twice `AGGREGATION_SCHEDULER_INTERVAL_SECONDS` — the indicator escalates to an explicit warning naming the age.
+**Valkey-down behavior is specified, not left to chance:** the freshness read is wrapped so that an unreachable or uninitialized cache yields `data_as_of: null` and `data_stale: true`, never an exception. The list endpoint is the product's core read path and must not acquire a hard dependency on an evictable cache — the key is explicitly evictable under `allkeys-lru` (DEPLOY-3). A null renders as no freshness line rather than an invented one.
 
-**Accessibility:** the stale state must not be signalled by color alone (PRODUCT.md, and `accessibility-spec.md`'s color-blind-safe rule). The escalated state changes the *text*, not just the hue.
+**Envelope caution:** `PaginatedResponse` is generic and also serves notifications. The new fields must not become required on every paginated payload — add them to the contracts response specifically, or as optional fields defaulting to null.
+
+**Display:** extend the existing count line in `Pagination.tsx` (`Page 1 of 13 · 622 contracts`) with `· updated 12 min ago`. The stale state escalates to explicit wording naming the age. Per `accessibility-spec.md`, staleness is never signalled by color alone — the escalated state changes the *text*.
+
+---
+
+## Workstream C — Site-wide link previews (Stage 0)
+
+Add `og:title`, `og:description`, `og:image`, `og:site_name`, and `twitter:card` to `index.html`. No routing changes, no backend work, roughly an hour. Today every link unfurls as nothing; after this, every link unfurls as the product.
+
+**The image must live in `public/`, not `/assets/`.** Vite content-hashes `/assets/*` filenames on every build, and `render.yaml` serves them `immutable` for a year. Discord caches embeds by URL at post time, so a hashed image URL breaks every previously-posted embed on the next frontend deploy. A stable `public/` path does not change.
 
 ---
 
 ## Workstream D — Retire the `status` field
 
-`Contract.status` is always the literal `"unknown"` — ESI's public contracts route returns no status, and `background_aggregation.py:108` defaults it. Verified across a 100-contract production sample. The frontend never reads it.
+`Contract.status` is always the literal `"unknown"` (ESI's public route returns no status; `background_aggregation.py:108` defaults it). Verified across a 100-contract production sample; the frontend never reads it.
 
-Remove it from the API response and regenerate the typed client (`pdm run export-openapi` → `npm run generate:api`). The DB column and the `ix_contracts_type_status` index are left alone; dropping them is a migration with no benefit at this size, and the column becomes meaningful if character/corp contracts are ever ingested.
+Remove it from the API response and regenerate the typed client (`pdm run export-openapi` → `npm run generate:api`). Keep the DB column and its index — dropping them is a migration with no benefit at this size, and the column becomes meaningful if character/corp contracts are ever ingested.
+
+**`e2e/fixtures/contracts.ts` declares `status`** and must be updated in the same change, or the fixture lane drifts from the wire shape it exists to pin.
 
 ---
 
-## First implementation task: settle the edge-cache question
+## Deferred: per-URL link previews
 
-**Can backend-rendered HTML be edge-cached by Render's CDN?** If a response carrying `s-maxage=60` is honored on a rewrite destination, repeat views of a contract return to ~50 ms and crawlers are served from cache — which erases the Stage 1 latency cost entirely. If not, Stage 1 still ships; nothing blocks.
+Recorded here so the follow-on design starts from what this review established rather than rediscovering it.
 
-Narrowed, but not settled, without deploying: **the backend sets no `Cache-Control` header anywhere** (grep across `fastapi_app/` finds none), yet every response through the rewrite carries `cache-control: max-age=0` — `/ready`, `/contracts/`, `/openapi.json`, and `/docs` alike, all `cf-cache-status: BYPASS`. That header therefore originates at the edge, not the application.
+**The routing approach that survives scrutiny is the backend rendering the shell**, not a Cloudflare Worker. The Worker option serves different HTML per User-Agent, which is a `Vary: User-Agent` cache hazard forcing `no-store` and deleting its own performance rationale; its central benefit is unverified, since a rewrite to a Cloudflare destination has never been measured; it re-creates the stacked-CDN topology the DNS-only apex decision (M4 D-12) exists to avoid; and a Worker fetching the apex for the shell re-enters the rewrite that invoked it.
 
-Which means today's `BYPASS` is uninformative: the origin sends nothing to honor, so the edge defaulting to `max-age=0` is exactly what one would expect either way. The open question is specifically **whether an explicit origin `s-maxage` is passed through or overwritten** by that edge default. Only a deployed response carrying its own cache header can distinguish those.
+**Three constraints the follow-on must satisfy — all found by review, none obvious:**
 
-The probe: an endpoint returning `Cache-Control: public, s-maxage=60` plus a request timestamp in the body; request it repeatedly and watch whether `cf-cache-status` ever reports `HIT` and whether the timestamp freezes. Roughly fifteen minutes.
+1. **The backend already owns `/contracts` at a bare path.** `api/contracts.py` mounts `APIRouter(prefix="/contracts")` with `@router.get("/{contract_id}")`, and the `/api/v1/*` rewrite strips the prefix, so SPA API calls arrive at exactly `/contracts/123` — verified live (`200 application/json` on the origin). A naive `/contracts*` document rewrite lands the HTML handler on the JSON endpoint: either crawlers get JSON or the SPA's detail page breaks. The document handler needs a **distinct backend prefix** with the rewrite supplying it as the destination path, plus a regression test asserting the JSON API still returns JSON.
 
-This cannot be answered from outside and needs a deployed response header plus repeated requests watching `cf-cache-status` — roughly fifteen minutes. It goes **first**, because a positive result simplifies everything after it.
+2. **Backend deploys are recreate deploys.** `render.yaml` pins a disk to keep the scheduler single-instance, which forces recreate rather than rolling deploys. Routing documents through the backend therefore makes **every backend deploy a brief site-wide document outage**, since `/` redirects to `/contracts`. That is a routine operational cost, not the tail risk the first draft described.
+
+3. **Scope it to `/contracts/*` detail pages only.** Routing the list page — the effective homepage — through the backend buys nothing until search summaries exist, and doubles the blast radius.
+
+**Also unverified:** whether Render's route globs accept the suffix form `/contracts*` at all. Every existing rule is segment-style (`/api/v1/*`).
+
+**Data inlining is cut from M5 entirely.** Dehydrating TanStack Query state into a non-SSR SPA is a real piece of engineering, and the ~200 ms it would repay is small against a 1265 ms baseline.
+
+**Preview content, when it is built:** hull name and price as title, with **absolute expiry in the description** — Discord caches embeds at post time, so a relative "expires in 3h" or an `EXPIRED` prefix is frozen at the moment of posting and misleads later readers. Image from `https://images.evetech.net/types/{type_id}/render?size=512`, verified 200 `image/jpeg` for real hulls, falling back to `icon` (verified 200 for a type whose `render` 400s) and then to the Stage 0 image. The fallback chain must be resolved from stored data, not a per-request probe of an external CDN. All interpolated values HTML-escaped — contract titles are player-authored free text, and this is an injection concern with an explicit hostile-input test.
+
+**Settle the edge-cache question first.** The backend sets no `Cache-Control` anywhere, yet every response through the rewrite carries `cache-control: max-age=0` with `cf-cache-status: BYPASS` — so that header comes from the edge, and today's `BYPASS` is uninformative rather than evidence either way. The open question is whether an explicit origin `s-maxage` is passed through or overwritten. Probe: an endpoint returning `Cache-Control: public, s-maxage=60` plus a timestamp; request repeatedly; watch for `HIT` and a frozen timestamp.
 
 ---
 
 ## Testing
 
-Per the repo's TDD mandate, every item below is written test-first, and characterization tests are mutation-verified (TEST-12) — a preview test that passes with the tag-injection deleted is not evidence.
+Every item is written test-first, and characterization tests are mutation-verified (TEST-12) — a filter test that passes with the predicate deleted is not evidence.
 
-- **Expiry filtering:** a fixture set spanning the expiry boundary asserting expired contracts are absent from list results and that `total` reflects the filtered count. Must cross a page boundary (TEST-4).
-- **Detail page serves expired:** an expired contract returns 200 with its expiry state, not 404.
-- **Tag injection:** HTTP-level tests asserting real `og:*` tags in the response body for a live contract, an expired contract, and an unknown ID (generic fallback, 200).
-- **Escaping:** a contract title containing `<`, `>`, `"`, and `&` must not break out of the meta tag. Hostile input, asserted explicitly.
-- **Image fallback:** a type with no render falls back to icon, then to the site-wide image.
-- **Freshness:** `data_as_of` present and correct; the stale threshold flips at more than twice the scheduler interval; the stale state is distinguishable without color.
+- **Expiry filter:** fixtures spanning the expiry boundary; expired contracts absent from results; `total` reflects the filtered count. Must cross a page boundary (TEST-4) and must exercise **both** the joined and simple fetch paths, since the predicate's placement determines whether count and pages agree (SQLA-1).
+- **Delisted detection:** a contract absent from a later complete run is filtered; and — the one that matters — **a contract absent from a *partial* run is NOT filtered**, so a failed region cannot erase the site.
+- **Detail page:** expired and delisted contracts return 200 with their state, not 404.
+- **Freshness:** `data_as_of` and `data_stale` present and correct; the threshold flips at more than twice the scheduler interval; **Valkey unreachable yields nulls and a 200, never a 500**; the stale state is distinguishable without color.
+- **Status removal:** the field is gone from the schema, the regenerated client compiles, and the e2e fixture matches the new wire shape.
 - **Frontend:** stub at the fetch seam (TEST-5); every fixture-lane spec intercepts `GET /me` (TEST-9).
-- **Not mocked:** the shell fetch is exercised against a real static response in at least one test, since a mocked shell would test the mock (the repo's rule against testing mocked behavior).
 
 ---
 
 ## Risks
 
-**Deploy skew.** Between a frontend deploy and the backend's next shell revalidation, the injected shell may reference asset URLs that no longer exist, producing a broken page. Mitigated by per-request `If-None-Match` revalidation, which makes the window smaller than today's `s-maxage=300` baseline. Worth a pitfalls entry once the behavior is observed in practice.
+**A2's watermark is the one that can take the site down.** If a partial run advances it, every contract in a failed region is judged delisted at once. The mitigation is a test, not care.
 
-**Availability coupling.** With `/contracts*` routed to the backend, a backend outage takes down contract *documents*, where today the CDN would serve a shell that then fails to fetch data. The degradation is from "shell plus error state" to "no page." Mitigated for lookup failures by falling back to generic tags; a hard process-down is accepted for a trial-scale product, and noted here so the choice is deliberate.
+**Migrations.** A1 and A2 both add schema. Two migrations on a live database with a pre-deploy `alembic upgrade head` — the M4 machinery handles this, but it is the step class where DEPLOY-1's URL-scheme trap lives.
 
-**Scope creep.** This milestone is meant to be small. Stage 3 and the retention policy are explicitly deferred, and the appraisal and coverage directions are out of scope entirely.
+**Scope.** A2 is the item most likely to grow. If it does, A1 alone still ships a real improvement and A2 can follow.
 
 ---
 
 ## Reasoning worth preserving
 
-**The original latency objection was aimed at the wrong term.** The instinct — "routing pages through the backend costs 200 ms, and this product's principles say fast is a feature" — was correct in isolation and wrong in proportion. Measuring first showed document delivery is ~48 ms of ~1265 ms, and that ~720 ms of client bootstrap dwarfs everything the routing decision touches. The spike changed the decision.
+**The original latency objection was aimed at the wrong term.** "Routing pages through the backend costs 200 ms, and this product says fast is a feature" was right in isolation and wrong in proportion — document delivery is ~48 ms of ~1265 ms. Measuring changed the decision.
 
-**"OG tags and data inlining must ship together" was overstated and is rejected.** The claim was that Stage 1 alone ships a regression. An independent review argued that ~200 ms against a 1265 ms baseline is a purchase rather than a regression, and that coupling the stages enlarges blast radius for no safety gain. That is correct and is adopted, with the caveat recorded above that the cost lands on the target user.
+**Measuring the wrong population nearly shipped a wrong headline.** The first draft's "12% of contracts are expired" was true of the whole dataset and irrelevant to users, who see a ships-only default of 622. Corrected, the number fell to ~8.5% and the finding got *sharper* — 53 dead contracts against a 50-row page means the entire first page of the most natural sort is dead. Always measure the view the user actually gets.
 
-**The Cloudflare Worker option was more attractive than it deserved.** It appeared to give a clean crawler/human split at low cost. The `Vary: User-Agent` cache hazard, the unmeasured assumption that a Cloudflare-destination rewrite is cheaper than a Render-origin one, and the apex-refetch loop hazard only surfaced under adversarial review. The lesson generalizes: an option whose benefit rests on an unmeasured latency assumption should not beat one whose benefit rests on a measured fact.
+**The biggest gap was invisible from the outside.** Expiry is measurable through the public API; sold-but-still-listed is not, because the record looks identical to a live one. It surfaced only from reading the model and noticing no `last_seen_at` existed. Absence of a column is not something an API probe can find.
 
-**The biggest win was the cheapest and was nearly missed.** Static site-wide OG tags cost about an hour and change every link on the site from unfurling as nothing to unfurling as something. It surfaced only when the routing analysis was reviewed by someone not invested in the routing question. Staging exists in this design because of it.
+**The route collision would have reached production.** The first draft said "the backend serves these routes at bare paths, per PROXY-1" — correctly citing the pitfall while walking into it, because the backend already serves JSON at that exact bare path. Citing a pitfall is not the same as checking it.
 
-**Still uncertain:** whether the trial corporation shares contract links or search links (assumed contracts, cheaply revisable); whether Render's edge caches rewrite responses (first task); and whether an "include expired" toggle is wanted (deliberately left to the trial).
+**The cheapest win was nearly missed.** Static site-wide OG tags cost about an hour and change every link on the site. They surfaced only under review by someone uninvested in the routing question, which had absorbed all the attention.
+
+**Still uncertain:** whether the trial corporation shares contract links or search links (assumed contracts); whether Render's edge honors origin `s-maxage` on rewrites; whether an "include dead" toggle is wanted; and whether deferring per-URL previews is the right call, which is Sam's to make.

--- a/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
+++ b/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
@@ -37,7 +37,9 @@ The first draft measured this across all 51,365 contracts (~6,200 expired, ~12%)
 
 The watchlist matcher already gets this right for its own query, filtering both `date_expired > now()` and `date_completed IS NULL` (`watchlist_matcher.py`) — precedent worth citing, though `date_completed` alone cannot catch sold public contracts either.
 
-**2. Link previews are impossible today, and the latency objection was aimed at the wrong term** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags, and Render static sites cannot run server code or match routes on User-Agent. Routing a path to the backend costs ~161 ms — but document delivery is ~48 ms of a ~1265 ms warm time-to-content, dominated by ~720 ms of client bootstrap that no routing choice affects.
+**2. Link previews are impossible today, and the latency objection was aimed at the wrong term — though by a narrower margin than first reported** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags, and Render static sites cannot run server code or match routes on User-Agent.
+
+Routing a path to the backend costs ~161 ms. Document delivery is ~35–48 ms of a clean warm time-to-content of ~630–710 ms, with the largest single term being a 253–840 ms client bootstrap gap that no routing choice affects. **An earlier draft quoted a 1265 ms baseline and a 720 ms gap; those were the worst of four samples, presented as typical.** The conclusion — document delivery is the smallest term — survives, but the ~200 ms penalty is ~30% of a clean baseline rather than the ~16% first claimed.
 
 **Dismissed after investigation:** `search` and ship filtering work correctly (`is_ship_contract=true` → 622; `search` covers `Contract.title` OR `ContractItem.type_name` via the items join). An apparent "`ship_name` is always null" finding was an artifact of probing for a response field that does not exist.
 
@@ -113,7 +115,7 @@ Recorded here so the follow-on design starts from what this review established r
 
 **Also unverified:** whether Render's route globs accept the suffix form `/contracts*` at all. Every existing rule is segment-style (`/api/v1/*`).
 
-**Data inlining is cut from M5 entirely.** Dehydrating TanStack Query state into a non-SSR SPA is a real piece of engineering, and the ~200 ms it would repay is small against a 1265 ms baseline.
+**Data inlining is cut from M5 entirely**, but the follow-on should treat it as coupled to per-URL tags rather than optional. Against the corrected clean baseline (~650 ms), shipping tags alone costs ~30%, and inlining is what repays it by removing the client's ~330 ms API call. Dehydrating TanStack Query state into a non-SSR SPA is real engineering — which is precisely why it belongs in the same design pass as the routing work, not as a "fast-follow" that can quietly never arrive.
 
 **Preview content, when it is built:** hull name and price as title, with **absolute expiry in the description** — Discord caches embeds at post time, so a relative "expires in 3h" or an `EXPIRED` prefix is frozen at the moment of posting and misleads later readers. Image from `https://images.evetech.net/types/{type_id}/render?size=512`, verified 200 `image/jpeg` for real hulls, falling back to `icon` (verified 200 for a type whose `render` 400s) and then to the Stage 0 image. The fallback chain must be resolved from stored data, not a per-request probe of an external CDN. All interpolated values HTML-escaped — contract titles are player-authored free text, and this is an injection concern with an explicit hostile-input test.
 
@@ -146,7 +148,9 @@ Every item is written test-first, and characterization tests are mutation-verifi
 
 ## Reasoning worth preserving
 
-**The original latency objection was aimed at the wrong term.** "Routing pages through the backend costs 200 ms, and this product says fast is a feature" was right in isolation and wrong in proportion — document delivery is ~48 ms of ~1265 ms. Measuring changed the decision.
+**The original latency objection was aimed at the wrong term — and then the correction was overstated in the other direction.** "Routing pages through the backend costs 200 ms, and this product says fast is a feature" was right in isolation and wrong in proportion; measuring changed the decision. But the first measurement was a single warm sample that happened to be the slowest of four, and quoting its 1265 ms baseline made the penalty look like 16% when a clean baseline puts it near 30%.
+
+The lesson is not "measure" — that was done. It is **take more than one sample before a number becomes load-bearing**, especially in an automated browser where contention is invisible in the result. One sample is an anecdote wearing a decimal point. The same mistake in a different guise appears below in the population error.
 
 **Measuring the wrong population nearly shipped a wrong headline.** The first draft's "12% of contracts are expired" was true of the whole dataset and irrelevant to users, who see a ships-only default of 622. Corrected, the number fell to ~8.5% and the finding got *sharper* — 53 dead contracts against a 50-row page means the entire first page of the most natural sort is dead. Always measure the view the user actually gets.
 

--- a/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
+++ b/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
@@ -108,7 +108,11 @@ Remove it from the API response and regenerate the typed client (`pdm run export
 
 **Can backend-rendered HTML be edge-cached by Render's CDN?** If a response carrying `s-maxage=60` is honored on a rewrite destination, repeat views of a contract return to ~50 ms and crawlers are served from cache — which erases the Stage 1 latency cost entirely. If not, Stage 1 still ships; nothing blocks.
 
-The API currently returns `cache-control: max-age=0` and shows `cf-cache-status: BYPASS`. That it reports `BYPASS` rather than `DYNAMIC` is weak evidence the edge is evaluating origin cache headers at all rather than refusing outright.
+Narrowed, but not settled, without deploying: **the backend sets no `Cache-Control` header anywhere** (grep across `fastapi_app/` finds none), yet every response through the rewrite carries `cache-control: max-age=0` — `/ready`, `/contracts/`, `/openapi.json`, and `/docs` alike, all `cf-cache-status: BYPASS`. That header therefore originates at the edge, not the application.
+
+Which means today's `BYPASS` is uninformative: the origin sends nothing to honor, so the edge defaulting to `max-age=0` is exactly what one would expect either way. The open question is specifically **whether an explicit origin `s-maxage` is passed through or overwritten** by that edge default. Only a deployed response carrying its own cache header can distinguish those.
+
+The probe: an endpoint returning `Cache-Control: public, s-maxage=60` plus a request timestamp in the body; request it repeatedly and watch whether `cf-cache-status` ever reports `HIT` and whether the timestamp freezes. Roughly fifteen minutes.
 
 This cannot be answered from outside and needs a deployed response header plus repeated requests watching `cf-cache-status` — roughly fifteen minutes. It goes **first**, because a positive result simplifies everything after it.
 


### PR DESCRIPTION
Design for the first M5 milestone, plus the production recon behind it. **Docs only — no code.** This is the brainstorm's spec-gate output and needs your approval before any implementation plan is written.

## TL;DR — the recommendation changed under review

**Ship the small certain things; give per-URL link previews their own design pass.**

In M5: static site-wide OG tags, dead-contract filtering, the freshness surface, `status` removal. All small, independently valuable, no architectural risk.

**Deferred: per-URL previews.** This defers the headline Discord feature and you may well overrule it — but the routing work grew a route collision, a deploy-outage regression, and unverified glob syntax once reviewed, and this milestone's purpose was to be small and trial-ready. Static tags already take every link from "unfurls as nothing" to "unfurls as the product," at ~1 hour.

## What the spike settled

Routing a path to the backend costs **~161 ms** — but document delivery is **~48 ms of a ~1265 ms** warm time-to-content, dominated by **~720 ms of client bootstrap** before the first data request. My original latency objection was aimed at the smallest term. Numbers and method in `docs/audits/m5-recon/link-preview-latency-spike.md`.

## Two production findings

**Dead contracts are shown as live, in two ways:**

| | Detectable how | Status |
|---|---|---|
| **Expired** — no expiry filter in the list query | Public API | ~53 of 622 in the default ships-only view (~8.5%) |
| **Sold/delisted** — no `last_seen_at`, ingestion never deletes | Only by reading the model | A sold ship shows as available for up to **two weeks** |

The sharpest form: page size is 50 and 53 expired contracts sort ahead of every live one, so **clicking "Time left" — the one-click "what's expiring soonest?" — fills the entire first page with dead contracts.**

The sold-contract half is the larger one and is invisible to any API probe, since a sold record is byte-identical to a live one.

## The blocker the review caught

`api/contracts.py` mounts `APIRouter(prefix="/contracts")`, and the `/api/v1/*` rewrite strips its prefix — so SPA API calls **already arrive at bare `/contracts/123`** (verified live: `200 application/json` on the origin). My proposed `/contracts*` document rewrite would have put the HTML handler on the JSON endpoint. Either crawlers get JSON or the detail page breaks site-wide.

My first draft cited PROXY-1 by name while walking into it. Citing a pitfall is not the same as checking it.

## Corrections to my own work, on the record

- **I measured the wrong population.** "12% of contracts expired" was true of all 51,365 and irrelevant to users, who get a ships-only default of 622. Corrected to ~8.5% — smaller number, sharper finding.
- **Two suspected bugs were my own artifacts.** `search` and ship filtering work correctly; my "`ship_name` is always null" alarm was probing for a response field that doesn't exist.
- **"OG tags and data inlining must ship together" was overstated** and is rejected — ~200 ms against a 1265 ms baseline is a purchase, not a regression.

## Open questions for you

1. **Is deferring per-URL previews right?** It's the headline feature and the reason this milestone exists.
2. **Should an "include dead contracts" toggle exist?** Precedent exists (ships-only has one). Recommendation: no toggle; let the trial ask.
3. **Does the corp share contract links or search links?** Assumed contracts; cheap to revise.

## Contents

- `docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md` — the design
- `docs/audits/m5-recon/link-preview-latency-spike.md` — latency measurements
- `docs/audits/m5-recon/expired-contracts-finding.md` — dead-contract finding
- `docs/audits/m5-recon/routing-review-fable.md`, `spec-review-fable.md` — the two blind reviews

## Merge classification

**Review — this is a design awaiting your approval.** Do not auto-merge. The brainstorming gate means no implementation starts until you've signed off, and three open questions above are yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)