### PR TITLE
docs(audit): withdraw the client-bootstrap gap — it was measuring contention

### DIFF
--- a/docs/audits/m5-recon/link-preview-latency-spike.md
+++ b/docs/audits/m5-recon/link-preview-latency-spike.md
@@ -48,24 +48,42 @@ Warm load (assets HTTP-cached — the returning-user case). **Four samples, beca
 | 3 | 66 ms | 364 ms | **298 ms** | **711 ms** |
 | 4 | 46 ms | 299 ms | **253 ms** | **628 ms** |
 
-**Honest range: a 253–840 ms bootstrap gap and 628–1265 ms time-to-content.** Samples 3 and 4 ran clean; samples 1 and 2 show contention. Sample 2 is instructive — two *cache-hit* modules (`format-*.js`, `useWatchlist-*.js`, both `transferSize === 0`) reported 825 ms durations, which reads as main-thread blocking or cache-read stalling rather than real work.
+> **SUPERSEDED (2026-07-26, same day): every one of those four samples was contaminated.** Re-measured in a freshly opened browser tab, the bootstrap gap is **≈ 0** — three clean samples gave **2 ms, 10 ms and −12 ms** (negative because the API request fires *before* the last cached asset finishes; they overlap). Time-to-content was **~457 ms**, with FCP at 100–304 ms.
+>
+> The four samples below were taken in a tab that had been open across many navigations and heavy `Runtime.evaluate` calls. **The "bootstrap gap" was contention in the measuring environment, not work the application does.** Sample 2's two *cache-hit* modules reporting 825 ms durations was the tell, and it was misread as evidence of app cost rather than as evidence that the whole tab was stalled.
+>
+> **Corrected figures: warm time-to-content ~450–500 ms, of which the document is ~35–50 ms and the API call ~270 ms. There is no meaningful client-bootstrap term.**
+>
+> Original contaminated table preserved below, because the sequence of wrong numbers is the useful part.
 
-**What the gap is, and is not.** It is not asset downloading: every JS/CSS file was a cache hit in every sample. It is the interval after the bundles are in hand and before `useQuery` issues its request — main-bundle execution, React mount, TanStack Router resolving the route, the route component rendering. The breakdown *within* that window was not instrumented (no `longtask` entries were captured), so no attribution between JS execution, framework init, and application logic is claimed here.
+**Contaminated range (superseded): a 253–840 ms bootstrap gap and 628–1265 ms time-to-content.** Samples 3 and 4 ran clean *relative to the others*; samples 1 and 2 show heavy contention.
+
+**What the gap was, and was not.** Not asset downloading — every JS/CSS file was a cache hit in every sample. It was assumed to be main-bundle execution, React mount, TanStack Router route resolution and render. **That assumption was wrong**: in a clean tab the interval is ~0, so there is no app-side bootstrap cost to attribute.
+
+**How that was settled, and a trap in the instrument.** `performance.getEntriesByType('longtask')` always returns empty — long tasks are only reachable through a `PerformanceObserver`. A first attempt with `observe({type:'longtask', buffered:true})` returned zero entries and was nearly reported as "no main-thread blocking". It was a **false negative**: validating the instrument by deliberately blocking the main thread for 220 ms and re-querying returned zero as well. Chrome keeps **no buffer for `longtask`**, so `buffered: true` retrieves nothing retroactively, even though it works for `paint` (verified — it returns `first-paint`/`first-contentful-paint`).
+
+What does work:
+- **Live observation** — register the observer *before* the work; the 220 ms synthetic block was caught correctly.
+- **`long-animation-frame`** (LoAF) is supported here and is the right modern tool: it carries per-script attribution (`sourceURL`, `sourceFunctionName`, `invoker`) plus a style/layout breakdown. It also needs pre-load registration.
+
+**So instrumenting load-time attribution requires registering an observer before the app boots — a code change** (an inline script in `index.html`, or `performance.mark()` calls at module-eval, mount, route-resolve and query-issue boundaries, with `performance.measure()` between them). That work was **not** done, because the re-measurement removed the thing it would have explained: there is no gap left to attribute.
+
+**Never trust a zero from an unvalidated instrument.** Prove the instrument can see the thing before concluding the thing is absent.
 
 Measured on a 10-core / 16 GB machine in an automated browser. A real user's Chrome may show less contention; the clean samples are probably closer to reality than the slow ones.
 
 ## What this means for the routing decision
 
-1. **Document delivery is the smallest component of time-to-content**, not the largest. Against a clean warm baseline of ~630–710 ms, the document is ~35–48 ms. Optimizing document delivery to protect "fast is a feature" was aiming at the wrong term. This conclusion survives the corrected numbers — but by a smaller margin than the first draft claimed.
+1. **Document delivery is a real term, and the conclusion that it was negligible does NOT survive.** Against the corrected clean baseline of ~450–500 ms, the document is ~35–50 ms and the API call ~270 ms. With the imagined bootstrap gap gone, there is no large term for document delivery to hide behind.
 
-2. **Routing contract pages through the backend costs ~200 ms of document delivery** (edge HIT → origin BYPASS). Against the originally-quoted 1265 ms baseline that is ~16%; against the clean ~650 ms baseline it is **closer to ~30%**. The first framing understated it, because it compared against the slowest observed sample.
+2. **Routing contract pages through the backend costs ~200 ms of document delivery** (edge HIT → origin BYPASS). That is ~16% of the originally-quoted 1265 ms, ~30% of the once-corrected ~650 ms, and **~40%+ of the true ~450–500 ms baseline**. The estimate got worse at every re-measurement; each earlier figure flattered the change.
 
-3. **Inlining contract data into the server-rendered shell removes the client's separate API call (~414 ms).** Net effect is roughly **300 ms faster than today**, not slower. This inverts the original objection. The backend already holds the data in-process for the OG tags, so inlining costs one query it was already making — unlike a Cloudflare Worker, which would need a second network fetch to get it.
+3. **Inlining contract data into the server-rendered shell removes the client's separate API call (~270 ms).** Tags plus inlining lands around ~250–300 ms against today's ~450–500 ms — still **net faster**, by roughly 150–200 ms rather than the ~300 ms first estimated. The backend already holds the data in-process for the OG tags, so inlining costs one query it was already making — unlike a Cloudflare Worker, which would need a second network fetch to get it.
 
-4. **Consequence for scoping.** Shipping tags without inlining costs entry loads ~200 ms — about 30% of a clean baseline. That is a real regression rather than a rounding error, though not obviously a blocking one; whether to couple the stages is a judgement call, and the corrected numbers make coupling more defensible than the first draft concluded.
+4. **Consequence for scoping.** Shipping tags without inlining costs entry loads ~200 ms — **~40%+ of the true baseline**, and it is the *only* stage that is pure cost. Tags-alone is a regression users would feel; tags-plus-inlining is an improvement. On the corrected numbers these should ship together, which is where this spike started before two inflated baselines argued otherwise.
 
 5. **Two larger performance findings fall out of this spike and are out of scope here**, recorded so they are not lost:
-   - **The bootstrap gap (253–840 ms) is the largest single term in warm time-to-content**, larger than the API call in the clean samples and far larger than document delivery. It has nothing to do with link previews and is the biggest available lever on page speed.
+   - ~~The bootstrap gap is the largest single term~~ — **withdrawn**. There is no bootstrap gap; it was measurement contention. The largest term is the API call (~270 ms), most of which is the origin penalty below.
    - **Every SPA API call pays the ~161 ms origin penalty**, site-wide, on every page.
 
 ## Open question this spike could not resolve

--- a/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
+++ b/docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md
@@ -39,7 +39,9 @@ The watchlist matcher already gets this right for its own query, filtering both 
 
 **2. Link previews are impossible today, and the latency objection was aimed at the wrong term — though by a narrower margin than first reported** (`link-preview-latency-spike.md`). `index.html` carries no `og:*` tags, and Render static sites cannot run server code or match routes on User-Agent.
 
-Routing a path to the backend costs ~161 ms. Document delivery is ~35–48 ms of a clean warm time-to-content of ~630–710 ms, with the largest single term being a 253–840 ms client bootstrap gap that no routing choice affects. **An earlier draft quoted a 1265 ms baseline and a 720 ms gap; those were the worst of four samples, presented as typical.** The conclusion — document delivery is the smallest term — survives, but the ~200 ms penalty is ~30% of a clean baseline rather than the ~16% first claimed.
+Routing a path to the backend costs ~161 ms. **Corrected 2026-07-26 after re-measuring in a clean browser tab:** warm time-to-content is **~450–500 ms** — document ~35–50 ms, API call ~270 ms — and the "client bootstrap gap" this design twice leaned on **does not exist**. Measured at 2 ms, 10 ms and −12 ms in a fresh tab; the earlier 253–840 ms figures were contention in a long-lived measuring tab, not work the app does.
+
+That removes the argument that document delivery is negligible: the ~200 ms routing penalty is **~40%+ of the real baseline**, not the ~16% first claimed or the ~30% of the first correction. Each successive measurement made the change look worse, which is the direction that should have been assumed.
 
 **Dismissed after investigation:** `search` and ship filtering work correctly (`is_ship_contract=true` → 622; `search` covers `Contract.title` OR `ContractItem.type_name` via the items join). An apparent "`ship_name` is always null" finding was an artifact of probing for a response field that does not exist.
 
@@ -115,7 +117,7 @@ Recorded here so the follow-on design starts from what this review established r
 
 **Also unverified:** whether Render's route globs accept the suffix form `/contracts*` at all. Every existing rule is segment-style (`/api/v1/*`).
 
-**Data inlining is cut from M5 entirely**, but the follow-on should treat it as coupled to per-URL tags rather than optional. Against the corrected clean baseline (~650 ms), shipping tags alone costs ~30%, and inlining is what repays it by removing the client's ~330 ms API call. Dehydrating TanStack Query state into a non-SSR SPA is real engineering — which is precisely why it belongs in the same design pass as the routing work, not as a "fast-follow" that can quietly never arrive.
+**Data inlining is cut from M5 entirely**, but the follow-on should treat it as **coupled to per-URL tags, not optional**. Against the true ~450–500 ms baseline, shipping tags alone costs ~40%+, and inlining is what repays it by removing the client's ~270 ms API call. On these numbers the original "both or neither" instinct was closer to right than the review that talked me out of it — the review's arithmetic was sound, but it was fed an inflated baseline. Dehydrating TanStack Query state into a non-SSR SPA is real engineering — which is precisely why it belongs in the same design pass as the routing work, not as a "fast-follow" that can quietly never arrive.
 
 **Preview content, when it is built:** hull name and price as title, with **absolute expiry in the description** — Discord caches embeds at post time, so a relative "expires in 3h" or an `EXPIRED` prefix is frozen at the moment of posting and misleads later readers. Image from `https://images.evetech.net/types/{type_id}/render?size=512`, verified 200 `image/jpeg` for real hulls, falling back to `icon` (verified 200 for a type whose `render` 400s) and then to the Stage 0 image. The fallback chain must be resolved from stored data, not a per-request probe of an external CDN. All interpolated values HTML-escaped — contract titles are player-authored free text, and this is an injection concern with an explicit hostile-input test.
 
@@ -148,7 +150,7 @@ Every item is written test-first, and characterization tests are mutation-verifi
 
 ## Reasoning worth preserving
 
-**The original latency objection was aimed at the wrong term — and then the correction was overstated in the other direction.** "Routing pages through the backend costs 200 ms, and this product says fast is a feature" was right in isolation and wrong in proportion; measuring changed the decision. But the first measurement was a single warm sample that happened to be the slowest of four, and quoting its 1265 ms baseline made the penalty look like 16% when a clean baseline puts it near 30%.
+**The same number was wrong three times, in the same direction.** Time-to-content was quoted as 1265 ms (one sample, the slowest of four), then ~650 ms (four samples, all from a contaminated tab), then finally ~450–500 ms (clean tab). Each figure made routing through the backend look cheaper than it is: 16%, then 30%, then 40%+. The "720 ms client bootstrap" that justified dismissing document latency was never real — it was contention in the measuring environment, and it survived a re-measurement because the re-measurement reused the same dirty tab.
 
 The lesson is not "measure" — that was done. It is **take more than one sample before a number becomes load-bearing**, especially in an automated browser where contention is invisible in the result. One sample is an anecdote wearing a decimal point. The same mistake in a different guise appears below in the population error.
 


### PR DESCRIPTION
Corrects a load-bearing number that was wrong three times, always in the same direction.

## What changed

The "~720 ms of client bootstrap" that this design twice used to argue document latency was negligible **does not exist**. Re-measured in a freshly opened browser tab:

| | Bootstrap gap | Time-to-content |
|---|---|---|
| Originally reported (1 sample) | 720 ms | 1265 ms |
| First correction (4 samples, same dirty tab) | 253–840 ms | 628–1265 ms |
| **Clean tab (3 samples)** | **2 ms, 10 ms, −12 ms** | **~450–500 ms** |

The −12 ms is not noise: the API request fires *before* the last cached asset finishes, so they overlap. There is no bootstrap phase to speak of.

All four earlier samples came from a tab left open across many navigations and heavy `Runtime.evaluate` calls. Sample 2's two **cache-hit** modules reporting 825 ms durations was the tell — I read it as evidence of application cost when it was evidence the whole tab was stalled.

## Why it matters

It makes the routing change look **worse**, not better. The ~200 ms penalty for serving contract documents from the backend is:

- ~16% of the originally-quoted 1265 ms
- ~30% of the once-corrected ~650 ms
- **~40%+ of the true ~450–500 ms baseline**

Each successive measurement flattered the change less. Consequently **per-URL tags and data inlining should ship together** — tags alone is pure cost users would feel; tags plus inlining still nets ~150–200 ms faster. That is where the spike started, before two inflated baselines argued me out of it. The review that talked me out of "both or neither" had sound arithmetic; it was fed a bad baseline.

## On instrumentation (the question that prompted this)

The first attempt to attribute the gap reported zero long tasks. That was a **false negative**: Chrome keeps no buffer for `longtask`, so `buffered: true` retrieves nothing retroactively — verified by deliberately blocking the main thread for 220 ms and still reading zero, while the same buffered flag works fine for `paint`.

What works: live observation (caught the synthetic block), and `long-animation-frame`, which carries per-script attribution. Both need registering **before** the app boots — an inline script in `index.html`, or `performance.mark()` at module-eval / mount / route-resolve / query-issue boundaries.

That code change was **not** made, because re-measuring removed the thing it would have explained. Recorded so the next person reaches for LoAF rather than `longtask`, and so the general rule survives: **never trust a zero from an unvalidated instrument.**

The contaminated table is preserved under a SUPERSEDED banner — the sequence of wrong numbers is the useful part.

## Merge classification

**Routine** — documentation only. Corrects published figures; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)