### PR TITLE
docs(strategy): contract-coverage gap analysis + MCP surface research

### DIFF
--- a/docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md
+++ b/docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md
@@ -1,0 +1,158 @@
+<!-- ABOUTME: Gap analysis of Hangar Bay vs EVE Workbench's market tool and the wider EVE marketplace-tool ecosystem, -->
+<!-- ABOUTME: motivating the decision to display all ingested contract types (not just ships) and sketching an MCP surface. -->
+
+# Contract coverage gap analysis: Hangar Bay vs EVE Workbench and the marketplace-tool ecosystem
+
+**Date:** 2026-08-01
+**Status:** Analysis complete; decisions pending Sam
+**Prompting question:** "Should we at least display the data for all these other contracts we're ingesting besides plain ships?"
+
+## 0. Method and evidence quality
+
+Five parallel research lanes, run 2026-08-01 (Opus/Sonnet subagents; findings synthesized here):
+
+1. **EVE Workbench live recon** — drove the rendered site (v2.2.0) anonymously; extracted the full Angular route table (62 routes) and grepped the shipped JS bundle for contract features. High confidence.
+2. **Hangar Bay code + prod inventory** — file:line-verified pass over ingestion, API, and frontend; prod quantification via the public API (live corpus `total` counts are exact; contract-type/category breakdowns are a 12.7% systematic sample, validated by matching the sampled BPC rate 49.6% against the exact 49.7%). Render MCP was unauthorized, so these are *live visible corpus* numbers, not raw table counts.
+3. **Ecosystem recon** — Adam4EVE, MutaMarket, EVE Ref, EVE Tycoon, Fuzzwork, Janice, jita.space, via server-rendered HTML, public API specs, and app bundles. Mostly primary-source; flagged inferences noted inline.
+4. **Domain research** — ESI public-contracts schema, player use-cases per contract type, appraisal-source conventions. ESI schema facts verified against the OpenAPI spec.
+5. **MCP surface research** — see §7.
+
+A parallel verify-and-fix lane confirmed the defects in §4.4 and is producing a Review-classified PR from branch `claude/contract-filter-bugfixes`.
+
+## 1. Headline findings
+
+1. **We already ingest the whole market and display 1.2% of it.** The live Forge corpus is 33,817 contracts; 411 are ship-flagged. All three contract types are stored; items are fetched for every item_exchange and auction; the ships-only view is purely a client-side default (`ships_only` in `app/frontend/web/src/features/contracts/filters.ts`). The "All Contracts" view already ships behind one checkbox — unlabeled, un-columned, and un-designed for what it contains.
+2. **The non-ship market is BPCs and abyssals, not junk.** 49.1% of live contracts contain a blueprint copy (16,609 — ~40× the ship market by count). The top non-ship item types cluster into abyssal/mutated modules and capital-component blueprints, plus skill injectors and containers. These are exactly the item classes that *cannot* trade on the regular market — contracts are their only marketplace.
+3. **EVE Workbench has no contracts feature at all.** Confirmed definitively: no contract route among all 62 routes; the word "contract" appears in their bundle only as paste-source instructions for their appraisal/refinery tools. Their market tool is a plain order browser (no charts, stats, or derived metrics).
+4. **The competitive void is real and specific.** Across the seven surveyed tools, only Adam4EVE browses public contracts — and it is maintenance-only (© 2013-2021, "not being developed further"), returning `Too many connections` on roughly half of requests. MutaMarket proves the model works but covers only abyssal modules. EVE Tycoon's contract features are personal-history-only behind a paid tier. **Nobody in the ecosystem handles courier contracts.**
+5. **We drop, at ingestion, exactly the fields the non-ship market runs on.** BPC `runs`/`material_efficiency`/`time_efficiency` are in the ESI items payload and never persisted; auction `buyout` is never ingested; item `group_id`/`category_id` are fetched during enrichment then discarded (`category` is a ship/not-ship boolean, `app/backend/src/fastapi_app/services/background_aggregation.py:692`). Displaying non-ship contracts well is therefore mostly an **ingestion-fields + taxonomy + presentation** problem, not a pipeline problem.
+
+## 2. Gap analysis vs EVE Workbench's market tool
+
+EVE Workbench's market browser (`/market/:orderType/:regionId/:locationId/:id`) is the tool Sam asked to compare against. It browses **market orders**, which is adjacent to but distinct from our contracts domain; the useful comparison is UX mechanics, not data.
+
+### 2.1 What they have that we lack
+
+| EVE Workbench feature | Hangar Bay today | Assessment |
+|---|---|---|
+| Hierarchical market-group tree with in-place search that preserves ancestor paths | Free-text search only; no taxonomy UI at all | **Adopt** — needs persisted `group_id`/`category_id` (§4.1). Best-in-survey pattern for "where do things live" |
+| Scope-preserving links (item links carry active region/station scope) | Filters live in the URL (good) but no equivalent cross-navigation | Adopt where taxonomy navigation lands |
+| Sell/Buy tabs with live counts in the label | Single list; no count-bearing segmentation | Adopt for contract-type segmentation (exchange/auction/courier tabs with counts) |
+| Location scoping to station level, security-status chips on stations | Region filter only (and only one region has data — §4.3); no security display | Adopt security chips; station scoping already has an unused `station_ids` API filter |
+| "My current location" → contextual sortable `Jumps` column | Nothing | Adopt eventually — Adam4EVE proves the contract-market version (jumps + route-security tooltip) |
+| `remaining / total` quantity in one cell | n/a (contracts don't partial-fill) | n/a |
+| Deep-linkable, server-rendered first paint (SEO/sharing) | SPA | Relevant to the M5 trust/shareability theme (see `docs/superpowers/specs/2026-07-26-m5-trust-shareability-design.md`) |
+| Item info modal (dogma attributes, description, variations) | Type names only | Cheap alternative: deep-link item rows to everef.net/types/{id} instead of building an item encyclopedia |
+
+### 2.2 What they get wrong (traps to avoid)
+
+- **Abbreviated-only prices** (`4.72M`, no exact figure anywhere) — unusable for margin decisions. We show full ISK; keep it.
+- **Absolute-only expiry timestamps** on the one table where time pressure matters. Contracts need relative countdowns with urgency treatment (we already render time-left).
+- **No summary statistics of any kind** — no median/spread/history. Their market tool is a raw dump; the LP Store's `ISK/LP` default-sort is the only derived metric on the site, and it's their best page. Lesson: **a computed profitability metric as the default sort is the product** (maps to the parked appraisal direction, `docs/superpowers/specs/2026-07-26-m5-direction-options.md`).
+- **Silent filter no-ops** — "PLEX in Aridia" renders Jita orders because CCP's global PLEX pseudo-region ignores the region scope, and the UI asserts a scope it didn't apply. We have the same defect class live today (`system_ids` matches zero rows, §4.4) — an empty-state-or-explain rule should be a product invariant.
+- **No error states** (failed backend call → infinite spinner) and **`Unknown Structure` at security `-0.5`** for unresolvable player structures — dishonest fallbacks.
+
+### 2.3 What we already do better
+
+Full ISK prices, relative expiry, honest empty states, liveness watermarking (`last_seen_at` per region), typed OpenAPI client, and a contracts domain they don't touch at all. EVE Workbench's strength is breadth of adjacent tools (fits, appraisal, refinery, LP store) and anonymous-friendly personalization — not market UX depth.
+
+## 3. What the wider ecosystem teaches about displaying non-ship contracts
+
+Full per-tool detail lives in the recon lane's report; this section keeps what changes our decisions.
+
+### 3.1 Type-specific summary rows, not one universal table
+
+The consistent lesson across MutaMarket, Adam4EVE, and EVE Tycoon: browse rows lead with a **compact, type-aware summary**; itemization is the detail view's job.
+
+| Contract shape | Row leads with | Distinctive fields | Valuation display |
+|---|---|---|---|
+| Single-item exchange | the item | quantity | ask vs market price, margin % |
+| Multi-item ("loot pile") | composition counts (MutaMarket pattern: e.g. `3 modules · 1 BPC · 2 other`) + total m³ | priced-vs-unpriced coverage (Adam4EVE `NoP` column) | ask vs buy-side AND sell-side totals; optionally reprocess value (Fuzzwork) |
+| BPC | name + **ME / TE / Runs as first-class columns** | BPO-vs-BPC flag | never silently price at type market price — either refuse-and-flag (EVE Tycoon) or price per (type, ME, TE, runs) tuple (Adam4EVE) |
+| Abyssal/mutated | base module + mutaplasmid | roll-quality score; per-attribute value + signed delta | estimate with error bars + sample count, or explicit "no estimate" (MutaMarket). Note: rolled stats are NOT in ESI public-contract data; parity with MutaMarket needs another source |
+| Courier | route (origin → destination), jumps | reward, collateral, volume, days_to_complete | reward/jump and reward/m³ — the ratios haulers sort on |
+| Auction | current-bid + countdown | bid count, buyout | requires ingesting `buyout` (§4.2) and the bids endpoint (bidder identity is not public) |
+
+### 3.2 Valuation display conventions (unanimous across serious tools)
+
+Recorded here because appraisal is the parked headline feature; these are the table stakes when it lands:
+
+1. **Never a single price** — buy-side and sell-side (or buy/split/sell à la Janice) always shown together.
+2. **Medians beside spot prices** (Janice: 5-day and 30-day) — contract items are disproportionately thin-market.
+3. **Reject outliers and publish the rejection** (EVE Tycoon returns thresholds + excluded-order counts) — contract markets are scam-rich.
+4. **Coverage/provenance as a visible, filterable column** — Adam4EVE's `NoP`/`NMkt?` columns; EVE Tycoon's per-row tinted `Appraisal Method`. The single most transferable idea in the survey.
+
+### 3.3 Cheap differentiators nobody (or almost nobody) does
+
+- **"Open in EVE client" via ESI `POST /ui/openwindow/contract/`** — only Adam4EVE has it; we already have EVE SSO from M2, making this nearly free and closing the browse→buy loop.
+- **Symmetric want-to-buy handling** — render "items received" and "items to deliver" as twin tables (`is_included=false` items); expose want-to-buy as a filter. We already store `is_included`.
+- **Courier browsing at all** — a wholly unoccupied niche; we already store ~173 live couriers (with zero item rows, correctly — couriers have no items).
+- **`last_seen_at` as a user-facing column and filter** — the only staleness signal an ESI ingester has; we compute it and never show it.
+
+## 4. The internal gap: ingested-but-invisible, dropped-at-ingestion, and defects
+
+### 4.1 Fetched-then-discarded taxonomy (the enabling gap)
+
+Enrichment already resolves each item's `group_id` and `category_id` from ESI and keeps only a ship/not-ship boolean (`background_aggregation.py:683-695`). `EsiMarketGroupCache` is an unused empty-shell model. Persisting group/category unlocks every category-filter promise in `design/features/F002-Ship-Browsing-Advanced-Search-Filtering.md` and the type-aware rows in §3.1. **Caveat measured in prod:** `market_group_id` is ~87% NULL on sampled non-ship items (abyssal items are off-market), so the taxonomy must be dogma category/group based, not market-group based.
+
+### 4.2 Dropped ESI fields
+
+| Field | ESI has it | We store | Blocks |
+|---|---|---|---|
+| item `runs`, `material_efficiency`, `time_efficiency` | yes (items endpoint) | no | real ME/TE/runs filters (currently inert per pitfall FASTAPI-2; runs filter mis-wired to `raw_quantity`), honest BPC display for 49% of the corpus |
+| contract `buyout` | yes | no | any meaningful auction display (~527 live auctions show only starting bid) |
+| contract `days_to_complete` | yes | no | courier display |
+| auction bids (`/contracts/public/bids/`) | yes (no bidder identity) | not fetched | current-bid display |
+
+### 4.3 Region coverage
+
+One region ingested (The Forge) while the frontend offers a 70-region filter — 69 of which can never match. Multi-region is an explicit M5 non-goal (`2026-07-26-m5-trust-shareability-design.md`); noted here because several ecosystem patterns (jumps-from-my-location, route security) only pay off with broader coverage.
+
+### 4.4 Defects (verification + fixes in flight on `claude/contract-filter-bugfixes`)
+
+1. `is_bpc=false` matches zero rows (`is_blueprint_copy` is True-or-NULL; empirically `total: 0` in prod).
+2. `system_ids` filter matches zero rows (`start_location_system_id` never populated by ingestion).
+3. Courier contracts render as "Exchange" in both table and detail views (two-way badge assumes exchange/auction).
+4. Courier serialization 500 risk: `ContractSchema.start_location_id` non-optional over a nullable column, reachable via the shipped `ships_only=false` view.
+5. `collateral` is filterable and sortable but absent from every response schema.
+6. `min_runs`/`max_runs` filters `raw_quantity`, which is not a run count (deferred to the product plan — the correct fix is ingesting `runs`, §4.2).
+7. `status` is always the literal `"unknown"` and `date_completed` always NULL (fields don't exist in public ESI data); `date_completed` is used as an always-true liveness predicate in the watchlist matcher (dead-code class, report-only).
+
+## 5. Where the specs already stand
+
+- The ships-only **default** is decided (PRODUCT.md: non-ship reachable by explicit toggle, "never the default noise") — this analysis does not challenge it. What's absent is any spec for what the non-ship view *is*: it's defended as a shipped non-regression in the M5 ingestion designs yet has no product spec, no design treatment, and no name.
+- Contract-type filtering was promised (F002 Story 7/Criterion 6.1) then explicitly deferred in the M1 design ("no such filter param exists"). Two spec conflicts need reconciling: F002's market-group filter is simultaneously MVP-scoped (F002) and deferred-no-backing-API (M1 design); courier handling has no written policy at all.
+- Appraisal is formally parked as the likely headline feature with a named re-ordering trigger (`2026-07-26-m5-direction-options.md`). §3.2 above is the display contract for when it lands.
+
+## 6. Recommendation
+
+**Yes — display what we ingest.** The data is already paid for (fetched, enriched, stored); the audience (BPC and abyssal buyers) has no living alternative; the incumbent-shaped competitor (Adam4EVE) is decaying; and EVE Workbench — the strongest general EVE tools site — has left contracts entirely unoccupied. The risk is not building it; the risk is shipping the current unlabeled "All Contracts" checkbox view as if it were the feature.
+
+Sequenced shape (sizes are relative; a plan would firm these up):
+
+1. **Now / small — stop being wrong.** Land the defect fixes (§4.4, PR in flight). Cost: already spent.
+2. **Foundation / medium — ingest what we throw away.** Persist item `category_id`/`group_id`; ingest `runs`/ME/TE, `buyout`, `days_to_complete`. Schema migrations + enrichment changes + client regeneration. This unblocks everything else and makes three inert filter families real.
+3. **Presentation / medium-large — the type-aware browse view.** Contract-type tabs with counts; type-specific summary rows per §3.1; courier columns (route, reward, collateral); BPC columns (ME/TE/runs); want-to-buy symmetry; `last_seen_at` surfaced. This is the actual "display the data" milestone and needs its own feature spec (an F008) reconciling the F002-vs-M1 conflicts.
+4. **Later / large — valuation.** Unchanged from the M5 direction doc, but §3.2's conventions become requirements, and Adam4EVE's per-(type, ME, TE, runs) BPC pricing plus MutaMarket's published-error-bars model are the reference implementations.
+
+Abyssal roll-stats (MutaMarket parity) are explicitly out: ESI public-contract data doesn't carry rolled attributes, so that's a different-data-source product decision, not a display gap.
+
+## 7. MCP surface for Hangar Bay's final form
+
+*(Pending — a research lane on MCP prior art, consumer personas, proposed tool surface, and hosting/auth considerations is in flight; this section will be filled in when it reports.)*
+
+## Appendix A. Reasoning notes and uncertainties
+
+**Why the comparison target shifted.** The prompting question named EVE Workbench's market tool, but recon established it browses market *orders* and has zero contract features — so a feature-parity comparison would answer the wrong question. The analysis therefore treats EVE Workbench as a UX-mechanics reference (§2) and the real gap analysis as Hangar Bay vs the contract-tool ecosystem (§3) plus Hangar Bay vs its own ingested data (§4). That reframing is the load-bearing judgment call in this doc.
+
+**What I'm still uncertain about.**
+- Adam4EVE's per-commodity contract price-history methodology (single-item contracts only?) is inferred from page shape; its explanation is an image we couldn't OCR-verify. Confirm before building per-type BPC price history on the same model.
+- Prod numbers are live-visible-corpus counts via the public API, not raw SQL (Render MCP unauthorized this session); type/category breakdowns are a validated 12.7% sample. Directionally solid; not a census.
+- EVE Workbench's logged-in surface (developer applications, personal access tokens) was unreachable anonymously — they may expose a third-party API whose shape we haven't seen.
+
+**Considered and set aside.**
+- *Matching EVE Workbench's market-order browsing* (i.e., adding a market-orders view to Hangar Bay): rejected — crowded space (Fuzzwork, EVE Tycoon, Adam4EVE, jita.space all do it), zero differentiation, and orthogonal to our ingestion asset.
+- *Market-group-based taxonomy* for the category filter: rejected on measurement — ~87% NULL coverage precisely where non-ship volume concentrates; dogma category/group is the viable axis.
+- *Changing the ships-only default*: not proposed — PRODUCT.md's default stands; this analysis argues for making the non-default view real, not for changing the default.
+
+**Things almost missed.** The `system_ids`/`is_bpc=false` dead filters surfaced only because the inventory lane checked filter columns against ingestion writes rather than trusting the API schema — the same defect class (silent filter no-op) then showed up independently in EVE Workbench's PLEX/region behavior, which is what promoted "empty-state-or-explain" from a bug fix to a proposed product invariant.

--- a/docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md
+++ b/docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md
@@ -17,7 +17,7 @@ Five parallel research lanes, run 2026-08-01 (Opus/Sonnet subagents; findings sy
 4. **Domain research** — ESI public-contracts schema, player use-cases per contract type, appraisal-source conventions. ESI schema facts verified against the OpenAPI spec.
 5. **MCP surface research** — see §7.
 
-A parallel verify-and-fix lane confirmed the defects in §4.4 and is producing a Review-classified PR from branch `claude/contract-filter-bugfixes`.
+A parallel verify-and-fix lane independently confirmed all §4.4 defects (correcting recon's causal story on two) and produced the Review-classified [PR #98](https://github.com/scarson/hangar-bay/pull/98). A sixth lane researched the MCP protocol/hosting landscape (§7 and companion doc).
 
 ## 1. Headline findings
 
@@ -108,15 +108,26 @@ Enrichment already resolves each item's `group_id` and `category_id` from ESI an
 
 One region ingested (The Forge) while the frontend offers a 70-region filter — 69 of which can never match. Multi-region is an explicit M5 non-goal (`2026-07-26-m5-trust-shareability-design.md`); noted here because several ecosystem patterns (jumps-from-my-location, route security) only pay off with broader coverage.
 
-### 4.4 Defects (verification + fixes in flight on `claude/contract-filter-bugfixes`)
+### 4.4 Defects — independently verified; four fixed in [PR #98](https://github.com/scarson/hangar-bay/pull/98) (Review — serialization contract; awaiting Sam)
 
-1. `is_bpc=false` matches zero rows (`is_blueprint_copy` is True-or-NULL; empirically `total: 0` in prod).
-2. `system_ids` filter matches zero rows (`start_location_system_id` never populated by ingestion).
-3. Courier contracts render as "Exchange" in both table and detail views (two-way badge assumes exchange/auction).
-4. Courier serialization 500 risk: `ContractSchema.start_location_id` non-optional over a nullable column, reachable via the shipped `ships_only=false` view.
-5. `collateral` is filterable and sortable but absent from every response schema.
-6. `min_runs`/`max_runs` filters `raw_quantity`, which is not a run count (deferred to the product plan — the correct fix is ingesting `runs`, §4.2).
-7. `status` is always the literal `"unknown"` and `date_completed` always NULL (fields don't exist in public ESI data); `date_completed` is used as an always-true liveness predicate in the watchlist matcher (dead-code class, report-only).
+| # | Defect | Verdict | Action |
+|---|---|---|---|
+| 1 | `is_bpc=false` matches zero rows | Confirmed | **Fixed** (filter treats NULL as not-a-BPC) |
+| 2 | `system_ids` matches zero rows (column never populated) | Confirmed | Deferred — needs a location→system cache (see below) |
+| 3 | Courier serialization 500 (`start_location_id` non-optional over nullable column) | Confirmed, **worse than reported** — one null row 500s the whole page of 50, since `PaginatedResponse` validates every item | **Fixed** |
+| 4 | Courier renders as "Exchange" | Confirmed | **Fixed** (renders "Courier") |
+| 5 | `collateral` filterable/sortable but never returned | Confirmed | **Fixed** (added to response schema; client chain regenerated) |
+| 6 | `min_runs`/`max_runs` wired to `raw_quantity` | Confirmed, **cause corrected** — `raw_quantity` doesn't exist on the *public* items route at all (authenticated routes only), so the column is permanently NULL | Deferred to the §6 phase-2 plan (ingest `runs`) |
+| 7 | `status` always `"unknown"`, `date_completed` always NULL | Confirmed; one real behavioral gap found (below) | Reported |
+
+Verification corrections and new findings from the fix lane (full evidence in the PR):
+
+- **Defect 1's cause was mis-diagnosed by recon:** ingestion *does* map `is_blueprint_copy`; ESI simply omits the flag for non-copies (live sample of 1,658 public item rows: `true` 1,396×, absent 262×, `false` never). The bug was purely the filter's `col == False` NULL semantics.
+- **ESI public-vs-authenticated schema split matters for §4.2:** `runs` is public (present on exactly the BPC rows), but the documented `runs == -1` for originals **never occurs on the public route** — originals omit the field. A naive implementation of the runs filter would be wrong; recorded as a pitfall (ESI-2) in PR #98 alongside FASTAPI-3, TEST-17, TEST-18.
+- **Root cause behind three false-passing tests:** the backend test fixture hand-wrote three columns ingestion never writes (`is_blueprint_copy=False`, `raw_quantity`, `start_location_system_id`) — a data shape ESI cannot produce — so the dead filters had green tests. The fixture now carries the production shape and documents what it still fakes.
+- **New: watchlist notifications outlive purchase.** The watchlist matcher filters on expiry plus the always-true `date_completed IS NULL`, and does *not* use the per-region `last_seen_at` watermark the list view uses — so an already-accepted contract keeps generating notifications until its expiry date (up to two weeks). Deferred because the fix changes notification semantics; recommended fix is reusing the watermark predicate.
+- **`system_ids` sizing:** ESI's public payload has no system id; `/v1/universe/stations/` resolution covers 97.1% of sampled start locations (player structures need ACL-scoped tokens and would stay NULL); only 160 distinct locations across 7,292 contracts, so a location→system cache table is tiny. Deferred as a design decision, param left in place.
+- The lane also fixed a **pre-existing red test on `origin/dev`** (a hard-coded 2026-07-31 expiry under a liveness predicate — detonated on 2026-08-01, before this work started).
 
 ## 5. Where the specs already stand
 
@@ -139,7 +150,14 @@ Abyssal roll-stats (MutaMarket parity) are explicitly out: ESI public-contract d
 
 ## 7. MCP surface for Hangar Bay's final form
 
-*(Pending — a research lane on MCP prior art, consumer personas, proposed tool surface, and hosting/auth considerations is in flight; this section will be filled in when it reports.)*
+Full research in the companion doc `2026-08-01-mcp-surface-research.md` (prior art, personas, tool sketches, auth/hosting/license analysis). The decision-relevant summary:
+
+- **The gap is a moat, not just a hole.** Every existing EVE MCP server is a thin ESI wrapper and none touch contracts — because ESI's public-contract surface structurally cannot answer "find me a cheap fitted Ishtar near Jita" without first ingesting an entire region (one items call per contract, ~33.8k calls). Hangar Bay is the only party that has already paid that cost; an MCP surface converts a differentiated website into differentiated infrastructure.
+- **Small, hand-designed, read-only v1.** Roughly five to seven `hangarbay_*` tools — contract search (ranked shortlist, default limit 10, concise projection without full item lists), contract detail, name⇄id resolution, an aggregation/summary tool, and (only after appraisal ships) an appraise tool whose schema makes partial valuations impossible to launder into confident prose. Explicitly **not** OpenAPI auto-generation, which would faithfully reproduce our inert ME/TE params, the broken runs filter, and a token-bomb response schema — and which Anthropic's connector review criteria and the empirical record both reject.
+- **Authenticated `/me/*` stays web-only for now.** The MCP auth spec requires an OAuth 2.1 authorization server that Hangar Bay operates; EVE SSO cannot fill that role (no dynamic client registration, no RFC 8707, wrong token audience) and would sit federated *behind* our AS. That is a milestone of its own; a read-only public server is fully spec-conformant without it.
+- **Sequencing: downstream of M5, not parallel.** Freshness (`data_as_of`/`data_stale` in every payload, escalated in words, not just booleans), sold/delisted liveness filtering, and honest coverage signaling ("no data for Amarr", never an empty list) are *preconditions* for an agent-facing surface — an agent laundering a stale row into confident prose is this surface's worst failure mode. API rate limiting is net-new mandatory work (none exists today).
+- **License shapes the strategy:** the CCP developer license forbids monetization, so "free backend" risk is managed operationally (free API keys for attribution/quota), and nobody else can build a paid product on our back either. ESI-data redistribution is unaddressed-but-precedented (EVE Ref, zKillboard, Fuzzwork); a short question to CCP's third-party dev channel is cheap insurance.
+- **Timing note:** the MCP spec had a breaking revision on 2026-07-28; the official Python SDK v2 supports it (and serves older clients) as of the same day, while Claude-side client support is still rolling out. A deliberately small tool surface is also the hedge against further protocol churn.
 
 ## Appendix A. Reasoning notes and uncertainties
 

--- a/docs/superpowers/specs/2026-08-01-mcp-surface-research.md
+++ b/docs/superpowers/specs/2026-08-01-mcp-surface-research.md
@@ -1,0 +1,326 @@
+<!-- ABOUTME: Design-space research for a Hangar Bay MCP server — prior art, consumer personas, a proposed seven-tool -->
+<!-- ABOUTME: surface, auth/rate-limit/hosting considerations, and CCP-license constraints. Companion to the 2026-08-01 gap analysis. -->
+
+# Hangar Bay MCP surface — design-space research
+
+**Date:** 2026-08-01
+**Status:** Research; no decisions taken. Companion to `2026-08-01-contract-coverage-gap-analysis.md` (§7 there summarizes this doc).
+**Provenance:** Opus research agent output, lightly edited for formatting. All claims were verified by the agent against primary sources (spec pages, GitHub repos, the CCP license, and this repo); unverified items are flagged inline.
+
+**Biggest single finding up front:** the MCP spec revision changed on **2026-07-28 — days before this research** ([versioning](https://modelcontextprotocol.io/specification/versioning)). It carries breaking changes (the initialize handshake is replaced by per-request `_meta` version negotiation plus a `server/discover` RPC; server-initiated requests are replaced by the Multi Round-Trip Requests pattern). Any MCP design written from 2025-era knowledge is now wrong in structural ways; treat every "current MCP practice" claim — including from recent blogs — as suspect until checked against `2026-07-28`.
+
+---
+
+## 1. Prior art: what good public-data / marketplace MCP servers look like in 2026
+
+### 1a. The registry and governance landscape
+
+The official registry (`github.com/modelcontextprotocol/registry`) is still **preview, not GA**, with an API freeze at v0.1 since 2025-10-24; publishing requires namespace ownership proof via GitHub OAuth/OIDC or DNS/HTTP domain verification ([repo](https://github.com/modelcontextprotocol/registry)). Secondary sources claim 10,000+ public servers and ~97M SDK downloads/month as of March 2026 — **unverified marketing-adjacent stats**.
+
+### 1b. The single best structural analog: Shopify Storefront Catalog MCP
+
+The closest prior art to what Hangar Bay would build ([shopify.dev/docs/agents/catalog/storefront-catalog](https://shopify.dev/docs/agents/catalog/storefront-catalog)). Three tools, not thirty:
+
+| Tool | Params | Shape |
+|---|---|---|
+| `search_catalog` | `query` (free text), `context` (buyer signals), `filters` (category, price range), `pagination` (cursor + limit) | product summaries + cursor |
+| `lookup_catalog` | `ids` (array, **max 10**) | bulk resolve, with explicit `not_found` entries |
+| `get_product` | `id`, `selected` (option selections) | full detail |
+
+Notable conventions: opaque cursor pagination with `limit` min 1 / default 10 / max 250, an explicit `has_next_page` signal, prices in minor units, and a `context` object separating *buyer situation* from *filters*. It implements the [UCP Catalog capability](https://ucp.dev/latest/specification/catalog/mcp/) (Google's Universal Commerce Protocol, 2026-04-08). Whether UCP survives as a standard is unknowable; the *tool shape* is good regardless.
+
+The lesson: **default limit 10, not 50.** Shopify's human storefront paginates at 24–48; their agent-facing tool defaults to 10.
+
+### 1c. Financial / market-data MCPs: the anti-pattern
+
+Polygon.io's official MCP server "exposes all Polygon.io API endpoints as MCP tools" — 35+ tools ([PulseMCP](https://www.pulsemcp.com/servers/polygon)). This endpoint-mirroring approach is exactly what Anthropic and FastMCP's maintainer both argue against (§4d). Popular because it is cheap to generate, not because it works well.
+
+### 1d. EVE Online MCP servers — they exist, and none of them do contracts
+
+A cluster, essentially all from one author (`kongyo2`), all thin ESI/third-party-API wrappers, all tiny (4–8 stars):
+
+- [`kongyo2/eve-online-mcp`](https://github.com/kongyo2/eve-online-mcp) — market data via ESI (`get-market-prices`, `get-market-orders`, `get-market-history`, `get-market-groups`, `get-structure-orders`, …). TypeScript, MIT, 8 stars. **No contracts.**
+- [`kongyo2/evetycoon-mcp-server`](https://github.com/kongyo2/evetycoon-mcp-server) — wraps evetycoon.com's API rather than ESI. The closest structural precedent for "an EVE site exposes itself via MCP." 4 stars.
+- [`kongyo2/eve-online-traffic-mcp`](https://github.com/kongyo2/eve-online-traffic-mcp), [`kongyo2/eve-online-osint-mcp`](https://github.com/kongyo2/eve-online-osint-mcp), and an "ask-eve" PI server on LobeHub.
+
+Separately, [EVE AI Agent](https://developers.eveonline.com/docs/community/eve-ai-agent/) is a community LLM chat assistant featured **on CCP's own developer docs site** — it does not use MCP, but CCP linking to an LLM-powered ESI consumer is a meaningful posture signal (§5).
+
+**The gap is a moat, not just a hole.** ESI's public-contract surface is `/contracts/public/{region_id}/` (paged, no filtering) plus one items call per contract. An ESI-wrapping MCP server **structurally cannot** answer "find me a cheap fitted Ishtar near Jita": it would have to page an entire region and issue ~33,800 item fetches. Hangar Bay's ingestion + index turns that into one SQL query. No cleverness closes that gap on the ESI side.
+
+### 1e. Extracted patterns from well-regarded servers
+
+- **Few fat tools beat many thin ones.** Anthropic: build "a few thoughtful tools targeting specific high-impact workflows"; consolidate ([Writing effective tools for AI agents](https://www.anthropic.com/engineering/writing-tools-for-agents)).
+- **Namespace by service and resource** (`asana_search`, `asana_projects_search`).
+- **Return names, not IDs**; offer a `response_format` enum (`"concise"`/`"detailed"`) when IDs are unavoidable.
+- **Token efficiency is a design parameter**: pagination, filtering, truncation with sensible defaults, and truncation messages that steer the agent toward "many small targeted searches instead of a single broad search."
+- **Errors are prompts.** Tool-execution errors go in the result with `isError: true` and must communicate "specific and actionable improvements, rather than opaque error codes" ([spec §Error Handling](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)).
+- **Structured output is first-class** (`outputSchema` + `structuredContent`, JSON echoed in a text block for compatibility). How widely clients actually consume `structuredContent` in practice is a **real, unmeasured uncertainty**.
+
+---
+
+## 2. Consumer personas, derived from concrete queries
+
+### P1 — The player's chat assistant (dominant persona; ~80% of value)
+
+| Utterance | Tool need |
+|---|---|
+| "Find me a well-priced fitted Ishtar near Jita" | free-text search + ship semantics + location scoping + price sort; name→type_id resolution; station/system proximity, not just region |
+| "What's the cheapest Gila on contract right now?" | same, ranked, small N — **one call returning ~5 rows, not 50** |
+| "Is this contract a good deal?" (pastes a URL/ID) | contract detail **plus** appraisal; URL→id parsing |
+| "Any cheap Gila BPCs?" | `is_bpc` + type filter; runs/ME/TE don't exist yet (gap analysis §4.2) |
+| "Watch for a Loki under 400m and tell me" | authenticated write, or more natively an MCP resource subscription (§3f) |
+| "What ships are for sale in Amarr?" | **currently unanswerable — coverage is The Forge only.** An MCP surface makes this failure louder: an empty list reads to an agent as "no ships in Amarr." |
+
+### P2 — The hauling / logistics assistant
+
+"Price a Jita→Amarr courier for 340k m³, 2bn collateral." Wants **aggregates, not rows** ("going ISK/m³ and ISK/jump on this lane?") — a statistics tool, and a strong argument for one aggregation tool in v1 (§3d).
+
+### P3 — The market-analysis / industry agent
+
+"How are capital BPC prices trending?" Given the corpus shape (49% BPC, big abyssal clusters), already well-served by the data, completely unserved by the UI. Wants faceted counts and distributions; the persona most likely to abuse the endpoint (§4a).
+
+### P4 — The corp/alliance Discord bot
+
+Scheduled saved queries; wants stable, cheap, cursor-paginated access and a freshness stamp. Where "free backend for someone else's product" risk lives (§5).
+
+**Persona-derived conclusion:** P1 dominates, and P1's queries are almost all "give me the best few, with enough context to judge." That is a **ranked-shortlist API**, not a paginated list-browsing API. Designing the MCP surface as a mirror of the contract list would serve the least important persona best.
+
+---
+
+## 3. Proposed first-draft tool surface
+
+### 3a. Naming and shape
+
+Namespace everything `hangarbay_*`. Seven tools for v1, three optional:
+
+```
+hangarbay_search_contracts     ← the workhorse
+hangarbay_get_contract         ← detail + items
+hangarbay_resolve_names        ← type/region/system/station name ⇄ id
+hangarbay_market_summary       ← aggregates (P2/P3)
+hangarbay_appraise_contract    ← post-appraisal only
+hangarbay_data_status          ← freshness/coverage (candidate for deletion, 3e)
+hangarbay_watch_type           ← authenticated; defer (3g)
+```
+
+### 3b. `hangarbay_search_contracts`
+
+```jsonc
+{
+  "name": "hangarbay_search_contracts",
+  "description": "Search live EVE Online public contracts aggregated by Hangar Bay. \
+Covers <REGIONS> (currently The Forge / Jita only). Data refreshes hourly; every \
+result carries the timestamp it was observed. Contracts already sold or expired are \
+excluded. Use a small limit and a narrow query; prefer several targeted searches \
+over one broad one.",
+  "inputSchema": {
+    "query":            "string  — free text over contract title and item names, min 3 chars",
+    "ship_type_ids":    "int[]   — resolve names first with hangarbay_resolve_names",
+    "region_ids":       "int[]",
+    "system_ids":       "int[]",
+    "station_ids":      "int[]",
+    "contract_type":    "enum: item_exchange | auction | courier | any  (default any)",
+    "ships_only":       "bool    — default true; mirrors the site default",
+    "is_bpc":           "bool",
+    "min_price":        "number  (ISK)",
+    "max_price":        "number",
+    "min_collateral":   "number",
+    "max_collateral":   "number",
+    "expires_after":    "string  (ISO 8601) — 'still available in N hours'",
+    "sort_by":          "enum: price | date_issued | time_left | volume | collateral (default price)",
+    "sort_direction":   "enum: asc | desc",
+    "limit":            "int 1..50, default 10",
+    "cursor":           "string  — opaque; from a previous response",
+    "response_format":  "enum: concise | detailed  (default concise)"
+  }
+}
+```
+
+Returns `structuredContent`:
+
+```jsonc
+{
+  "data_as_of": "2026-08-01T14:03:00Z",
+  "data_stale": false,
+  "coverage": ["The Forge"],
+  "total_matching": 47,
+  "returned": 10,
+  "next_cursor": "eyJvIjoxMH0",
+  "contracts": [{
+    "contract_id": 219000000, "url": "https://hangarbay…/contracts/219000000",
+    "type": "item_exchange", "title": "Ishtar, fitted",
+    "price_isk": 285000000, "collateral_isk": 0,
+    "location": "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+    "system": "Jita", "region": "The Forge",
+    "expires_in_hours": 71, "issued": "2026-07-29T00:00:00Z",
+    "item_count": 14,
+    "headline_items": ["Ishtar", "Heavy Assault Missile Launcher II ×5"],
+    "is_bpc_contract": false, "is_ship_contract": true
+  }]
+}
+```
+
+Design points, each earned from the repo:
+
+- **`concise` must NOT return `items`.** Today `ContractSchema` always carries the full `items` array and `contract_service.py` eager-loads it on both fetch paths (`selectinload(Contract.items)` in `_fetch_page_joined` and `_fetch_page_simple`). A 50-row page of fitted ships is thousands of item rows — fine for a table, a token bomb in an MCP result. **The MCP search tool needs its own projection — do not reuse `ContractSchema`.** `headline_items` + `item_count` is the concise shape; `detailed` may include items but should force `limit ≤ 5`.
+- **Names, not IDs, in the output.** The DB already denormalizes `start_location_name`; region/system names need a small reference table or cached ESI resolve (3c).
+- **`contract_type` is new.** The REST API has no type filter even though `Contract.type` is stored and indexed (`ix_contracts_type_status`). Cheap to add; unlocks the hauling persona.
+- **Cursor, not `page`.** MCP's pagination utility is opaque-cursor (clients MUST NOT parse cursors). It formally covers only list operations, but matching the convention is right — and the 2026-07-28 [Stateful Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools) guidance specifies how: opaque high-entropy handle, bounded lifetime, retention policy in the tool description, actionable error on expiry. A base64 offset+filter-digest cursor over the existing offset pagination needs no new state store.
+
+### 3c. `hangarbay_resolve_names` — not optional
+
+```
+{ names: string[], kinds?: ("type"|"region"|"system"|"station")[] }
+→ { resolved: [{name, id, kind, published, category}], ambiguous: [...], not_found: [...] }
+```
+
+Every P1 query starts with a name; every filter takes an id. Today there is **no backend reference surface at all**: regions are a generated static array in the *frontend* (`app/frontend/web/src/features/contracts/regions.ts`), and type-name resolution exists only inside `watchlist_service._resolve_name_to_type_id` (calls ESI). An MCP server needs this promoted into a real, cached backend service. Bulk-in/bulk-out with explicit `ambiguous`/`not_found` buckets follows Shopify's `lookup_catalog`; ambiguity ("Ishtar" vs "Ishtar Blueprint") is the natural elicitation point (3i).
+
+### 3d. `hangarbay_market_summary` — the token-economy tool
+
+```
+{ group_by: "ship_type"|"region"|"station"|"contract_type"|"price_bucket",
+  <same filters as search>, limit: int }
+→ { buckets: [{key, contract_count, min_price, median_price, p25, p75, total_volume}], data_as_of }
+```
+
+Makes a 33.8k-row corpus tractable: "what's the going rate for a Gila?" should be **one aggregate call**, not 50 rows the model averages itself. Serves the hauling persona (ISK/m³ by lane) and the analysis persona directly. This belongs in **v1, not v2** — it is what distinguishes a thoughtful MCP surface from a REST mirror.
+
+### 3e. `hangarbay_data_status`
+
+Coverage regions, `data_as_of`, `data_stale`, last ingest outcome, corpus counts. **Self-pushback:** a status tool the model must *remember to call* is worse than freshness embedded in every result. Candidate for deletion; keep only as a cheap diagnostic alongside per-result freshness fields.
+
+### 3f. `hangarbay_appraise_contract` — gate this hard
+
+Only after appraisal ships:
+
+```
+{ contract_id: int, basis?: "jita_split"|"jita_buy"|"jita_sell" }
+→ { asking_price, appraised_value, delta_isk, delta_pct, basis, priced_at,
+    line_items: [{type_name, qty, unit_value, source}],
+    unpriceable: [{type_name, qty, reason: "blueprint_copy"|"abyssal_mutated"|"no_market_data"}] }
+```
+
+The `unpriceable` array is the whole design. The M5 direction doc's named risk (a wrong valuation destroys trust, worse than no number) is **strictly worse over MCP**: a human sees a caveat next to a number; an LLM launders the number into prose that drops the caveat. Concrete mitigation: never return a bare `appraised_value` when `unpriceable` is non-empty — return `appraised_value_partial` plus `unpriced_item_count`, so the field name itself survives summarization. Given 49% of contracts contain BPCs, *most* of the corpus is partially unpriceable.
+
+Pricing bases: Fuzzwork's aggregates endpoint returns weightedAverage/max/min/median/percentile/volume/orderCount per side — and its author explicitly asks integrators not to hammer it ("Get the data yourself, direct from CCP"). ESI's `/markets/prices/` and regional order books are the first-party route.
+
+### 3g. Authenticated `/me/*` — recommendation: **web-only for v1**
+
+1. **The auth cost is disproportionate** (§4c — an OAuth 2.1 authorization server, not a session-cookie reuse).
+2. **The spec pushes human-in-the-loop on writes anyway**, and an all-read-only server is a far easier trust story for an institutionally paranoid community.
+3. **The natural MCP form of "watch this" isn't a write tool.** The 2026-07-28 spec has `subscriptions/listen` + `notifications/resources/updated`; a watchlist as a *subscribable resource* (`hangarbay://watch/{type_id}?max_price=…`) also addresses the M5 finding that alerts have no delivery path off the site. Exciting v2, but **client support for subscriptions is unverified**.
+
+If writes do come: `hangarbay_watch_type` maps 1:1 to `WatchlistItemCreate` (already accepts exactly one of `type_id`/`type_name` — agent-friendly); note `SavedSearchParameters` uses `extra="forbid"`, so an MCP tool must not pass through filter keys saved searches reject.
+
+### 3h. Resources vs tools
+
+**Tools for everything in v1.** Resources are application-driven (the spec's illustration is a resource-picker UI) — wrong model for searching 33k contracts. Defensible resource uses: a few static context docs (`hangarbay://reference/regions`, `hangarbay://about/coverage-and-freshness`; `resources/read` now supports `ttlMs`/`cacheScope`), and **resource links from tool results** (`{"type": "resource_link", "uri": "https://hangarbay…/contracts/…"}`) — the clean way to hand the user a shareable URL, which is PRODUCT.md's "the URL is the interface" principle.
+
+### 3i. Elicitation / Multi Round-Trip Requests
+
+The 2026-07-28 spec replaced server-initiated requests with [MRTR](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr): a tool returns `resultType: "input_required"` with `inputRequests` and an opaque `requestState`; the client gathers input and retries. Good fit for name ambiguity. Hard constraints: servers MUST NOT send elicitation to clients without the capability and MUST NOT assume a retry ever comes — so tools must still work by returning an `ambiguous` array. `requestState` is attacker-controlled: integrity-protect (HMAC/AEAD), principal-bind, TTL.
+
+---
+
+## 4. Design considerations
+
+### 4a. Rate limiting — a from-scratch build
+
+**There is no API-level rate limiting anywhere in the backend today** (grep: the only rate-limit code is ESI *outbound* error-limit handling; `security-spec.md` has no throttling section). The MCP spec says servers MUST rate-limit tool invocations. Agent traffic breaks human-calibrated limits by construction. Posture:
+
+- **Three keys**: per-caller, per-tool, global. Token bucket with burst, **weighted by tool cost** (`resolve_names` cache hit ≠ `market_summary` aggregate scan ≠ `appraise_contract` external data).
+- **Informative 429s** as tool-execution errors (`isError: true`) — which limit, wait time, quota — so the model self-corrects instead of blind-retrying.
+- **Unauthenticated access still needs a caller key of some kind** (free, self-service, no-PII), or the only key is IP — worthless against a hosted agent fleet.
+- **Amplification asymmetry:** appraisal calls consume external market data. Uncapped agent traffic on Hangar Bay becomes uncapped Hangar Bay traffic on Fuzzwork/ESI, and ESI bans for cache circumvention. **Cache appraisals aggressively; never proxy live.**
+
+### 4b. Freshness signaling — the repo is ahead of the requirement
+
+M5 Workstream B already specifies `data_as_of` + `data_stale` on the list envelope, sourced from the ingest-run record, with the right philosophy: *the server owns the judgement, the client owns the presentation* (the staleness threshold derives from the scheduler interval no client can see). For MCP, three rules:
+
+1. **`data_as_of` + `data_stale` in every tool result** — models drop context between calls; a payload field survives.
+2. **Escalate in text, not just a boolean.** A model will summarize away `true`; it will not summarize away "⚠ Data is 3.6 days old; these contracts may no longer exist."
+3. **Same for coverage:** `coverage: ["The Forge"]` in every result, and an explicit "no data for <region>" error rather than an empty list. **An empty list is a lie to an agent.**
+
+M5's liveness filtering (expiry + per-region `last_seen_at` watermark for sold/delisted contracts) is a **prerequisite** for MCP: an agent confidently recommending a sold contract is this surface's single worst failure mode.
+
+### 4c. Auth — the spec forecloses the easy path
+
+Current auth is an opaque Valkey session cookie (`core/current_user.py`); no bearer/PAT path exists. The [2026-07-28 authorization spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization): the MCP server is an OAuth 2.1 Resource Server, MUST implement RFC 9728 Protected Resource Metadata; clients MUST use RFC 8707 resource indicators; and — the killer — clients MUST NOT send tokens other than ones issued by the MCP server's own authorization server, and servers MUST NOT accept or transit any other tokens. **You cannot hand an EVE SSO token to the MCP server.** EVE SSO would sit *upstream* of an authorization server Hangar Bay operates or rents (AuthKit/Auth0/Stytch/Descope), issuing Hangar-Bay-audience tokens after federating to CCP — plus PKCE, discovery, RFC 9207, Client ID Metadata Documents (Dynamic Client Registration is now *deprecated*). **That is a milestone, not a task** — the strongest argument for a read-only public v1. Authorization is OPTIONAL in the spec; a fully public server is conformant.
+
+### 4d. Hosting, and the auto-generation question
+
+**Auto-generating from OpenAPI: the consensus is settled and it is "don't."** FastMCP's own docs recommend the FastAPI integration "for bootstrapping and prototyping, not for mirroring your API to LLM clients" ([gofastmcp.com/integrations/fastapi](https://gofastmcp.com/integrations/fastapi)); the maintainer's essay [Stop Converting Your REST APIs to MCP](https://jlowin.dev/blog/stop-converting-rest-apis-to-mcp) makes the argument at length; Anthropic's guidance points the same way. Hangar Bay is a textbook case: auto-generation would emit ME/TE parameters that are accepted-and-ignored (FASTAPI-2), a runs filter wired to `raw_quantity` (−1 BPO / −2 BPC, not a run count) so `min_runs=5` matches nothing, and a response schema dragging full `items` into every row. **Four inert parameters, two semantically wrong ones, and a token bomb — all correctly generated.**
+
+**Library state (verified 2026-08-01 by the spec/hosting lane — Part 2 below):** the recommendation flipped on 2026-07-28. The **official Python SDK v2.0.0** shipped that day with stable `2026-07-28` support and "serves every earlier revision from the same server"; it renamed `FastMCP` → `MCPServer` (decorator API unchanged) and ships middleware, caching, pagination, and OpenTelemetry pages of its own. **FastMCP 3.4.5** (stable) tops out at spec `2025-11-25` (hard `mcp<2.0` pin); `2026-07-28` support exists only in its 4.0.0b1 prerelease. `tadata-org/fastapi_mcp` is **dead** (last real commit 2025-08-10, unbounded `mcp>=1.12.0` pin that likely breaks on fresh installs against SDK v2). **Use the official SDK v2.**
+
+**Same app or sidecar?** Sidecar-in-the-same-process: mount the MCP ASGI app inside the existing FastAPI app (`mcp.streamable_http_app()` mounted in Starlette/FastAPI), sharing DB engine, Valkey, settings, structlog — but keep the tool layer **hand-written against `services/`, never against the HTTP routes**. Two project gotchas: PROXY-1 (an MCP mount needs an edge decision — likely its own hostname, e.g. `mcp.hangarbay…`, which also gives a clean RFC 8707 canonical resource URI and a separate rate-limit domain), and the single-worker/scheduler-split posture noted in the M5 options doc (check before assuming co-hosting is free).
+
+---
+
+## 5. What "final form" unlocks — and the strategic risks
+
+**From website to substrate.** An MCP surface changes the unit of competition from *presentation* to *the index itself*. The item-enriched, name-resolved, freshness-stamped contract corpus is the asset, and §1d establishes it is genuinely unreachable from ESI — every existing EVE MCP server is a thin ESI wrapper and none do contracts, because contracts are the one ESI dataset you cannot query without ingesting all of it. Hangar Bay is the only entity in this ecosystem that has already paid that cost. Infrastructure compounds where a website does not: every corp Discord bot and hauling assistant that integrates becomes a reason the pipeline must keep running well.
+
+**It changes what the product owes its users.** A website gets away with a stale row and a small-type caveat; an agent laundering that row into confident prose does not. M5's trust work (dead-contract filtering, freshness surface, retiring the always-`"unknown"` status column) stops being polish and becomes the **precondition** for an MCP surface being ethical to publish. Same for appraisal — over MCP, a wrong number degrades to an agent telling someone a 2-billion-ISK contract is a good deal. And ships-only/one-region scope becomes a load-bearing honesty problem the moment an agent asks about Amarr and gets `[]`. **Honest read: an MCP server should not ship before M5's trust work and coverage expansion land.** It is the right final form, and it is downstream of the current milestone, not parallel to it.
+
+**Risk 1 — becoming a free backend; CCP has already decided this for you.** The [EVE Developer License Agreement](https://developers.eveonline.com/license-agreement) §4.1: developers "may not charge any fee … or otherwise monetize the Application"; §4.4 permits only ISK-gated access, voluntary donations, and general advertising. **Paid tiers are not available as a mitigation.** What remains is operational: required free API keys for attribution and rate-limit keying, per-caller quotas, published fair-use terms. The risk is smaller than it looks — competitors also cannot charge, so nobody can build a *paid* product on your back; the realistic downside is bandwidth and ingestion cost, not revenue capture.
+
+**Risk 2 — ESI redistribution: permitted in practice, ambiguous on paper.** The license limits use to the defined "Purpose" (applications that "enhance Player's enjoyment of EVE") and never explicitly addresses re-serving ESI-derived data — *unaddressed rather than prohibited*. De-facto precedent is strong: EVE Ref runs a public API (`api.everef.net`) mirroring ESI scrapes with CCP-granted branding permission; zKillboard, Fuzzwork, and Adam4EVE all redistribute ESI-derived data. Explicit obligations: carry the CCP proprietary notice (§7.1), identifying User-Agent, respect `expires`/ETag, stay inside the error limit. **Assessment: legal risk low but non-zero; resolve by asking CCP's third-party dev channels, not by reading harder.** Mild positive signal: CCP features an LLM-powered ESI consumer on its own docs site.
+
+**Risk 3 — building on a protocol that moved days ago.** The 2026-07-28 revision is breaking; SDK support almost certainly lags; deprecated features get a 12-month runway under the [feature lifecycle policy](https://modelcontextprotocol.io/community/feature-lifecycle). Survivable — but it argues for a **small surface**: seven hand-written tools re-implemented against a new revision is a week; a thirty-tool auto-generated mirror is a quarter. The narrow surface is the hedge against protocol churn, not just the token-economy answer.
+
+---
+
+## Part 2 — spec + hosting deep-dive (separate verification lane, same date)
+
+A second research lane verified the protocol and hosting landscape directly against primary sources. Decision-relevant facts, including corrections to Part 1:
+
+### Protocol state
+
+- **Current spec revision is `2026-07-28`** (lineage: 2024-11-05 → 2025-03-26 → 2025-06-18 → 2025-11-25 → 2026-07-28; RC locked 2026-05-21 with a ten-week validation window). Headline breaking changes: `initialize` handshake and protocol sessions **removed** (per-request `_meta` version negotiation; state via server-minted opaque handles passed as tool arguments); `server/discover` is **mandatory** for servers; **MRTR** replaces all server-initiated requests; every result carries `resultType`; `subscriptions/listen` replaces `resources/subscribe`; **Sampling, Roots, and Logging are deprecated** (12-month runway).
+- **`ttlMs` + `cacheScope` are now REQUIRED** on list/read/discover results (`"public"` = shareable across auth contexts). A real win for a public read-heavy marketplace — shared intermediaries can cache tool lists and reference resources.
+- **Pagination is list-operations only; there is no tool-result pagination in MCP.** Tool-data pagination is convention: `limit`/`cursor` in the tool's own inputSchema, small defaults, `next_cursor` in `structuredContent`.
+- **Hard client limits:** Claude.ai/Desktop cap tool results at **~150,000 characters**; Claude Code at **25,000 tokens**; 300s timeout on hosted surfaces. Design responses well under the Claude Code cap.
+- **Client adoption lags the spec:** as of 2026-08-01 Claude's connector docs list auth support only through 2025-11-25 ("rolling out soon" for 2026-07-28). **Build for 2026-07-28; the official SDK serves earlier revisions from the same server.** Claude does not support resource subscriptions; ChatGPT supports tools only. **Tools are the only primitive with universal support — design the value in tools.**
+- **Elicitation** is active (now via MRTR) but client support is unverifiable — treat as enhancement, never load-bearing; always return an `ambiguous` array as the fallback path.
+
+### Auth — the three-layer architecture is confirmed, with EVE SSO blockers named
+
+**EVE SSO cannot be the MCP Authorization Server** — three independent blockers verified against CCP's SSO docs: no DCR/CIMD (manual portal registration only), no RFC 8707 resource indicators, and wrong audience (`aud = [client_id, "EVE Online"]`, not the MCP server's URI — unfixable without token passthrough, which the spec explicitly forbids). Correct architecture: (1) Hangar Bay MCP server as pure Resource Server (RFC 9728 metadata, audience validation); (2) an Authorization Server Hangar Bay operates or rents (Keycloak is the spec's own tutorial example) issuing MCP-audience tokens, CIMD preferred (DCR now deprecated); (3) EVE SSO federated upstream inside that AS — EVE/ESI tokens stay server-side, never visible to the MCP client.
+
+**Lazy auth is first-class and fits a public marketplace exactly:** "a product catalog can be browsed anonymously; an order history cannot." Anonymous clients call public tools; the server challenges on protected ones. Critical detail: the refusal must be a **transport-level `401` + `WWW-Authenticate`** gated before the JSON-RPC layer — a `200` with `isError: true` produces no auth prompt in Claude.
+
+**Anthropic's connector review criteria are an enforced gate:** a catch-all `api_request` tool with a `method` parameter is rejected; read and write must be separate tools; `readOnlyHint`/`destructiveHint` annotations determine per-call confirmation behavior; oversized responses are grounds for rejection. Pure machine-to-machine `client_credentials` is unsupported — every connection requires user consent.
+
+### Hosting — the recommendation flipped on 2026-07-28
+
+- **Official Python SDK v2.0.0** (released 2026-07-28): stable current-spec support, serves all earlier revisions, `FastMCP` class renamed `MCPServer`, ships provisional middleware (rate limiting/access control), caching, pagination, OpenTelemetry. **The safer choice today.**
+- **FastMCP 3.4.5** (stable): pinned `mcp<2.0`, tops out at spec 2025-11-25; current-spec support only in 4.0.0b1. Its genuine advantages over the official SDK: composition, proxying, OpenAPI generation (which we don't want), in-process test client.
+- **`tadata-org/fastapi_mcp`: dead.** Last real commit 2025-08-10, 161 open items, alpha classifier, unbounded `mcp>=` pin that likely breaks fresh installs against SDK v2.
+- **Two day-one pitfalls for mounting inside FastAPI** (worth `docs/pitfalls/` entries when this is built): (1) the parent app must enter the MCP session manager's lifespan — a mounted sub-app's lifespan never runs; symptom is `RuntimeError: Task group is not initialized` (the single most-reported integration bug); (2) the SDK's transport security accepts only localhost-addressed requests until `transport_security=` is configured with the real hostname — symptom is `421 Misdirected Request` on Render.
+- Rate-limit error codes: `-32020..-32099` is now **reserved for the spec**; implementation-defined errors use `-32000..-32019`, or plain HTTP 429.
+
+### Autogeneration verdict, quantified
+
+The empirical record behind "hand-design, don't mirror": GitHub Copilot cut ~40 tools to 13 and gained 2–5pp on SWE-bench across two model families; Anthropic's docs state tool selection degrades past **30–50 tools**; a controlled Pet Store experiment found cliff-edge failure at 107 tools; an academic survey (AutoMCP, arXiv 2507.16044) found hand-written servers expose a **median 19% of available API operations** — curation is the norm, not the exception. No credible non-vendor source argues the opposite; vendors selling generation all ship curation features that concede the point.
+
+## Appendix: repo-grounded facts a plan would need
+
+| Fact | Location |
+|---|---|
+| List endpoint always eager-loads `items` on both fetch paths | `services/contract_service.py` `_fetch_page_joined`, `_fetch_page_simple` |
+| `min_me`/`max_me`/`min_te`/`max_te` accepted but ignored (FASTAPI-2) | `schemas/contracts.py` |
+| `min_runs`/`max_runs` filter `raw_quantity` (−1 BPO / −2 BPC), not runs | `services/contract_service.py` `_apply_item_filters` |
+| `ContractItem.category` is only `"ship"` or NULL; `group_id`/`category_id` not stored | `models/contracts.py`; `background_aggregation.py` ~692 |
+| `Contract.type` stored + indexed but not exposed as a filter | `models/contracts.py` `ix_contracts_type_status` |
+| `status` always `"unknown"`; retirement designed in M5 Workstream D | `2026-07-26-m5-trust-shareability-design.md` |
+| `data_as_of` / `data_stale` envelope design | same doc, Workstream B |
+| Liveness: expiry + per-region `last_seen_at` watermark | `contract_service.py` `_apply_contract_filters` |
+| Auth = opaque Valkey session cookie; no bearer/PAT path | `core/current_user.py`, `api/auth.py` |
+| No API rate limiting anywhere | grep across `src/`; `security-spec.md` silent |
+| No backend reference data; regions are a generated frontend constant | `app/frontend/web/src/features/contracts/regions.ts` |
+| Coverage = The Forge only | `render.yaml` `AGGREGATION_REGION_IDS = "[10000002]"` |
+| Routers mount bare; `/api/v1` owned by proxy/edge (PROXY-1) | `api/contracts.py` and siblings |
+
+**Unverified items, flagged rather than smoothed over:** FastMCP 3.0 GA status; SDK support for the 2026-07-28 revision; real-world client support for `structuredContent` and resource subscriptions; `fastapi_mcp` maintenance state; registry-scale statistics.


### PR DESCRIPTION
## Summary

Two research docs answering "should we display the non-ship contracts we already ingest?" and "what would a Hangar Bay MCP surface look like?":

- **`docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md`** — gap analysis vs EVE Workbench's market tool and the wider ecosystem (Adam4EVE, MutaMarket, EVE Ref, EVE Tycoon, Fuzzwork, Janice, jita.space), plus a file:line-verified inventory of what we ingest vs display (33,817 live contracts, 1.2% shown), the fields dropped at ingestion, and the defects independently verified and fixed in PR #98. Recommends displaying all ingested contract types via a sequenced plan (fixes → ingestion fields/taxonomy → type-aware browse view → valuation).
- **`docs/superpowers/specs/2026-08-01-mcp-surface-research.md`** — design-space research for an MCP server: prior art, consumer personas, a proposed small read-only tool surface, auth/hosting analysis against the 2026-07-28 MCP spec revision, and CCP-license constraints.

Both docs are analysis/decision-support only — no product decisions are taken in them; the recommendation sections are explicitly pending Sam.

## Merge classification

Routine — documentation only; no code, schema, or spec-of-record changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)