### PR TITLE
docs(api): mark min_runs/max_runs and system_ids as matching nothing

### DIFF
--- a/app/backend/src/fastapi_app/schemas/contracts.py
+++ b/app/backend/src/fastapi_app/schemas/contracts.py
@@ -97,10 +97,27 @@ class ContractFilters(BaseModel):
     max_collateral: Optional[float] = Field(
         default=None, ge=0, description="Maximum collateral."
     )
+    # NOTE (ESI-3): min_runs/max_runs are applied, but against ContractItem.raw_quantity —
+    # a field ESI returns only on the AUTHENTICATED contract-item routes, never on the public
+    # one we ingest. The column is therefore always NULL and both bounds match zero rows.
+    # Making them work requires ingesting the public `runs` field; note that on that route an
+    # original OMITS `runs` rather than sending -1, so the documented sentinel never appears.
     min_runs: Optional[int] = Field(
-        default=None, ge=-1, description="Minimum runs for BPCs (-1 for original)."
+        default=None,
+        ge=-1,
+        description=(
+            "Minimum runs for BPCs. "
+            "(NO MATCHES — filters an always-NULL column; do not expose in clients)"
+        ),
     )
-    max_runs: Optional[int] = Field(default=None, ge=-1, description="Maximum runs for BPCs.")
+    max_runs: Optional[int] = Field(
+        default=None,
+        ge=-1,
+        description=(
+            "Maximum runs for BPCs. "
+            "(NO MATCHES — filters an always-NULL column; do not expose in clients)"
+        ),
+    )
     # NOTE (FASTAPI-2): min_me/max_me/min_te/max_te are accepted but never applied
     # by the service (ME/TE data is not in the model). The descriptions flag them as
     # inert so generated clients (openapi.json → frontend codegen) do not surface them
@@ -142,8 +159,16 @@ class ContractFilters(BaseModel):
     region_ids: Optional[List[int]] = Field(
         default=None, description="List of region IDs to filter by."
     )
+    # NOTE: system_ids is applied, but Contract.start_location_system_id is never populated —
+    # ESI's public contracts carry a station/structure id and no system id, and no enrichment
+    # resolves one. Making it work needs a location→system lookup (/universe/stations/ covers
+    # NPC stations; player structures need an ACL-scoped token and would stay NULL).
     system_ids: Optional[List[int]] = Field(
-        default=None, description="List of solar system IDs to filter by."
+        default=None,
+        description=(
+            "List of solar system IDs to filter by. "
+            "(NO MATCHES — filters an always-NULL column; do not expose in clients)"
+        ),
     )
     station_ids: Optional[List[int]] = Field(
         default=None, description="List of station IDs to filter by."

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -1111,7 +1111,7 @@
             }
           },
           {
-            "description": "Minimum runs for BPCs (-1 for original).",
+            "description": "Minimum runs for BPCs. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
             "in": "query",
             "name": "min_runs",
             "required": false,
@@ -1125,12 +1125,12 @@
                   "type": "null"
                 }
               ],
-              "description": "Minimum runs for BPCs (-1 for original).",
+              "description": "Minimum runs for BPCs. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
               "title": "Min Runs"
             }
           },
           {
-            "description": "Maximum runs for BPCs.",
+            "description": "Maximum runs for BPCs. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
             "in": "query",
             "name": "max_runs",
             "required": false,
@@ -1144,7 +1144,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Maximum runs for BPCs.",
+              "description": "Maximum runs for BPCs. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
               "title": "Max Runs"
             }
           },
@@ -1246,7 +1246,7 @@
             }
           },
           {
-            "description": "List of solar system IDs to filter by.",
+            "description": "List of solar system IDs to filter by. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
             "in": "query",
             "name": "system_ids",
             "required": false,
@@ -1262,7 +1262,7 @@
                   "type": "null"
                 }
               ],
-              "description": "List of solar system IDs to filter by.",
+              "description": "List of solar system IDs to filter by. (NO MATCHES \u2014 filters an always-NULL column; do not expose in clients)",
               "title": "System Ids"
             }
           },

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -771,9 +771,9 @@ export interface operations {
                 min_collateral?: number | null;
                 /** @description Maximum collateral. */
                 max_collateral?: number | null;
-                /** @description Minimum runs for BPCs (-1 for original). */
+                /** @description Minimum runs for BPCs. (NO MATCHES — filters an always-NULL column; do not expose in clients) */
                 min_runs?: number | null;
-                /** @description Maximum runs for BPCs. */
+                /** @description Maximum runs for BPCs. (NO MATCHES — filters an always-NULL column; do not expose in clients) */
                 max_runs?: number | null;
                 /** @description Minimum Material Efficiency for BPCs. (NOT IMPLEMENTED — accepted but ignored by the service; do not expose in clients) */
                 min_me?: number | null;
@@ -785,7 +785,7 @@ export interface operations {
                 max_te?: number | null;
                 /** @description List of region IDs to filter by. */
                 region_ids?: number[] | null;
-                /** @description List of solar system IDs to filter by. */
+                /** @description List of solar system IDs to filter by. (NO MATCHES — filters an always-NULL column; do not expose in clients) */
                 system_ids?: number[] | null;
                 /** @description List of station IDs to filter by. */
                 station_ids?: number[] | null;


### PR DESCRIPTION
## Summary

Three query parameters are accepted, applied, and match zero rows against real data. Two of them were documented in a way that was actively misleading. This corrects the descriptions so the defect is visible in the OpenAPI schema and the generated client, following the convention already used for `min_me`/`max_me`/`min_te`/`max_te` (FASTAPI-2).

**No behavior change** — description strings only, plus the regenerated `openapi.json` and `schema.d.ts`.

- `min_runs` / `max_runs` previously read *"Minimum runs for BPCs (-1 for original)."* Both halves are wrong against public data: the filter reads `ContractItem.raw_quantity`, a field ESI returns only on the **authenticated** contract-item routes and never on the public one we ingest, so the column is permanently NULL; and on the public route an original **omits** `runs` rather than sending `-1`, so the documented sentinel never appears. Anyone implementing against that description would have written the wrong thing.
- `system_ids` gave no hint it matches nothing. `Contract.start_location_system_id` is never populated — ESI's public contracts carry a station/structure id and no system id, and no enrichment resolves one.

Each now carries a code comment explaining the mechanism and what fixing it would take, so the next person doesn't rediscover it. The params are deliberately left in place rather than removed — that would be a breaking API change and is a decision for Sam, not a drive-by.

This matters beyond the docs: a silent no-op filter is the antipattern the contract-coverage analysis flagged in a competitor's UI, and an agent-facing surface reading this schema would otherwise treat these as working controls.

## Merge classification

Routine — documentation strings and regenerated codegen. No behavior, schema, or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)