### PR TITLE
fix(api): stop watchlist alerts outliving a contract's purchase

### DIFF
--- a/app/backend/src/fastapi_app/services/contract_service.py
+++ b/app/backend/src/fastapi_app/services/contract_service.py
@@ -53,6 +53,41 @@ def _needs_item_join(filters: ContractFilters) -> bool:
     # multiplying rows. See _has_blueprint_copy_item.
 
 
+def still_listed_by_esi():
+    """Is this contract still present in ESI's public list?
+
+    Expiry only catches contracts that ran out of time; a contract that was ACCEPTED
+    disappears from ESI's public list while keeping a future date_expired, so it survives
+    the expiry predicate and would go on being offered for up to two weeks. Ingestion
+    restamps last_seen_at on every sighting, so a contract is present when its stamp
+    equals the newest stamp IN ITS OWN REGION.
+
+    Per-region rather than global, deliberately: if one region's ESI fetch fails, nothing in
+    it is restamped, and judging it against another region's fresher watermark would erase
+    every contract that region holds in one go. A stalled region simply keeps its own
+    watermark. If ingestion stops entirely, no watermark advances and everything stays
+    visible — stale data with a staleness signal beats an empty site.
+
+    NULL is visible: rows predating this column have no stamp, and hiding them would blank
+    the site between the migration and the first run. The migration backfills them anyway.
+
+    Shared with the watchlist matcher so "still on offer" has one definition. The tradeoff
+    the shared definition accepts: a contract that momentarily drops out of an ESI page —
+    an ingestion gap, a partial fetch that still restamped part of its region — reads as
+    gone, so a watchlist alert for it can be missed. That is the better failure. The
+    alternative is alerting on a contract someone already bought for as long as two weeks,
+    which sends the reader to a dead listing over and over and teaches them the alerts are
+    noise; a missed alert costs one opportunity and leaves the feature trustworthy.
+    """
+    newest_in_region = (
+        select(func.max(_ContractWatermark.last_seen_at))
+        .where(_ContractWatermark.start_location_region_id == Contract.start_location_region_id)
+        .correlate(Contract)
+        .scalar_subquery()
+    )
+    return or_(Contract.last_seen_at.is_(None), Contract.last_seen_at >= newest_in_region)
+
+
 def _has_blueprint_copy_item():
     """Correlated EXISTS: does this contract carry an item that is a blueprint copy?
 
@@ -92,29 +127,10 @@ def _apply_contract_filters(query, filters: ContractFilters):
     # contract it points at, and 404-ing yesterday's link reads as a broken site.
     query = query.filter(Contract.date_expired > func.now())
 
-    # 0b. Delisted contracts. Expiry only catches contracts that ran out of time; a contract
-    # that was ACCEPTED disappears from ESI's public list while keeping a future date_expired,
-    # so it survives the expiry predicate and would go on being offered for up to two weeks.
-    # Ingestion restamps last_seen_at on every sighting, so a contract is present when its
-    # stamp equals the newest stamp IN ITS OWN REGION.
-    #
-    # Per-region rather than global, deliberately: if one region's ESI fetch fails, nothing in
-    # it is restamped, and judging it against another region's fresher watermark would erase
-    # every contract that region holds in one go. A stalled region simply keeps its own
-    # watermark. If ingestion stops entirely, no watermark advances and everything stays
-    # visible — stale data with a staleness signal beats an empty site.
-    #
-    # NULL is visible: rows predating this column have no stamp, and hiding them would blank
-    # the site between the migration and the first run. The migration backfills them anyway.
-    newest_in_region = (
-        select(func.max(_ContractWatermark.last_seen_at))
-        .where(_ContractWatermark.start_location_region_id == Contract.start_location_region_id)
-        .correlate(Contract)
-        .scalar_subquery()
-    )
-    query = query.filter(
-        or_(Contract.last_seen_at.is_(None), Contract.last_seen_at >= newest_in_region)
-    )
+    # 0b. Delisted contracts — a contract accepted or withdrawn keeps a future date_expired
+    # and survives the expiry predicate above. See still_listed_by_esi for the per-region
+    # watermark and why it is per-region.
+    query = query.filter(still_listed_by_esi())
 
     # 1. Text search (on contract title or item name)
     if filters.search:

--- a/app/backend/src/fastapi_app/services/watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/services/watchlist_matcher.py
@@ -18,6 +18,7 @@ from ..core.logging import get_logger, log_key_event
 from ..models.account import Notification, WatchlistItem
 from ..models.contracts import Contract, ContractItem
 from ..models.user import User
+from .contract_service import still_listed_by_esi
 
 logger = logging.getLogger(__name__)
 slog = get_logger(__name__)
@@ -150,6 +151,19 @@ class WatchlistMatcherService:
                 Contract.type.in_(("item_exchange", "auction")),
                 Contract.date_expired > func.now(),
                 Contract.date_completed.is_(None),
+                # "Outstanding" is the same question the contracts list asks, so it gets
+                # the same answer: expiry catches only contracts that ran out of time,
+                # while a contract someone ACCEPTED vanishes from ESI's public list still
+                # carrying a future date_expired. Without the watermark that contract keeps
+                # generating alerts for as long as two weeks after it was bought — every
+                # one of them sending the reader to a listing that is gone. The tradeoff we
+                # take in exchange is stated in still_listed_by_esi: a contract that
+                # momentarily drops out of an ESI page reads as gone, so an alert for it can
+                # be missed. One missed opportunity beats a fortnight of alerts nobody can act
+                # on, which is what teaches a reader to ignore the feature entirely.
+                # date_completed above is inert against public-route data (ESI never sends
+                # it) and is kept for character/corp contracts, which do carry it.
+                still_listed_by_esi(),
                 or_(WatchlistItem.max_price.is_(None), Contract.price <= WatchlistItem.max_price),
             )
             .distinct()
@@ -194,10 +208,13 @@ class WatchlistMatcherService:
 
     async def _prune(self, db_session: AsyncSession) -> int:
         cutoff = self._now() - timedelta(days=self.settings.NOTIFICATION_RETENTION_DAYS)
+        # "Outstanding" here MUST mean what it means in _match_and_notify, or the prune
+        # deletes aged notifications the very next match run recreates.
         outstanding = select(Contract.contract_id).where(
             Contract.contract_id == Notification.contract_id,
             Contract.date_expired > func.now(),
             Contract.date_completed.is_(None),
+            still_listed_by_esi(),
         )
         # Delete only aged rows whose target contract is no longer outstanding (no-resurrection guard).
         stmt = delete(Notification).where(

--- a/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
@@ -45,15 +45,16 @@ async def _user(db, *, enabled=True, cid=91000001):
 
 
 async def _contract(db, *, cid, price, ctype="auction", expired_in_days=7, completed=False,
-                    location="Jita IV - Moon 4"):
+                    location="Jita IV - Moon 4", region_id=10000002, last_seen_at=None):
     c = Contract(
         contract_id=cid, title="t", price=price, collateral=0, status="unknown", type=ctype,
         issuer_id=1, issuer_corporation_id=1, start_location_id=60003760,
-        start_location_region_id=10000002, for_corporation=False,
+        start_location_region_id=region_id, for_corporation=False,
         date_issued=datetime.now(timezone.utc) - timedelta(days=1),
         date_expired=datetime.now(timezone.utc) + timedelta(days=expired_in_days),
         date_completed=(datetime.now(timezone.utc) if completed else None),
         start_location_name=location,
+        last_seen_at=last_seen_at,
     )
     db.add(c)
     await db.flush()
@@ -202,6 +203,58 @@ async def test_completed_contract_excluded(db_session: AsyncSession):
     assert created == 0
 
 
+async def test_delisted_contract_excluded(db_session: AsyncSession):
+    """A contract that stopped appearing in ESI's public list — accepted, sold, or
+    withdrawn — keeps a future date_expired, so expiry alone still matches it. It is
+    told apart by its last_seen_at trailing the newest stamp in its own region."""
+    u = await _user(db_session)
+    await _watch(db_session, u, type_id=621, max_price=None)
+    fresh = datetime.now(timezone.utc)
+    # The region's watermark: some other contract was restamped by the latest run.
+    await _contract(db_session, cid=6310, price=1, last_seen_at=fresh)
+    await _item(db_session, cid=6310, type_id=34, record_id=63100)
+    # Watched hull, unexpired, but last observed a run ago.
+    await _contract(db_session, cid=6311, price=1, last_seen_at=fresh - timedelta(hours=1))
+    await _item(db_session, cid=6311, type_id=621, record_id=63110)
+    _, created = await _service()._match_and_notify(db_session)
+    assert created == 0
+
+
+async def test_contract_at_its_region_watermark_notifies(db_session: AsyncSession):
+    """The positive half of the delisting gate: a contract restamped by the latest run
+    carries the region's newest stamp and must still match."""
+    u = await _user(db_session)
+    await _watch(db_session, u, type_id=621, max_price=None)
+    fresh = datetime.now(timezone.utc)
+    await _contract(db_session, cid=6320, price=1, last_seen_at=fresh - timedelta(hours=1))
+    await _item(db_session, cid=6320, type_id=34, record_id=63200)
+    await _contract(db_session, cid=6321, price=1, last_seen_at=fresh)
+    await _item(db_session, cid=6321, type_id=621, record_id=63210)
+    _, created = await _service()._match_and_notify(db_session)
+    assert created == 1
+    note = (await db_session.execute(select(Notification))).scalar_one()
+    assert note.contract_id == 6321
+
+
+async def test_stalled_region_is_judged_against_its_own_watermark(db_session: AsyncSession):
+    """The watermark is per-region so a region whose ESI fetch failed keeps its own,
+    older stamp. Judged against a fresher region's stamp, every contract the stalled
+    region holds would be silenced at once."""
+    u = await _user(db_session)
+    await _watch(db_session, u, type_id=621, max_price=None)
+    fresh = datetime.now(timezone.utc)
+    # Region 10000002 was restamped by the latest run.
+    await _contract(db_session, cid=6330, price=1, region_id=10000002, last_seen_at=fresh)
+    await _item(db_session, cid=6330, type_id=34, record_id=63300)
+    # Region 10000043's fetch failed, so nothing in it was restamped — but the watched
+    # hull is still the newest thing its own region has seen.
+    await _contract(db_session, cid=6331, price=1, region_id=10000043,
+                    last_seen_at=fresh - timedelta(hours=6))
+    await _item(db_session, cid=6331, type_id=621, record_id=63310)
+    _, created = await _service()._match_and_notify(db_session)
+    assert created == 1
+
+
 async def test_requested_item_excluded(db_session: AsyncSession):
     u = await _user(db_session)
     await _watch(db_session, u, type_id=621, max_price=None)
@@ -246,6 +299,22 @@ async def test_prune_keeps_old_when_contract_outstanding(db_session: AsyncSessio
     pruned = await _service(now=NOW)._prune(db_session)
     assert pruned == 0
     assert (await db_session.scalar(select(func.count()).select_from(Notification))) == 1
+
+
+async def test_prune_deletes_old_when_contract_delisted(db_session: AsyncSession):
+    """The prune's no-resurrection guard keeps aged notifications whose contract is still
+    outstanding. It has to read "outstanding" exactly as the match query does — a contract
+    that is unexpired but gone from ESI no longer matches, so nothing recreates its
+    notification and holding the row back serves nobody."""
+    u = await _user(db_session)
+    fresh = datetime.now(timezone.utc)
+    await _contract(db_session, cid=7250, price=1, last_seen_at=fresh)
+    await _contract(db_session, cid=7251, price=1, expired_in_days=7,
+                    last_seen_at=fresh - timedelta(hours=1))
+    await _note(db_session, u, cid=7251, created_at=NOW - timedelta(days=100))
+    pruned = await _service(now=NOW)._prune(db_session)
+    assert pruned == 1
+    assert (await db_session.scalar(select(func.count()).select_from(Notification))) == 0
 
 
 async def test_prune_keeps_recent(db_session: AsyncSession):


### PR DESCRIPTION
## The bug

`services/watchlist_matcher.py` selected candidate contracts with `date_expired > now()` **and** `date_completed IS NULL`. The second predicate is **always true**: ESI's public contracts route does not return `date_completed` (verified against its OpenAPI spec), so ingestion never populates the column.

Meanwhile the contracts **list** endpoint (`services/contract_service.py`) applies a second liveness gate the matcher did not — a per-region `last_seen_at` watermark, which is how it excludes contracts that have disappeared from ESI (sold, accepted, or delisted).

Net effect: a contract someone already bought kept generating watchlist notifications until its natural expiry — **up to two weeks**, every one of them sending the reader to a listing that is gone.

## The fix

The watermark predicate moves out of `_apply_contract_filters` into a named helper, `still_listed_by_esi()`, and the matcher reuses it. No reimplementation, no restructuring of either module.

Applied in **two** places in the matcher:

1. `_match_and_notify` — the actual bug.
2. `_prune` — the prune's no-resurrection guard asks the same "is this contract outstanding?" question. Left alone it would have been strictly more conservative (retaining a few extra 90-day-old rows), not wrong, but the two definitions of *outstanding* would have started drifting the moment either changed. Flagging it explicitly since it is one line beyond the reported bug — say the word and I will drop it.

`date_completed IS NULL` is **kept**. It is inert against public-route data, and the M5 trust/shareability design's reasoning for keeping the `status` column applies identically: it becomes meaningful if character/corp contracts are ever ingested.

## The tradeoff Sam approved

Sam approved this explicitly. The comment recording it, verbatim from `still_listed_by_esi()`:

> Shared with the watchlist matcher so "still on offer" has one definition. The tradeoff
> the shared definition accepts: a contract that momentarily drops out of an ESI page —
> an ingestion gap, a partial fetch that still restamped part of its region — reads as
> gone, so a watchlist alert for it can be missed. That is the better failure. The
> alternative is alerting on a contract someone already bought for as long as two weeks,
> which sends the reader to a dead listing over and over and teaches them the alerts are
> noise; a missed alert costs one opportunity and leaves the feature trustworthy.

And at the matcher's call site, verbatim:

> "Outstanding" is the same question the contracts list asks, so it gets
> the same answer: expiry catches only contracts that ran out of time,
> while a contract someone ACCEPTED vanishes from ESI's public list still
> carrying a future date_expired. Without the watermark that contract keeps
> generating alerts for as long as two weeks after it was bought — every
> one of them sending the reader to a listing that is gone. The tradeoff we
> take in exchange is stated in still_listed_by_esi: a contract that
> momentarily drops out of an ESI page reads as gone, so an alert for it can
> be missed. One missed opportunity beats a fortnight of alerts nobody can act
> on, which is what teaches a reader to ignore the feature entirely.
> date_completed above is inert against public-route data (ESI never sends
> it) and is kept for character/corp contracts, which do carry it.

## Tests (written first, all four mutation-verified per TEST-12)

| Test | Mutation applied | Result |
|---|---|---|
| `test_delisted_contract_excluded` | remove `still_listed_by_esi()` from the match query | RED — `assert 1 == 0` |
| `test_contract_at_its_region_watermark_notifies` | `last_seen_at >= watermark` → `>` | RED — `assert 0 == 1` |
| `test_stalled_region_is_judged_against_its_own_watermark` | per-region watermark → global | RED — `assert 0 == 1` |
| `test_prune_deletes_old_when_contract_delisted` | remove `still_listed_by_esi()` from the prune guard | RED — `assert 0 == 1` |

Restore-and-rerun after the last mutation: **25 passed** (baseline not clobbered). Mutations were applied and reverted from `cp` snapshots, never `git checkout --`.

The stalled-region test is the one that matters for blast radius: it pins that a region whose ESI fetch failed is judged against its own older watermark, so a partial ingestion run cannot silence every alert that region holds at once.

## Gates

- `pdm run pytest` — **514 passed** (510 baseline + 4 new)
- `pdm run lint` — clean

Frontend untouched.

## Merge classification

`Review — notification semantics change`

This changes when users do and do not receive watchlist alerts. Not merging it myself.