### PR TITLE
fix(api): keep caplog loggers alive across alembic fileConfig

### DIFF
--- a/app/backend/src/alembic/env.py
+++ b/app/backend/src/alembic/env.py
@@ -25,7 +25,9 @@ target_metadata = Base.metadata
 def run_migrations_offline() -> None:
     config = context.config
     if config.config_file_name is not None:
-        fileConfig(config.config_file_name)
+        # disable_existing_loggers=False: migrations run in-process under pytest, and the
+        # default (True) would kill every already-created logger, breaking caplog assertions.
+        fileConfig(config.config_file_name, disable_existing_loggers=False)
     context.configure(
         url=str(settings.DATABASE_URL),
         target_metadata=target_metadata,
@@ -62,7 +64,9 @@ async def run_migrations_online_async_cli():
 def run_migrations_online():
     config = context.config
     if config.config_file_name is not None:
-        fileConfig(config.config_file_name)
+        # disable_existing_loggers=False: migrations run in-process under pytest, and the
+        # default (True) would kill every already-created logger, breaking caplog assertions.
+        fileConfig(config.config_file_name, disable_existing_loggers=False)
     connectable = context.config.attributes.get("connection", None)
     if connectable is None:
         asyncio.run(run_migrations_online_async_cli())


### PR DESCRIPTION
## What

`src/alembic/env.py` called `logging.config.fileConfig(...)` with its default `disable_existing_loggers=True`, which tears down every logger already created in the process. Both call sites now pass `disable_existing_loggers=False` with a comment stating why.

## Why

Running `tests/test_migrations.py` before `tests/services/test_background_aggregation.py` in one pytest process kills the aggregation service's logger before those tests run, so their `caplog` assertions see an empty log. The full suite is green today only because default collection order happens to run `services/` first — the hazard fires on reordered, sharded, or targeted runs.

## Evidence (RED then GREEN)

Ordered pair, one process, **before** the fix:

```
FAILED .../test_background_aggregation.py::test_lock_release_does_not_delete_a_reacquired_lock
FAILED .../test_background_aggregation.py::test_structure_ids_are_excluded_from_name_resolution
FAILED .../test_background_aggregation.py::test_run_aggregation_rejects_non_list_region_config
FAILED .../test_background_aggregation.py::test_run_aggregation_rejects_region_list_containing_a_non_int
FAILED .../test_background_aggregation.py::test_run_aggregation_skips_on_empty_region_list
FAILED .../test_background_aggregation.py::test_fetch_regions_isolates_one_regions_failure
FAILED .../test_background_aggregation.py::test_apply_dev_limit_truncates_and_warns
7 failed, 26 passed in 2.01s
```

Representative assertion: `assert 'DEV_MODE: Limiting contracts to process from 3 to 2.' in ''` — the message was logged, but the logger was disabled so `caplog.text` was empty.

Same ordered pair **after** the fix:

```
33 passed in 1.99s
```

Full backend suite after the fix: `458 passed in 28.83s`, pristine output. `pdm run lint` exits 0.

## Merge classification

Routine

🤖 Generated with [Claude Code](https://claude.com/claude-code)