### PR TITLE
feat(esi): monitor drift in the ESI routes and fields we consume

### DIFF
--- a/.github/workflows/esi-spec-monitor.yml
+++ b/.github/workflows/esi-spec-monitor.yml
@@ -1,0 +1,124 @@
+# ABOUTME: Scheduled watch on the parts of EVE's ESI spec Hangar Bay consumes — diffs the live
+# ABOUTME: projection against the committed snapshot and files a self-closing issue when it moves.
+name: ESI spec monitor
+
+# Deliberately NOT wired to pull_request or push. This job reports on the outside
+# world, not on our diff: a change CCP made overnight must not turn an unrelated PR
+# red. The comparison logic's own unit tests DO run on every backend PR, via the
+# backend lane in ci.yml (pyproject's testpaths includes app/backend/tools).
+on:
+  schedule:
+    # Daily, off the top of the hour — GitHub drops scheduled runs during the
+    # congestion at :00. The spec is served with max-age=600, so daily is ample.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write        # the only write: filing/closing the drift issue below
+
+concurrency:
+  group: esi-spec-monitor
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: app/backend
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PYTHONPATH: tools
+      ISSUE_LABEL: esi-spec-drift
+      ISSUE_TITLE: ESI spec drift detected in routes Hangar Bay consumes
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      # No dependency install step: the monitor is standard-library only, so it
+      # cannot be broken by an unrelated change to the backend's dependency tree.
+
+      - name: Ensure the drift label exists
+        # Hoisted out of the two steps below because `gh issue list --label` errors on
+        # a label the repository has never had — which would make the green-path
+        # cleanup step fail on the very first run.
+        run: |
+          gh label create "$ISSUE_LABEL" --color B60205 \
+            --description 'The published ESI spec no longer matches the committed snapshot' \
+            2>/dev/null || true
+
+      - name: Compare the live spec against the committed snapshot
+        id: check
+        run: |
+          set +e
+          python -m esi_spec_monitor.monitor > "$RUNNER_TEMP/report.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/report.txt"
+          # Only the exit code crosses into GITHUB_OUTPUT. The report itself stays in
+          # a file and is passed to `gh` with --body-file: it is built from a document
+          # CCP controls, and interpolating that into GITHUB_OUTPUT would let a crafted
+          # string forge output variables.
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: File the drift issue
+        # Exactly 1 means "the spec moved". 2 means ESI was unreachable or served
+        # something unparseable — a real failure worth a red run, but not drift, and
+        # filing it as drift would train readers to ignore the issue.
+        if: steps.check.outputs.status == '1'
+        run: |
+          set -euo pipefail
+          open_issue=$(gh issue list --state open --label "$ISSUE_LABEL" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$open_issue" ]; then
+            # A drift that nobody has actioned yet is still the same drift. Commenting
+            # daily on it would turn a standing alarm into a notification stream, which
+            # is how alarms get muted.
+            echo "drift issue #$open_issue is already open — not filing a duplicate"
+            exit 0
+          fi
+
+          {
+            echo 'The scheduled ESI spec monitor found differences between the live spec and'
+            echo '`app/backend/tools/esi_spec_monitor/snapshot.json`.'
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/report.txt"
+            echo '```'
+            echo
+            echo '## What to do'
+            echo
+            echo '1. Read the breaking findings first — each names the call path, the field, what'
+            echo '   changed, and the code that reads it.'
+            echo '2. Fix or adapt the consuming code if the change breaks it.'
+            echo '3. Re-run `pdm run esi-spec-monitor --update` in `app/backend` and commit the'
+            echo '   snapshot in the same PR, so the accepted shape is reviewable.'
+            echo
+            echo 'This issue closes itself on the next green run.'
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > "$RUNNER_TEMP/body.md"
+
+          gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" \
+            --body-file "$RUNNER_TEMP/body.md"
+
+      - name: Close a resolved drift issue
+        if: steps.check.outputs.status == '0'
+        run: |
+          set -euo pipefail
+          # Self-resetting alarm: without this, a drift that was handled leaves a stale
+          # open issue, and a stale alarm is one nobody reads the next time it fires.
+          for number in $(gh issue list --state open --label "$ISSUE_LABEL" \
+              --json number --jq '.[].number'); do
+            gh issue close "$number" --comment \
+              "The ESI spec monitor is green again — the live spec matches the committed snapshot. Closed by ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}."
+          done
+
+      - name: Fail the run
+        if: steps.check.outputs.status != '0'
+        run: |
+          echo "::error::the ESI spec monitor exited ${{ steps.check.outputs.status }} — see the report above"
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,8 @@ pdm run pytest              # test suite (drops/recreates the DATABASE_URL_TESTS
 pdm run lint                # flake8
 pdm run format              # black
 pdm run export-openapi      # writes app/frontend/web/openapi.json from the live schema
+pdm run esi-spec-monitor    # diff EVE's published ESI spec against the committed
+                            #   snapshot of what we consume; --update to accept (ESI-4)
 ```
 
 **Frontend** (run from `app/frontend/web/`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,8 @@ pdm run pytest              # test suite (drops/recreates the DATABASE_URL_TESTS
 pdm run lint                # flake8
 pdm run format              # black
 pdm run export-openapi      # writes app/frontend/web/openapi.json from the live schema
+pdm run esi-spec-monitor    # diff EVE's published ESI spec against the committed
+                            #   snapshot of what we consume; --update to accept (ESI-4)
 ```
 
 **Frontend** (run from `app/frontend/web/`):

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -27,9 +27,16 @@ dev = [
 distribution = false
 
 [tool.pytest.ini_options]
-testpaths = ["src/fastapi_app/tests"]
-pythonpath = ["src"]
+# tools/ holds operational scripts rather than application code. Its tests are pure
+# unit tests — no database, no network — so they run in the ordinary backend lane and
+# the drift detector's own comparison logic is covered on every PR, not only when the
+# scheduled monitor happens to fire.
+testpaths = ["src/fastapi_app/tests", "tools"]
+pythonpath = ["src", "tools"]
 markers = [
+    # No test carries this marker. Detecting ESI schema drift is the job of
+    # tools/esi_spec_monitor, which diffs the published spec on a schedule; a live
+    # test lane can only see drift its sample happens to contain.
     "esi_live: marks tests that hit the live ESI API (to be used with VCR)",
 ]
 asyncio_mode = "strict"
@@ -43,3 +50,4 @@ migrate = {shell = "cd src && python -m alembic upgrade head"}
 makemigration = {shell = "cd src && python -m alembic revision --autogenerate -m {args}"}
 migrate-check = {shell = "cd src && python -m alembic current"}
 provision-dashboards = "python observability/provision_dashboards.py"
+esi-spec-monitor = {cmd = "python -m esi_spec_monitor.monitor", env = {PYTHONPATH = "tools"}}

--- a/app/backend/tools/esi_spec_monitor/__init__.py
+++ b/app/backend/tools/esi_spec_monitor/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Package marker for the ESI spec drift monitor — manifest, projection, comparison, CLI.
+# ABOUTME: Pure-stdlib on purpose so the scheduled workflow needs no dependency install.

--- a/app/backend/tools/esi_spec_monitor/manifest.py
+++ b/app/backend/tools/esi_spec_monitor/manifest.py
@@ -1,0 +1,203 @@
+# ABOUTME: The explicit manifest of ESI endpoints and response fields Hangar Bay consumes,
+# ABOUTME: each field annotated with the code that reads it so a drift report names the consumer.
+"""What Hangar Bay actually depends on in EVE's ESI API.
+
+This is the projection lens. The monitor compares only what is listed here, so the
+full 182-path spec's constant churn in areas we do not consume produces no noise.
+
+Two path spaces exist and they are not the same:
+
+*   **Call path** — what `ESIClient` puts on the wire, version-prefixed (`/v1/...`,
+    `/v3/...`) per the pinning rule in docs/pitfalls/implementation-pitfalls.md ESI-1.
+*   **Spec path** — the key under `paths` in `https://esi.evetech.net/meta/openapi.json`,
+    which is **unversioned**. ESI replaced route versioning with the
+    `X-Compatibility-Date` header, so the meta spec documents one shape per route and
+    selects between historical shapes by date rather than by URL segment.
+
+`spec_path` is therefore the lookup key and `call_path` is what a failure message
+should quote back, because that is the string a reader will grep for.
+
+`consumed_fields` lists only fields our code actually reads, each mapped to the reader.
+Fields the spec carries that we ignore are still captured by the projection (so their
+arrival or departure is visible) but a change to them is not attributed to a consumer.
+
+`known_absent_fields` records fields our code reads that the spec does **not** carry —
+the ESI-3 family of traps. They are declared rather than silently tolerated so that
+(a) nobody re-derives the same discovery by hand, and (b) if ESI ever starts sending
+one, the monitor says so, because a dead filter suddenly becoming implementable is
+news worth having.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class KnownAbsentField:
+    """A field our code reads that the public spec does not document.
+
+    `consequence` states what the code silently does today, so a reader deciding
+    whether to care does not have to go and work it out again.
+    """
+
+    name: str
+    consumer: str
+    consequence: str
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """One ESI operation Hangar Bay calls, and what it depends on inside it."""
+
+    spec_path: str
+    method: str
+    call_path: str
+    caller: str
+    consumed_fields: dict[str, str] = field(default_factory=dict)
+    known_absent_fields: tuple[KnownAbsentField, ...] = ()
+
+    @property
+    def key(self) -> str:
+        """Stable snapshot key: `GET /contracts/public/{region_id}`."""
+        return f"{self.method.upper()} {self.spec_path}"
+
+
+MANIFEST: tuple[Endpoint, ...] = (
+    Endpoint(
+        spec_path="/contracts/public/{region_id}",
+        method="get",
+        call_path="/v1/contracts/public/{region_id}/",
+        caller="core/esi_client_class.py ESIClient.get_public_contracts",
+        consumed_fields={
+            "contract_id": "background_aggregation._build_contract_rows -> Contract.contract_id (primary key)",
+            "issuer_id": "background_aggregation._build_contract_rows -> Contract.issuer_id, and name resolution",
+            "issuer_corporation_id": "background_aggregation._build_contract_rows -> Contract.issuer_corporation_id",
+            "type": "background_aggregation._build_contract_rows -> Contract.type; _fetch_item_rows gates item enrichment on item_exchange/auction",
+            "date_issued": "background_aggregation._build_contract_rows -> Contract.date_issued",
+            "date_expired": "background_aggregation._build_contract_rows -> Contract.date_expired",
+            "start_location_id": "background_aggregation._build_contract_rows -> Contract.start_location_id, and name resolution",
+            "end_location_id": "background_aggregation._build_contract_rows -> Contract.end_location_id",
+            "title": "background_aggregation._build_contract_rows -> Contract.title",
+            "for_corporation": "background_aggregation._build_contract_rows -> Contract.for_corporation",
+            "price": "background_aggregation._build_contract_rows -> Contract.price (sortable, filterable)",
+            "collateral": "background_aggregation._build_contract_rows -> Contract.collateral",
+            "reward": "background_aggregation._build_contract_rows -> Contract.reward",
+            "volume": "background_aggregation._build_contract_rows -> Contract.volume",
+        },
+        known_absent_fields=(
+            KnownAbsentField(
+                name="status",
+                consumer="background_aggregation._build_contract_rows -> Contract.status (non-null column, indexed by ix_contracts_type_status); no longer on the wire",
+                consequence="defaults to the literal 'unknown' on every row, so the column and its index carry one constant value; dropped from ContractSchema in PR #115 and re-fills only when a user's own authenticated contracts are ingested",
+            ),
+            KnownAbsentField(
+                name="date_completed",
+                consumer="background_aggregation._build_contract_rows -> Contract.date_completed; no longer on the wire",
+                consequence="always NULL — a public contract is by definition outstanding; dropped from ContractSchema in PR #115 and re-fills only under authenticated ingestion",
+            ),
+        ),
+    ),
+    Endpoint(
+        spec_path="/contracts/public/items/{contract_id}",
+        method="get",
+        call_path="/v1/contracts/public/items/{contract_id}/",
+        caller="core/esi_client_class.py ESIClient.get_contract_items",
+        consumed_fields={
+            "record_id": "background_aggregation._fetch_item_rows -> ContractItem.record_id (primary key)",
+            "type_id": "background_aggregation._fetch_item_rows -> ContractItem.type_id; drives the /universe/types enrichment fan-out",
+            "quantity": "background_aggregation._fetch_item_rows -> ContractItem.quantity",
+            "is_included": "background_aggregation._fetch_item_rows -> ContractItem.is_included; _enrich_items lets only included items set the ship flag",
+            "is_blueprint_copy": "background_aggregation._fetch_item_rows -> ContractItem.is_blueprint_copy; contract_service._has_blueprint_copy_item backs the is_bpc filter",
+        },
+        known_absent_fields=(
+            KnownAbsentField(
+                name="raw_quantity",
+                consumer="background_aggregation._fetch_item_rows -> ContractItem.raw_quantity; read by the min_runs/max_runs filter in contract_service",
+                consequence="always NULL, so min_runs/max_runs match zero rows — this field is on the AUTHENTICATED character/corporation item routes only (ESI-3)",
+            ),
+            KnownAbsentField(
+                name="is_singleton",
+                consumer="background_aggregation._fetch_item_rows -> ContractItem.is_singleton (non-null column, exposed as ContractItemSchema.is_singleton)",
+                consequence="defaults to False on every row — same authenticated-route confusion as raw_quantity",
+            ),
+        ),
+    ),
+    Endpoint(
+        spec_path="/universe/types/{type_id}",
+        method="get",
+        call_path="/v3/universe/types/{type_id}/",
+        caller="core/esi_client_class.py ESIClient.get_universe_type",
+        consumed_fields={
+            "name": "background_aggregation._enrich_items -> ContractItem.type_name (the searchable ship name)",
+            "group_id": "background_aggregation._enrich_items -> the /universe/groups fan-out that decides the ship flag",
+            "market_group_id": "background_aggregation._enrich_items -> ContractItem.market_group_id",
+        },
+    ),
+    Endpoint(
+        spec_path="/universe/groups/{group_id}",
+        method="get",
+        call_path="/v1/universe/groups/{group_id}/",
+        caller="core/esi_client_class.py ESIClient.get_universe_group",
+        consumed_fields={
+            "category_id": "background_aggregation._enrich_items -> compared against SHIP_CATEGORY_ID; this single field decides whether a contract is a ship contract, which is the product's default view",
+        },
+    ),
+    Endpoint(
+        spec_path="/universe/names",
+        method="post",
+        call_path="/v3/universe/names/",
+        caller="core/esi_client_class.py ESIClient.resolve_ids_to_names",
+        consumed_fields={
+            "id": "esi_client_class.resolve_ids_to_names -> the id->name map key",
+            "name": "esi_client_class.resolve_ids_to_names -> Contract.issuer_name / issuer_corporation_name / start_location_name",
+        },
+    ),
+    Endpoint(
+        spec_path="/universe/ids",
+        method="post",
+        call_path="/v1/universe/ids/",
+        caller="core/esi_client_class.py ESIClient.resolve_names",
+        consumed_fields={
+            "inventory_types": "watchlist_service resolves a watched ship name to a type id through this category; an unmatched name yields 200 with the category absent",
+        },
+    ),
+    Endpoint(
+        spec_path="/universe/stations/{station_id}",
+        method="get",
+        call_path="/v2/universe/stations/{station_id}/",
+        caller="core/esi_client_class.py ESIClient.get_universe_station",
+        consumed_fields={
+            # The whole reason the route is called. ESI's public contract payload
+            # carries a location id and no system id, so without this the system_ids
+            # filter has nothing to match — its disappearance would leave every
+            # start_location_system_id NULL while the ingestion kept reporting success.
+            "system_id": "background_aggregation._resolve_station_systems -> Contract.start_location_system_id, which backs the system_ids filter",
+        },
+    ),
+    Endpoint(
+        spec_path="/universe/regions",
+        method="get",
+        call_path="/v1/universe/regions/",
+        caller="app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        consumed_fields={},
+    ),
+    Endpoint(
+        spec_path="/universe/regions/{region_id}",
+        method="get",
+        call_path="/v1/universe/regions/{region_id}/",
+        caller="app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        consumed_fields={
+            "region_id": "generate-regions.mjs -> the value of each option in src/features/contracts/regions.ts",
+            "name": "generate-regions.mjs -> the label of each option in src/features/contracts/regions.ts",
+        },
+    ),
+)
+
+# Not here, and deliberately: /universe/structures/{structure_id}. Contracts started at
+# player-owned structures keep a NULL system, because that route requires the
+# esi-universe.read_structures.v1 scope and 403s for structures the token's character
+# cannot dock at — there is no tokenless equivalent. If it is ever added, note that it
+# names the field `solar_system_id`, NOT the `system_id` the station route sends. Copying
+# the station entry unchanged would read an absent key, write NULL, and look like it
+# worked — the ESI-3 shape exactly.

--- a/app/backend/tools/esi_spec_monitor/monitor.py
+++ b/app/backend/tools/esi_spec_monitor/monitor.py
@@ -1,0 +1,704 @@
+# ABOUTME: Projects EVE's ESI meta OpenAPI document down to the endpoints and fields Hangar Bay
+# ABOUTME: consumes, diffs that projection against the committed snapshot, and reports what moved.
+"""ESI spec drift monitor.
+
+Run `--check` (the default) to compare the live spec against `snapshot.json`, or
+`--update` to rewrite the snapshot after reviewing what changed. Updating is meant to
+be a deliberate act inside a PR — the same shape as bumping a lockfile — so nothing
+here ever rewrites the snapshot on its own.
+
+**Why a projection and not a whole-spec diff.** The full document is 182 paths and
+changes constantly in areas Hangar Bay never calls; a diff of all of it would be noise,
+and an ignored monitor is worse than none. `manifest.py` names what we depend on, and
+only that is compared.
+
+**Why no live data calls.** The only request made is for the static
+`https://esi.evetech.net/meta/openapi.json` (rate-limit group `meta`, 150/15m), plus
+`/meta/compatibility-dates`. ESI's shared error budget — 100 errors in 60 s buys a
+blanket 420 across every endpoint — must never be spent by a monitor.
+
+**Compatibility dates.** ESI replaced route versioning with the `X-Compatibility-Date`
+header. A request that omits it is served the *oldest* published date, and the meta spec
+answers per date (`Vary: X-Compatibility-Date`, and `info.version` echoes the date
+served). So the snapshot holds two views: `pinned`, the shape our client actually
+receives today, and `newest_compatibility_date`, the shape we would receive if we
+adopted the newest published date. The list of published dates is deliberately NOT
+snapshotted — CCP publishes one every few weeks and almost none of them touch our
+routes, so snapshotting the list would fire the monitor on schedule rather than on news.
+
+Standard library only, on purpose: the scheduled workflow then needs no dependency
+install, and the monitor cannot be broken by an unrelated change to the backend's deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from esi_spec_monitor.manifest import MANIFEST, Endpoint
+
+SPEC_URL = "https://esi.evetech.net/meta/openapi.json"
+COMPATIBILITY_DATES_URL = "https://esi.evetech.net/meta/compatibility-dates"
+SNAPSHOT_PATH = Path(__file__).resolve().parent / "snapshot.json"
+
+# ESI's best practices ask for an agent that identifies the application and a way to
+# reach a human; CCP has publicly named generic agents as an offence.
+USER_AGENT = (
+    "hangar-bay-esi-spec-monitor/1.0 "
+    "(+https://github.com/scarson/hangar-bay; samuel.carson@gmail.com)"
+)
+
+PINNED_VIEW = "pinned"
+NEWEST_VIEW = "newest_compatibility_date"
+
+BREAKING = "breaking"
+INFORMATIONAL = "informational"
+
+# How deep the response-field projection descends. ESI nests at most a couple of
+# levels in the shapes we consume (`/universe/ids` returns category -> [{id, name}]);
+# the cap stops a future recursive schema from exploding the snapshot.
+MAX_FIELD_DEPTH = 4
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One reported difference. `consumer` is what makes it actionable."""
+
+    kind: str
+    severity: str
+    view: str
+    endpoint: str
+    subject: str
+    detail: str
+    consumer: str = ""
+    call_path: str = ""
+
+
+# --- spec projection --------------------------------------------------------
+
+
+def _resolve(spec: dict, node: dict) -> dict:
+    """Follow a local `$ref`. An unresolvable ref raises rather than yielding {}.
+
+    Projecting a broken ref as "this endpoint has no fields" would be
+    indistinguishable from CCP deleting every field on the route.
+    """
+    seen = 0
+    while "$ref" in node:
+        seen += 1
+        if seen > 10:
+            raise ValueError(f"$ref cycle at {node['$ref']}")
+        ref = node["$ref"]
+        if not ref.startswith("#/"):
+            raise KeyError(f"unsupported non-local $ref: {ref}")
+        target: Any = spec
+        for part in ref[2:].split("/"):
+            target = target[part]  # KeyError on a dangling ref, deliberately
+        node = target
+    return node
+
+
+def _describe(node: dict) -> dict:
+    """The comparable scalar description of one schema node."""
+    described: dict[str, Any] = {"type": node.get("type")}
+    if "format" in node:
+        described["format"] = node["format"]
+    if "enum" in node:
+        described["enum"] = sorted(node["enum"])
+    return described
+
+
+def _describe_array(spec: dict, node: dict) -> dict:
+    """An array's description, including its element type when elements are scalars.
+
+    Without this an array of enum strings (a station's `services`) and an array of
+    integers project identically as `{"type": "array"}`, so a change to what the
+    list contains would pass unnoticed. Arrays of objects need no element summary:
+    their properties are projected individually as `name[].property`.
+    """
+    described = _describe(node)
+    items = _resolve(spec, node.get("items") or {})
+    if items and not items.get("properties"):
+        described["items"] = _describe(items)
+    return described
+
+
+def _flatten_fields(spec: dict, node: dict, prefix: str, out: dict, depth: int) -> None:
+    """Walk a response schema into flat `name` / `parent.child` / `[].name` keys."""
+    if depth > MAX_FIELD_DEPTH:
+        return
+    node = _resolve(spec, node)
+    if node.get("type") == "array":
+        items = node.get("items")
+        if items is not None:
+            _flatten_fields(spec, items, f"{prefix}[].", out, depth + 1)
+        return
+    required = set(node.get("required", []))
+    for name, raw in sorted(node.get("properties", {}).items()):
+        child = _resolve(spec, raw)
+        key = f"{prefix}{name}"
+        summary = _describe_array(spec, child) if child.get("type") == "array" else _describe(child)
+        out[key] = {**summary, "required": name in required}
+        if child.get("type") in ("object", "array"):
+            separator = "" if child.get("type") == "array" else "."
+            _flatten_fields(spec, child, f"{key}{separator}", out, depth + 1)
+
+
+def _response_fields(spec: dict, operation: dict) -> dict:
+    """Flatten the 200 response's JSON body. A 200 without a body projects as {}."""
+    schema = (
+        operation.get("responses", {})
+        .get("200", {})
+        .get("content", {})
+        .get("application/json", {})
+        .get("schema")
+    )
+    if not schema:
+        return {}
+    out: dict[str, dict] = {}
+    _flatten_fields(spec, schema, "", out, 0)
+    return out
+
+
+def _parameters(spec: dict, operation: dict) -> dict:
+    """Project parameters keyed `in:name`, resolving the shared `$ref` ones.
+
+    The shared parameters are not boilerplate to us: `If-None-Match` is what the
+    ETag-conditional fetch in `ESIClient.get_esi_data_with_etag_caching` rides on.
+    """
+    out: dict[str, dict] = {}
+    for raw in operation.get("parameters", []):
+        param = _resolve(spec, raw)
+        key = f"{param.get('in')}:{param.get('name')}"
+        described = _describe(_resolve(spec, param.get("schema", {})))
+        if param.get("name") == "X-Compatibility-Date":
+            # Its enum echoes whichever date this copy of the spec was served for, so
+            # keeping it would make the snapshot restate the served date on every
+            # operation — the monitor would then fire each time CCP publishes a new
+            # date, which is a calendar event, not drift in a route we consume. The
+            # served date is snapshotted once, at the top level.
+            described.pop("enum", None)
+        out[key] = {**described, "required": bool(param.get("required", False))}
+    # One of three redundant layers holding "a cosmetic reshuffle by CCP must not
+    # produce a snapshot diff", alongside the property sort in `_flatten_fields` and
+    # `sort_keys` in `serialize`. Any one suffices, so
+    # test_projection_is_stable_across_key_ordering goes red only if all three go.
+    return dict(sorted(out.items()))
+
+
+def _security(spec: dict, operation: dict) -> list:
+    """Normalize the auth requirement. `[]` means the route is public.
+
+    An operation without its own `security` inherits the document's, which for ESI
+    is absent entirely — so absent means public here, but the fallback is explicit
+    rather than assumed, because a document-level `security` appearing is exactly
+    the silent break this monitor exists to catch.
+    """
+    requirements = operation.get("security", spec.get("security", []))
+    return sorted(
+        [scheme, sorted(scopes)]
+        for requirement in requirements
+        for scheme, scopes in requirement.items()
+    )
+
+
+def _request_body(spec: dict, operation: dict) -> dict | None:
+    body = operation.get("requestBody")
+    if body is None:
+        return None
+    schema = body.get("content", {}).get("application/json", {}).get("schema", {})
+    return {
+        "required": bool(body.get("required", False)),
+        "schema": _resolve(spec, schema),
+    }
+
+
+def _normalize(names: Iterable[str]) -> set[str]:
+    """Field keys with any leading array marker stripped, for manifest lookups.
+
+    A manifest naming `contract_id` should match the projected `[].contract_id`
+    of a list-returning route; making authors write `[].contract_id` would trade
+    a readable dependency document for a mechanical detail.
+    """
+    normalized = set()
+    for name in names:
+        normalized.add(name)
+        if name.startswith("[]."):
+            normalized.add(name[3:])
+    return normalized
+
+
+def _project_endpoint(spec: dict, endpoint: Endpoint) -> dict:
+    operation = spec.get("paths", {}).get(endpoint.spec_path, {}).get(endpoint.method)
+    if operation is None:
+        return {"present": False}
+
+    fields = _response_fields(spec, operation)
+    available = _normalize(fields)
+    known_absent = {a.name: a for a in endpoint.known_absent_fields}
+
+    return {
+        "present": True,
+        "call_path": endpoint.call_path,
+        "caller": endpoint.caller,
+        "operation_id": operation.get("operationId"),
+        "security": _security(spec, operation),
+        "server_cache_mode": operation.get("x-server-cache-mode"),
+        "operation_compatibility_date": operation.get("x-compatibility-date"),
+        "parameters": _parameters(spec, operation),
+        "request_body": _request_body(spec, operation),
+        "response_statuses": sorted(operation.get("responses", {})),
+        "response_fields": fields,
+        "consumers": dict(sorted(endpoint.consumed_fields.items())),
+        "known_absent_fields": {
+            name: {"consumer": a.consumer, "consequence": a.consequence}
+            for name, a in sorted(known_absent.items())
+        },
+        "consumed_fields_absent_from_spec": sorted(
+            name for name in endpoint.consumed_fields if name not in available
+        ),
+        "known_absent_fields_now_present": sorted(
+            name for name in known_absent if name in available
+        ),
+    }
+
+
+def project(spec: dict, manifest: Sequence[Endpoint] = MANIFEST) -> dict:
+    """Reduce the whole spec to just what Hangar Bay depends on."""
+    return {endpoint.key: _project_endpoint(spec, endpoint) for endpoint in manifest}
+
+
+def build_snapshot(
+    pinned_spec: dict,
+    newest_spec: dict,
+    manifest: Sequence[Endpoint] = MANIFEST,
+) -> dict:
+    """Assemble the committed document from the two compatibility-date views."""
+    return {
+        "readme": (
+            "Committed projection of https://esi.evetech.net/meta/openapi.json, "
+            "narrowed to the endpoints and fields Hangar Bay consumes. Regenerate "
+            "with `pdm run esi-spec-monitor --update` and review the diff; never "
+            "update it to silence a failure you have not understood."
+        ),
+        "spec_url": SPEC_URL,
+        "pinned_compatibility_date": pinned_spec.get("info", {}).get("version"),
+        "views": {
+            PINNED_VIEW: project(pinned_spec, manifest),
+            NEWEST_VIEW: project(newest_spec, manifest),
+        },
+    }
+
+
+# --- comparison -------------------------------------------------------------
+
+
+@dataclass
+class _Context:
+    """Everything a per-endpoint diff needs to describe what it found."""
+
+    view: str
+    endpoint: str
+    old: dict
+    new: dict
+    findings: list = field(default_factory=list)
+
+    @property
+    def call_path(self) -> str:
+        return self.old.get("call_path") or self.new.get("call_path") or ""
+
+    def consumer_for(self, subject: str) -> str:
+        consumers = self.new.get("consumers") or self.old.get("consumers") or {}
+        name = subject[3:] if subject.startswith("[].") else subject
+        return consumers.get(subject) or consumers.get(name) or ""
+
+    def add(self, kind: str, severity: str, subject: str, detail: str, consumer: str = "") -> None:
+        self.findings.append(
+            Finding(
+                kind=kind,
+                # Nothing at the newest published date is breaking yet: it is not the
+                # shape our client receives. It becomes breaking when ESI raises the
+                # floor a header-less request is served, which the pinned view catches.
+                severity=INFORMATIONAL if self.view == NEWEST_VIEW else severity,
+                view=self.view,
+                endpoint=self.endpoint,
+                subject=subject,
+                detail=detail,
+                consumer=consumer or self.consumer_for(subject),
+                call_path=self.call_path,
+            )
+        )
+
+
+def _severity(ctx: _Context, subject: str, when_consumed: str) -> str:
+    """A change to a field we read is breaking; the same change elsewhere is news."""
+    return when_consumed if ctx.consumer_for(subject) else INFORMATIONAL
+
+
+def _diff_scalars(ctx: _Context) -> None:
+    """Operation-level attributes that are single values."""
+    checks = (
+        ("security", "AUTH_CHANGED", BREAKING),
+        ("operation_id", "OPERATION_ID_CHANGED", INFORMATIONAL),
+        # ESI is converting routes from clock expiry to event-driven invalidation
+        # (ESI-2). A conversion does not break the client — it reads Cache-Control
+        # first — but it removes the signal any Expires-derived scheduling rests on,
+        # so it needs a decision rather than a note.
+        ("server_cache_mode", "CACHE_MODE_CHANGED", BREAKING),
+        (
+            "operation_compatibility_date",
+            "OPERATION_COMPATIBILITY_DATE_CHANGED",
+            INFORMATIONAL,
+        ),
+        ("request_body", "REQUEST_BODY_CHANGED", BREAKING),
+    )
+    for key, kind, severity in checks:
+        before, after = ctx.old.get(key), ctx.new.get(key)
+        if before != after:
+            ctx.add(kind, severity, key, f"{json.dumps(before)} -> {json.dumps(after)}")
+
+
+def _diff_keyed(
+    ctx: _Context,
+    key: str,
+    kinds: tuple[str, str],
+    on_common: Callable[[_Context, str, dict, dict], None],
+    added_severity: str = INFORMATIONAL,
+    removed_severity: str | None = BREAKING,
+) -> None:
+    """Diff a name -> descriptor mapping (response fields, or parameters).
+
+    `removed_severity=None` means "breaking only if we consume this name" — right
+    for response fields, where ESI dropping something we never read is news rather
+    than a break. Parameters pass a fixed BREAKING instead: they are not in the
+    consumer map at all, and losing one (If-None-Match, say) breaks the client
+    regardless of which response fields it happens to read.
+    """
+    before, after = ctx.old.get(key, {}), ctx.new.get(key, {})
+    added_kind, removed_kind = kinds
+    for name in sorted(set(after) - set(before)):
+        ctx.add(added_kind, added_severity, name, f"added as {json.dumps(after[name])}")
+    for name in sorted(set(before) - set(after)):
+        severity = removed_severity or _severity(ctx, name, BREAKING)
+        ctx.add(removed_kind, severity, name, f"was {json.dumps(before[name])}")
+    for name in sorted(set(before) & set(after)):
+        on_common(ctx, name, before[name], after[name])
+
+
+def _items_note(descriptor: dict) -> str:
+    items = descriptor.get("items")
+    return f" of {items.get('type')}" if items else ""
+
+
+def _shape_of(descriptor: dict) -> tuple:
+    """Everything about a field except whether it is required and its enum members."""
+    return (
+        descriptor.get("type"),
+        descriptor.get("format"),
+        json.dumps(descriptor.get("items"), sort_keys=True),
+    )
+
+
+def _diff_field_shape(ctx: _Context, name: str, before: dict, after: dict) -> None:
+    if _shape_of(before) != _shape_of(after):
+        ctx.add(
+            "FIELD_TYPE_CHANGED",
+            _severity(ctx, name, BREAKING),
+            name,
+            f"{before.get('type')}/{before.get('format')}"
+            f"{_items_note(before)} -> {after.get('type')}/{after.get('format')}"
+            f"{_items_note(after)}",
+        )
+    if before.get("enum") != after.get("enum"):
+        # We branch on enum values (`type` gates item enrichment to
+        # item_exchange/auction), so a new member falls through silently.
+        ctx.add(
+            "FIELD_ENUM_CHANGED",
+            _severity(ctx, name, BREAKING),
+            name,
+            f"{json.dumps(before.get('enum'))} -> {json.dumps(after.get('enum'))}",
+        )
+    if before.get("required") != after.get("required"):
+        became_required = bool(after.get("required"))
+        ctx.add(
+            "FIELD_BECAME_REQUIRED" if became_required else "FIELD_BECAME_OPTIONAL",
+            INFORMATIONAL if became_required else _severity(ctx, name, BREAKING),
+            name,
+            f"required {before.get('required')} -> {after.get('required')}",
+        )
+
+
+def _diff_parameter_shape(ctx: _Context, name: str, before: dict, after: dict) -> None:
+    if before != after:
+        ctx.add(
+            "PARAMETER_CHANGED",
+            BREAKING,
+            name,
+            f"{json.dumps(before)} -> {json.dumps(after)}",
+        )
+
+
+def _relabel_known_absent_arrivals(ctx: _Context) -> None:
+    """A declared-absent field arriving is its own headline, not a generic addition.
+
+    These are the ESI-3 traps: fields our code reads that the public routes have
+    never carried. If one shows up, the filter it powers becomes implementable —
+    which is the actionable news, so it must not read as routine churn.
+    """
+    known_absent = ctx.new.get("known_absent_fields") or {}
+    if not known_absent:
+        return
+    for index, finding in enumerate(ctx.findings):
+        if finding.kind != "FIELD_ADDED":
+            continue
+        name = finding.subject[3:] if finding.subject.startswith("[].") else finding.subject
+        record = known_absent.get(name)
+        if record is None:
+            continue
+        ctx.findings[index] = Finding(
+            kind="KNOWN_ABSENT_FIELD_APPEARED",
+            severity=INFORMATIONAL,
+            view=ctx.view,
+            endpoint=ctx.endpoint,
+            subject=name,
+            detail=f"{finding.detail}; previously undocumented on this route",
+            consumer=f"{record['consumer']} — today: {record['consequence']}",
+            call_path=ctx.call_path,
+        )
+
+
+def _diff_manifest_consistency(ctx: _Context) -> None:
+    """Report manifest/spec disagreements that the field diff did not already explain.
+
+    A consumed field can go missing because the spec dropped it (already reported as
+    FIELD_REMOVED) or because someone added a name to the manifest that ESI never
+    documented. Only the second needs its own finding.
+    """
+    explained = {f.subject for f in ctx.findings} | {
+        f.subject[3:] for f in ctx.findings if f.subject.startswith("[].")
+    }
+    before = set(ctx.old.get("consumed_fields_absent_from_spec", []))
+    after = set(ctx.new.get("consumed_fields_absent_from_spec", []))
+    for name in sorted(after - before - explained):
+        ctx.add(
+            "MANIFEST_FIELD_UNDOCUMENTED",
+            BREAKING,
+            name,
+            "listed in the manifest as consumed, but absent from the spec",
+        )
+    for name in sorted(before - after - explained):
+        ctx.add(
+            "MANIFEST_FIELD_DOCUMENTED",
+            INFORMATIONAL,
+            name,
+            "consumed field is documented again",
+        )
+
+    # The mirror case: a known-absent declaration that the spec contradicts. When the
+    # spec starts carrying the field, `_relabel_known_absent_arrivals` has already
+    # said so; anything left over is a manifest that claims a field is undocumented
+    # when it is documented — the monitor understating its own coverage.
+    stale = set(ctx.new.get("known_absent_fields_now_present", [])) - set(
+        ctx.old.get("known_absent_fields_now_present", [])
+    )
+    for name in sorted(stale - explained):
+        ctx.add(
+            "KNOWN_ABSENT_DECLARATION_STALE",
+            BREAKING,
+            name,
+            "declared known-absent in the manifest, but the spec documents it",
+        )
+
+
+def _diff_endpoint(view: str, key: str, old: dict, new: dict) -> list[Finding]:
+    ctx = _Context(view=view, endpoint=key, old=old, new=new)
+
+    if old.get("present") and not new.get("present"):
+        ctx.add(
+            "ENDPOINT_MISSING",
+            BREAKING,
+            key,
+            f"{old.get('call_path', key)} is gone from the spec; called by "
+            f"{old.get('caller', 'unknown caller')}",
+        )
+        return ctx.findings
+    if not old.get("present") and new.get("present"):
+        ctx.add("ENDPOINT_RESTORED", INFORMATIONAL, key, f"{new.get('call_path', key)} is back")
+        return ctx.findings
+    if not old.get("present") and not new.get("present"):
+        return ctx.findings
+
+    _diff_scalars(ctx)
+    _diff_keyed(ctx, "response_fields", ("FIELD_ADDED", "FIELD_REMOVED"), _diff_field_shape,
+                removed_severity=None)
+    _diff_keyed(ctx, "parameters", ("PARAMETER_ADDED", "PARAMETER_REMOVED"),
+                _diff_parameter_shape)
+    _diff_status_codes(ctx)
+    _relabel_known_absent_arrivals(ctx)
+    _diff_manifest_consistency(ctx)
+    return ctx.findings
+
+
+def _diff_status_codes(ctx: _Context) -> None:
+    before = set(ctx.old.get("response_statuses", []))
+    after = set(ctx.new.get("response_statuses", []))
+    for code in sorted(after - before):
+        ctx.add("RESPONSE_STATUS_ADDED", INFORMATIONAL, code, f"new response status {code}")
+    for code in sorted(before - after):
+        ctx.add("RESPONSE_STATUS_REMOVED", BREAKING, code, f"response status {code} is gone")
+
+
+def compare_snapshots(old: dict, new: dict) -> list[Finding]:
+    """Every difference between two snapshots, breaking findings first."""
+    findings: list[Finding] = []
+
+    before_date = old.get("pinned_compatibility_date")
+    after_date = new.get("pinned_compatibility_date")
+    if before_date != after_date:
+        findings.append(
+            Finding(
+                kind="PINNED_COMPATIBILITY_DATE_CHANGED",
+                severity=BREAKING,
+                view=PINNED_VIEW,
+                endpoint="(spec)",
+                subject="info.version",
+                detail=(
+                    f"{before_date} -> {after_date}: a request that omits "
+                    "X-Compatibility-Date is served this date, so the floor our client "
+                    "is pinned to has moved"
+                ),
+            )
+        )
+
+    for view in (PINNED_VIEW, NEWEST_VIEW):
+        old_view = old.get("views", {}).get(view, {})
+        new_view = new.get("views", {}).get(view, {})
+        for key in sorted(set(old_view) | set(new_view)):
+            findings.extend(
+                _diff_endpoint(view, key, old_view.get(key, {}), new_view.get(key, {}))
+            )
+
+    findings.sort(key=lambda f: (f.severity != BREAKING, f.view != PINNED_VIEW, f.endpoint, f.subject))
+    return findings
+
+
+def format_report(findings: Sequence[Finding]) -> str:
+    """A message that names the endpoint, the field, what moved, and who reads it."""
+    if not findings:
+        return "ESI spec monitor: no drift — the committed snapshot still matches the live spec."
+
+    breaking = [f for f in findings if f.severity == BREAKING]
+    lines = [
+        f"ESI spec monitor: {len(findings)} change(s) against the committed snapshot "
+        f"({len(breaking)} breaking).",
+        "",
+    ]
+    for finding in findings:
+        marker = "BREAKING" if finding.severity == BREAKING else "note    "
+        where = finding.call_path or finding.endpoint
+        lines.append(f"[{marker}] {finding.kind} — {where}")
+        lines.append(f"           field: {finding.subject}")
+        lines.append(f"           change: {finding.detail}")
+        if finding.consumer:
+            lines.append(f"           consumed by: {finding.consumer}")
+        if finding.view == NEWEST_VIEW:
+            lines.append(
+                "           (seen only at the newest published compatibility date — "
+                "not what our client receives today)"
+            )
+        lines.append("")
+    lines.append(
+        "If these changes are understood and accepted, re-run with --update and commit "
+        "the snapshot in a PR that says why."
+    )
+    return "\n".join(lines)
+
+
+# --- fetching ---------------------------------------------------------------
+
+
+def _get_json(url: str, compatibility_date: str | None = None, timeout: float = 30.0) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    if compatibility_date:
+        request.add_header("X-Compatibility-Date", compatibility_date)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_specs(get_json: Callable[..., dict] = _get_json) -> tuple[dict, dict, str]:
+    """The pinned spec, the newest-compatibility-date spec, and that newest date.
+
+    Three requests to static meta documents, no data endpoints, so ESI's shared
+    error budget is untouched.
+    """
+    pinned = get_json(SPEC_URL)
+    dates = get_json(COMPATIBILITY_DATES_URL).get("compatibility_dates", [])
+    if not dates:
+        raise ValueError(f"{COMPATIBILITY_DATES_URL} listed no compatibility dates")
+    newest = max(dates)
+    return pinned, get_json(SPEC_URL, compatibility_date=newest), newest
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def serialize(snapshot: dict) -> str:
+    """The exact bytes committed to snapshot.json.
+
+    `sort_keys` is what makes the committed file a stable artifact: without it the
+    file would re-order whenever ESI re-ordered anything in its own document, and a
+    reviewer would face a large diff that means nothing.
+    """
+    return json.dumps(snapshot, indent=2, sort_keys=True) + "\n"
+
+
+def _write_snapshot(snapshot: dict, path: Path) -> None:
+    path.write_text(serialize(snapshot), encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite the committed snapshot from the live spec (review the diff!)",
+    )
+    parser.add_argument("--snapshot", type=Path, default=SNAPSHOT_PATH)
+    args = parser.parse_args(argv)
+
+    try:
+        pinned_spec, newest_spec, newest_date = fetch_specs()
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError) as exc:
+        # An unreachable ESI is not drift. Say so distinctly so nobody reads a
+        # network blip as a schema change and "fixes" it by updating the snapshot.
+        print(f"ESI spec monitor: could not retrieve the spec — {type(exc).__name__}: {exc}",
+              file=sys.stderr)
+        return 2
+
+    current = build_snapshot(pinned_spec, newest_spec)
+    print(f"newest published compatibility date: {newest_date}")
+    print(f"date served without the header:      {current['pinned_compatibility_date']}")
+
+    if args.update:
+        _write_snapshot(current, args.snapshot)
+        print(f"snapshot written to {args.snapshot}")
+        return 0
+
+    if not args.snapshot.exists():
+        print(f"no snapshot at {args.snapshot}; run with --update to create it", file=sys.stderr)
+        return 2
+
+    committed = json.loads(args.snapshot.read_text(encoding="utf-8"))
+    findings = compare_snapshots(committed, current)
+    print(format_report(findings))
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/backend/tools/esi_spec_monitor/snapshot.json
+++ b/app/backend/tools/esi_spec_monitor/snapshot.json
@@ -1,0 +1,2259 @@
+{
+  "pinned_compatibility_date": "2020-01-01",
+  "readme": "Committed projection of https://esi.evetech.net/meta/openapi.json, narrowed to the endpoints and fields Hangar Bay consumes. Regenerate with `pdm run esi-spec-monitor --update` and review the diff; never update it to silence a failure you have not understood.",
+  "spec_url": "https://esi.evetech.net/meta/openapi.json",
+  "views": {
+    "newest_compatibility_date": {
+      "GET /contracts/public/items/{contract_id}": {
+        "call_path": "/v1/contracts/public/items/{contract_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_contract_items",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "is_blueprint_copy": "background_aggregation._fetch_item_rows -> ContractItem.is_blueprint_copy; contract_service._has_blueprint_copy_item backs the is_bpc filter",
+          "is_included": "background_aggregation._fetch_item_rows -> ContractItem.is_included; _enrich_items lets only included items set the ship flag",
+          "quantity": "background_aggregation._fetch_item_rows -> ContractItem.quantity",
+          "record_id": "background_aggregation._fetch_item_rows -> ContractItem.record_id (primary key)",
+          "type_id": "background_aggregation._fetch_item_rows -> ContractItem.type_id; drives the /universe/types enrichment fan-out"
+        },
+        "known_absent_fields": {
+          "is_singleton": {
+            "consequence": "defaults to False on every row \u2014 same authenticated-route confusion as raw_quantity",
+            "consumer": "background_aggregation._fetch_item_rows -> ContractItem.is_singleton (non-null column, exposed as ContractItemSchema.is_singleton)"
+          },
+          "raw_quantity": {
+            "consequence": "always NULL, so min_runs/max_runs match zero rows \u2014 this field is on the AUTHENTICATED character/corporation item routes only (ESI-3)",
+            "consumer": "background_aggregation._fetch_item_rows -> ContractItem.raw_quantity; read by the min_runs/max_runs filter in contract_service"
+          }
+        },
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetContractsPublicItemsContractId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:contract_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "query:page": {
+            "format": "int32",
+            "required": false,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "[].is_blueprint_copy": {
+            "required": false,
+            "type": "boolean"
+          },
+          "[].is_included": {
+            "required": true,
+            "type": "boolean"
+          },
+          "[].item_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].material_efficiency": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].quantity": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].record_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].runs": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].time_efficiency": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "204"
+        ],
+        "security": [],
+        "server_cache_mode": "ttl-based"
+      },
+      "GET /contracts/public/{region_id}": {
+        "call_path": "/v1/contracts/public/{region_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_public_contracts",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "collateral": "background_aggregation._build_contract_rows -> Contract.collateral",
+          "contract_id": "background_aggregation._build_contract_rows -> Contract.contract_id (primary key)",
+          "date_expired": "background_aggregation._build_contract_rows -> Contract.date_expired",
+          "date_issued": "background_aggregation._build_contract_rows -> Contract.date_issued",
+          "end_location_id": "background_aggregation._build_contract_rows -> Contract.end_location_id",
+          "for_corporation": "background_aggregation._build_contract_rows -> Contract.for_corporation",
+          "issuer_corporation_id": "background_aggregation._build_contract_rows -> Contract.issuer_corporation_id",
+          "issuer_id": "background_aggregation._build_contract_rows -> Contract.issuer_id, and name resolution",
+          "price": "background_aggregation._build_contract_rows -> Contract.price (sortable, filterable)",
+          "reward": "background_aggregation._build_contract_rows -> Contract.reward",
+          "start_location_id": "background_aggregation._build_contract_rows -> Contract.start_location_id, and name resolution",
+          "title": "background_aggregation._build_contract_rows -> Contract.title",
+          "type": "background_aggregation._build_contract_rows -> Contract.type; _fetch_item_rows gates item enrichment on item_exchange/auction",
+          "volume": "background_aggregation._build_contract_rows -> Contract.volume"
+        },
+        "known_absent_fields": {
+          "date_completed": {
+            "consequence": "always NULL \u2014 a public contract is by definition outstanding; dropped from ContractSchema in PR #115 and re-fills only under authenticated ingestion",
+            "consumer": "background_aggregation._build_contract_rows -> Contract.date_completed; no longer on the wire"
+          },
+          "status": {
+            "consequence": "defaults to the literal 'unknown' on every row, so the column and its index carry one constant value; dropped from ContractSchema in PR #115 and re-fills only when a user's own authenticated contracts are ingested",
+            "consumer": "background_aggregation._build_contract_rows -> Contract.status (non-null column, indexed by ix_contracts_type_status); no longer on the wire"
+          }
+        },
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetContractsPublicRegionId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "query:page": {
+            "format": "int32",
+            "required": false,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "[].buyout": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].collateral": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].contract_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].date_expired": {
+            "format": "date-time",
+            "required": true,
+            "type": "string"
+          },
+          "[].date_issued": {
+            "format": "date-time",
+            "required": true,
+            "type": "string"
+          },
+          "[].days_to_complete": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].end_location_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].for_corporation": {
+            "required": false,
+            "type": "boolean"
+          },
+          "[].issuer_corporation_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].issuer_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].price": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].reward": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].start_location_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].title": {
+            "required": false,
+            "type": "string"
+          },
+          "[].type": {
+            "enum": [
+              "auction",
+              "courier",
+              "item_exchange",
+              "loan",
+              "unknown"
+            ],
+            "required": true,
+            "type": "string"
+          },
+          "[].volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": "ttl-based"
+      },
+      "GET /universe/groups/{group_id}": {
+        "call_path": "/v1/universe/groups/{group_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_group",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "category_id": "background_aggregation._enrich_items -> compared against SHIP_CATEGORY_ID; this single field decides whether a contract is a ship contract, which is the product's default view"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseGroupsGroupId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "category_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "published": {
+            "required": true,
+            "type": "boolean"
+          },
+          "types": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "required": true,
+            "type": "array"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/regions": {
+        "call_path": "/v1/universe/regions/",
+        "caller": "app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {},
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseRegions",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {},
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/regions/{region_id}": {
+        "call_path": "/v1/universe/regions/{region_id}/",
+        "caller": "app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "name": "generate-regions.mjs -> the label of each option in src/features/contracts/regions.ts",
+          "region_id": "generate-regions.mjs -> the value of each option in src/features/contracts/regions.ts"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseRegionsRegionId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "constellations": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "required": true,
+            "type": "array"
+          },
+          "description": {
+            "required": false,
+            "type": "string"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/stations/{station_id}": {
+        "call_path": "/v2/universe/stations/{station_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_station",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "system_id": "background_aggregation._resolve_station_systems -> Contract.start_location_system_id, which backs the system_ids filter"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseStationsStationId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:station_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "max_dockable_ship_volume": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "office_rental_cost": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "owner": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "position": {
+            "required": true,
+            "type": "object"
+          },
+          "position.x": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "position.y": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "position.z": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "race_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "reprocessing_efficiency": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "reprocessing_stations_take": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "services": {
+            "items": {
+              "enum": [
+                "assasination-missions",
+                "black-market",
+                "bounty-missions",
+                "cloning",
+                "courier-missions",
+                "dna-therapy",
+                "docking",
+                "factory",
+                "fitting",
+                "gambling",
+                "insurance",
+                "interbus",
+                "jump-clone-facility",
+                "labratory",
+                "loyalty-point-store",
+                "market",
+                "navy-offices",
+                "news",
+                "office-rental",
+                "paintshop",
+                "refinery",
+                "repair-facilities",
+                "reprocessing-plant",
+                "security-offices",
+                "stock-exchange",
+                "storage",
+                "surgery"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "type": "array"
+          },
+          "station_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "system_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/types/{type_id}": {
+        "call_path": "/v3/universe/types/{type_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_type",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "group_id": "background_aggregation._enrich_items -> the /universe/groups fan-out that decides the ship flag",
+          "market_group_id": "background_aggregation._enrich_items -> ContractItem.market_group_id",
+          "name": "background_aggregation._enrich_items -> ContractItem.type_name (the searchable ship name)"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseTypesTypeId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "capacity": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "description": {
+            "required": true,
+            "type": "string"
+          },
+          "dogma_attributes": {
+            "required": false,
+            "type": "array"
+          },
+          "dogma_attributes[].attribute_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "dogma_attributes[].value": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "dogma_effects": {
+            "required": false,
+            "type": "array"
+          },
+          "dogma_effects[].effect_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "dogma_effects[].is_default": {
+            "required": true,
+            "type": "boolean"
+          },
+          "graphic_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "icon_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "market_group_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "mass": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "packaged_volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "portion_size": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "published": {
+            "required": true,
+            "type": "boolean"
+          },
+          "radius": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "POST /universe/ids": {
+        "call_path": "/v1/universe/ids/",
+        "caller": "core/esi_client_class.py ESIClient.resolve_names",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "inventory_types": "watchlist_service resolves a watched ship name to a type id through this category; an unmatched name yields 200 with the category absent"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "PostUniverseIds",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": {
+          "required": true,
+          "schema": {
+            "items": {
+              "description": "name string",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "response_fields": {
+          "agents": {
+            "required": false,
+            "type": "array"
+          },
+          "agents[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "agents[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "alliances": {
+            "required": false,
+            "type": "array"
+          },
+          "alliances[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "alliances[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "characters": {
+            "required": false,
+            "type": "array"
+          },
+          "characters[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "characters[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "constellations": {
+            "required": false,
+            "type": "array"
+          },
+          "constellations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "constellations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "corporations": {
+            "required": false,
+            "type": "array"
+          },
+          "corporations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "corporations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "factions": {
+            "required": false,
+            "type": "array"
+          },
+          "factions[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "factions[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "inventory_types": {
+            "required": false,
+            "type": "array"
+          },
+          "inventory_types[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "inventory_types[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "regions": {
+            "required": false,
+            "type": "array"
+          },
+          "regions[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "regions[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "stations": {
+            "required": false,
+            "type": "array"
+          },
+          "stations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "stations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "systems": {
+            "required": false,
+            "type": "array"
+          },
+          "systems[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "systems[].name": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "POST /universe/names": {
+        "call_path": "/v3/universe/names/",
+        "caller": "core/esi_client_class.py ESIClient.resolve_ids_to_names",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "id": "esi_client_class.resolve_ids_to_names -> the id->name map key",
+          "name": "esi_client_class.resolve_ids_to_names -> Contract.issuer_name / issuer_corporation_name / start_location_name"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "PostUniverseNames",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": {
+          "required": true,
+          "schema": {
+            "items": {
+              "description": "id integer",
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxItems": 1000,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "response_fields": {
+          "[].category": {
+            "enum": [
+              "alliance",
+              "character",
+              "constellation",
+              "corporation",
+              "faction",
+              "inventory_type",
+              "region",
+              "solar_system",
+              "station"
+            ],
+            "required": true,
+            "type": "string"
+          },
+          "[].id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].name": {
+            "required": true,
+            "type": "string"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      }
+    },
+    "pinned": {
+      "GET /contracts/public/items/{contract_id}": {
+        "call_path": "/v1/contracts/public/items/{contract_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_contract_items",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "is_blueprint_copy": "background_aggregation._fetch_item_rows -> ContractItem.is_blueprint_copy; contract_service._has_blueprint_copy_item backs the is_bpc filter",
+          "is_included": "background_aggregation._fetch_item_rows -> ContractItem.is_included; _enrich_items lets only included items set the ship flag",
+          "quantity": "background_aggregation._fetch_item_rows -> ContractItem.quantity",
+          "record_id": "background_aggregation._fetch_item_rows -> ContractItem.record_id (primary key)",
+          "type_id": "background_aggregation._fetch_item_rows -> ContractItem.type_id; drives the /universe/types enrichment fan-out"
+        },
+        "known_absent_fields": {
+          "is_singleton": {
+            "consequence": "defaults to False on every row \u2014 same authenticated-route confusion as raw_quantity",
+            "consumer": "background_aggregation._fetch_item_rows -> ContractItem.is_singleton (non-null column, exposed as ContractItemSchema.is_singleton)"
+          },
+          "raw_quantity": {
+            "consequence": "always NULL, so min_runs/max_runs match zero rows \u2014 this field is on the AUTHENTICATED character/corporation item routes only (ESI-3)",
+            "consumer": "background_aggregation._fetch_item_rows -> ContractItem.raw_quantity; read by the min_runs/max_runs filter in contract_service"
+          }
+        },
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetContractsPublicItemsContractId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:contract_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "query:page": {
+            "format": "int32",
+            "required": false,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "[].is_blueprint_copy": {
+            "required": false,
+            "type": "boolean"
+          },
+          "[].is_included": {
+            "required": true,
+            "type": "boolean"
+          },
+          "[].item_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].material_efficiency": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].quantity": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].record_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].runs": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].time_efficiency": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "204"
+        ],
+        "security": [],
+        "server_cache_mode": "ttl-based"
+      },
+      "GET /contracts/public/{region_id}": {
+        "call_path": "/v1/contracts/public/{region_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_public_contracts",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "collateral": "background_aggregation._build_contract_rows -> Contract.collateral",
+          "contract_id": "background_aggregation._build_contract_rows -> Contract.contract_id (primary key)",
+          "date_expired": "background_aggregation._build_contract_rows -> Contract.date_expired",
+          "date_issued": "background_aggregation._build_contract_rows -> Contract.date_issued",
+          "end_location_id": "background_aggregation._build_contract_rows -> Contract.end_location_id",
+          "for_corporation": "background_aggregation._build_contract_rows -> Contract.for_corporation",
+          "issuer_corporation_id": "background_aggregation._build_contract_rows -> Contract.issuer_corporation_id",
+          "issuer_id": "background_aggregation._build_contract_rows -> Contract.issuer_id, and name resolution",
+          "price": "background_aggregation._build_contract_rows -> Contract.price (sortable, filterable)",
+          "reward": "background_aggregation._build_contract_rows -> Contract.reward",
+          "start_location_id": "background_aggregation._build_contract_rows -> Contract.start_location_id, and name resolution",
+          "title": "background_aggregation._build_contract_rows -> Contract.title",
+          "type": "background_aggregation._build_contract_rows -> Contract.type; _fetch_item_rows gates item enrichment on item_exchange/auction",
+          "volume": "background_aggregation._build_contract_rows -> Contract.volume"
+        },
+        "known_absent_fields": {
+          "date_completed": {
+            "consequence": "always NULL \u2014 a public contract is by definition outstanding; dropped from ContractSchema in PR #115 and re-fills only under authenticated ingestion",
+            "consumer": "background_aggregation._build_contract_rows -> Contract.date_completed; no longer on the wire"
+          },
+          "status": {
+            "consequence": "defaults to the literal 'unknown' on every row, so the column and its index carry one constant value; dropped from ContractSchema in PR #115 and re-fills only when a user's own authenticated contracts are ingested",
+            "consumer": "background_aggregation._build_contract_rows -> Contract.status (non-null column, indexed by ix_contracts_type_status); no longer on the wire"
+          }
+        },
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetContractsPublicRegionId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "query:page": {
+            "format": "int32",
+            "required": false,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "[].buyout": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].collateral": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].contract_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].date_expired": {
+            "format": "date-time",
+            "required": true,
+            "type": "string"
+          },
+          "[].date_issued": {
+            "format": "date-time",
+            "required": true,
+            "type": "string"
+          },
+          "[].days_to_complete": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].end_location_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].for_corporation": {
+            "required": false,
+            "type": "boolean"
+          },
+          "[].issuer_corporation_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].issuer_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].price": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].reward": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "[].start_location_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "[].title": {
+            "required": false,
+            "type": "string"
+          },
+          "[].type": {
+            "enum": [
+              "auction",
+              "courier",
+              "item_exchange",
+              "loan",
+              "unknown"
+            ],
+            "required": true,
+            "type": "string"
+          },
+          "[].volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": "ttl-based"
+      },
+      "GET /universe/groups/{group_id}": {
+        "call_path": "/v1/universe/groups/{group_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_group",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "category_id": "background_aggregation._enrich_items -> compared against SHIP_CATEGORY_ID; this single field decides whether a contract is a ship contract, which is the product's default view"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseGroupsGroupId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "category_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "published": {
+            "required": true,
+            "type": "boolean"
+          },
+          "types": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "required": true,
+            "type": "array"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/regions": {
+        "call_path": "/v1/universe/regions/",
+        "caller": "app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {},
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseRegions",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {},
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/regions/{region_id}": {
+        "call_path": "/v1/universe/regions/{region_id}/",
+        "caller": "app/frontend/web/scripts/generate-regions.mjs (build-time codegen for the region filter)",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "name": "generate-regions.mjs -> the label of each option in src/features/contracts/regions.ts",
+          "region_id": "generate-regions.mjs -> the value of each option in src/features/contracts/regions.ts"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseRegionsRegionId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "constellations": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "required": true,
+            "type": "array"
+          },
+          "description": {
+            "required": false,
+            "type": "string"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "region_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/stations/{station_id}": {
+        "call_path": "/v2/universe/stations/{station_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_station",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "system_id": "background_aggregation._resolve_station_systems -> Contract.start_location_system_id, which backs the system_ids filter"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseStationsStationId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:station_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "max_dockable_ship_volume": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "office_rental_cost": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "owner": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "position": {
+            "required": true,
+            "type": "object"
+          },
+          "position.x": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "position.y": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "position.z": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "race_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "reprocessing_efficiency": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "reprocessing_stations_take": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "services": {
+            "items": {
+              "enum": [
+                "assasination-missions",
+                "black-market",
+                "bounty-missions",
+                "cloning",
+                "courier-missions",
+                "dna-therapy",
+                "docking",
+                "factory",
+                "fitting",
+                "gambling",
+                "insurance",
+                "interbus",
+                "jump-clone-facility",
+                "labratory",
+                "loyalty-point-store",
+                "market",
+                "navy-offices",
+                "news",
+                "office-rental",
+                "paintshop",
+                "refinery",
+                "repair-facilities",
+                "reprocessing-plant",
+                "security-offices",
+                "stock-exchange",
+                "storage",
+                "surgery"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "type": "array"
+          },
+          "station_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "system_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "GET /universe/types/{type_id}": {
+        "call_path": "/v3/universe/types/{type_id}/",
+        "caller": "core/esi_client_class.py ESIClient.get_universe_type",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "group_id": "background_aggregation._enrich_items -> the /universe/groups fan-out that decides the ship flag",
+          "market_group_id": "background_aggregation._enrich_items -> ContractItem.market_group_id",
+          "name": "background_aggregation._enrich_items -> ContractItem.type_name (the searchable ship name)"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "GetUniverseTypesTypeId",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          },
+          "path:type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          }
+        },
+        "present": true,
+        "request_body": null,
+        "response_fields": {
+          "capacity": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "description": {
+            "required": true,
+            "type": "string"
+          },
+          "dogma_attributes": {
+            "required": false,
+            "type": "array"
+          },
+          "dogma_attributes[].attribute_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "dogma_attributes[].value": {
+            "format": "double",
+            "required": true,
+            "type": "number"
+          },
+          "dogma_effects": {
+            "required": false,
+            "type": "array"
+          },
+          "dogma_effects[].effect_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "dogma_effects[].is_default": {
+            "required": true,
+            "type": "boolean"
+          },
+          "graphic_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "group_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "icon_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "market_group_id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "mass": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "name": {
+            "required": true,
+            "type": "string"
+          },
+          "packaged_volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "portion_size": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "published": {
+            "required": true,
+            "type": "boolean"
+          },
+          "radius": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          },
+          "type_id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "volume": {
+            "format": "double",
+            "required": false,
+            "type": "number"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "POST /universe/ids": {
+        "call_path": "/v1/universe/ids/",
+        "caller": "core/esi_client_class.py ESIClient.resolve_names",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "inventory_types": "watchlist_service resolves a watched ship name to a type id through this category; an unmatched name yields 200 with the category absent"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "PostUniverseIds",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": {
+          "required": true,
+          "schema": {
+            "items": {
+              "description": "name string",
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "response_fields": {
+          "agents": {
+            "required": false,
+            "type": "array"
+          },
+          "agents[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "agents[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "alliances": {
+            "required": false,
+            "type": "array"
+          },
+          "alliances[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "alliances[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "characters": {
+            "required": false,
+            "type": "array"
+          },
+          "characters[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "characters[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "constellations": {
+            "required": false,
+            "type": "array"
+          },
+          "constellations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "constellations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "corporations": {
+            "required": false,
+            "type": "array"
+          },
+          "corporations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "corporations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "factions": {
+            "required": false,
+            "type": "array"
+          },
+          "factions[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "factions[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "inventory_types": {
+            "required": false,
+            "type": "array"
+          },
+          "inventory_types[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "inventory_types[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "regions": {
+            "required": false,
+            "type": "array"
+          },
+          "regions[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "regions[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "stations": {
+            "required": false,
+            "type": "array"
+          },
+          "stations[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "stations[].name": {
+            "required": false,
+            "type": "string"
+          },
+          "systems": {
+            "required": false,
+            "type": "array"
+          },
+          "systems[].id": {
+            "format": "int64",
+            "required": false,
+            "type": "integer"
+          },
+          "systems[].name": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      },
+      "POST /universe/names": {
+        "call_path": "/v3/universe/names/",
+        "caller": "core/esi_client_class.py ESIClient.resolve_ids_to_names",
+        "consumed_fields_absent_from_spec": [],
+        "consumers": {
+          "id": "esi_client_class.resolve_ids_to_names -> the id->name map key",
+          "name": "esi_client_class.resolve_ids_to_names -> Contract.issuer_name / issuer_corporation_name / start_location_name"
+        },
+        "known_absent_fields": {},
+        "known_absent_fields_now_present": [],
+        "operation_compatibility_date": "2020-01-01",
+        "operation_id": "PostUniverseNames",
+        "parameters": {
+          "header:Accept-Language": {
+            "enum": [
+              "de",
+              "en",
+              "es",
+              "fr",
+              "ja",
+              "ko",
+              "ru",
+              "zh"
+            ],
+            "required": false,
+            "type": "string"
+          },
+          "header:If-Modified-Since": {
+            "required": false,
+            "type": "string"
+          },
+          "header:If-None-Match": {
+            "required": false,
+            "type": "string"
+          },
+          "header:X-Compatibility-Date": {
+            "format": "date",
+            "required": true,
+            "type": "string"
+          },
+          "header:X-Tenant": {
+            "required": false,
+            "type": "string"
+          }
+        },
+        "present": true,
+        "request_body": {
+          "required": true,
+          "schema": {
+            "items": {
+              "description": "id integer",
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxItems": 1000,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "response_fields": {
+          "[].category": {
+            "enum": [
+              "alliance",
+              "character",
+              "constellation",
+              "corporation",
+              "faction",
+              "inventory_type",
+              "region",
+              "solar_system",
+              "station"
+            ],
+            "required": true,
+            "type": "string"
+          },
+          "[].id": {
+            "format": "int64",
+            "required": true,
+            "type": "integer"
+          },
+          "[].name": {
+            "required": true,
+            "type": "string"
+          }
+        },
+        "response_statuses": [
+          "200",
+          "default"
+        ],
+        "security": [],
+        "server_cache_mode": null
+      }
+    }
+  }
+}

--- a/app/backend/tools/esi_spec_monitor/tests/__init__.py
+++ b/app/backend/tools/esi_spec_monitor/tests/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Package marker for the ESI spec monitor's unit tests.
+# ABOUTME: Present so the tests import as esi_spec_monitor.tests under the tools pythonpath entry.

--- a/app/backend/tools/esi_spec_monitor/tests/test_monitor.py
+++ b/app/backend/tools/esi_spec_monitor/tests/test_monitor.py
@@ -1,0 +1,643 @@
+# ABOUTME: Unit tests for the ESI spec monitor's projection and comparison logic — the part
+# ABOUTME: that can be silently wrong, so every drift kind is proven detected and no-change proven quiet.
+"""Tests for the drift detector itself.
+
+These build fixture OpenAPI documents rather than hitting the network: the question
+under test is "does the comparison notice X", and a live sample cannot answer that
+reliably because it only contains whatever CCP happens to be serving today. The
+predecessor to this monitor was a set of VCR cassettes whose replay made the tests
+structurally unable to fail; the discipline here is the opposite — every assertion
+is that a specific, deliberately-introduced mutation IS reported.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from esi_spec_monitor.manifest import Endpoint, KnownAbsentField
+from esi_spec_monitor.monitor import (
+    build_snapshot,
+    compare_snapshots,
+    format_report,
+    project,
+    serialize,
+)
+
+# --- fixtures ---------------------------------------------------------------
+
+WIDGET = Endpoint(
+    spec_path="/widgets/{widget_id}",
+    method="get",
+    call_path="/v1/widgets/{widget_id}/",
+    caller="core/widget_client.py WidgetClient.get_widget",
+    consumed_fields={
+        "widget_id": "widget_service._build_rows -> Widget.widget_id",
+        "colour": "widget_service._build_rows -> Widget.colour",
+    },
+    known_absent_fields=(
+        KnownAbsentField(
+            name="sparkle",
+            consumer="widget_service._build_rows -> Widget.sparkle",
+            consequence="always NULL; the sparkle filter matches zero rows",
+        ),
+    ),
+)
+
+GADGET = Endpoint(
+    spec_path="/gadgets",
+    method="post",
+    call_path="/v2/gadgets/",
+    caller="core/widget_client.py WidgetClient.resolve_gadgets",
+    consumed_fields={"id": "widget_service -> the gadget id map key"},
+)
+
+FIXTURE_MANIFEST = (WIDGET, GADGET)
+
+
+def _spec() -> dict:
+    """A minimal but structurally faithful ESI-shaped OpenAPI document."""
+    return {
+        "openapi": "3.1.0",
+        "info": {"version": "2020-01-01"},
+        "components": {
+            "schemas": {
+                "WidgetsWidgetIdGet": {
+                    "type": "object",
+                    "properties": {
+                        "widget_id": {"type": "integer", "format": "int64"},
+                        "colour": {
+                            "type": "string",
+                            "enum": ["red", "green"],
+                        },
+                        "mass": {"type": "number", "format": "double"},
+                    },
+                    "required": ["widget_id", "colour"],
+                },
+                "GadgetsPost": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "integer", "format": "int64"},
+                            "name": {"type": "string"},
+                        },
+                        "required": ["id", "name"],
+                    },
+                },
+            }
+        },
+        "paths": {
+            "/widgets/{widget_id}": {
+                "get": {
+                    "operationId": "GetWidgetsWidgetId",
+                    "parameters": [
+                        {
+                            "in": "path",
+                            "name": "widget_id",
+                            "required": True,
+                            "schema": {"type": "integer", "format": "int64"},
+                        },
+                        {"in": "query", "name": "page", "schema": {"type": "integer"}},
+                    ],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/WidgetsWidgetIdGet"
+                                    }
+                                }
+                            }
+                        },
+                        "default": {"content": {"application/json": {"schema": {}}}},
+                    },
+                    "x-server-cache-mode": "ttl-based",
+                    "x-compatibility-date": "2020-01-01",
+                }
+            },
+            "/gadgets": {
+                "post": {
+                    "operationId": "PostGadgets",
+                    "parameters": [],
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {"type": "integer"},
+                                    "maxItems": 1000,
+                                }
+                            }
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/GadgetsPost"}
+                                }
+                            }
+                        }
+                    },
+                    "x-compatibility-date": "2020-01-01",
+                }
+            },
+        },
+    }
+
+
+def _snapshot(spec: dict | None = None, newest: dict | None = None) -> dict:
+    """Build a snapshot, defaulting both compatibility-date views to the same spec."""
+    base = spec if spec is not None else _spec()
+    return build_snapshot(base, newest if newest is not None else base, FIXTURE_MANIFEST)
+
+
+def _findings(mutate) -> list:
+    """Compare a baseline against a snapshot whose PINNED view alone was mutated.
+
+    Isolating the pinned view keeps each assertion about one drift kind rather than
+    about the view dimension; `test_a_change_at_both_dates_is_reported_once_per_view`
+    covers the case where a change lands at every compatibility date at once.
+    """
+    spec = _spec()
+    mutate(spec)
+    return compare_snapshots(_snapshot(), _snapshot(spec, newest=_spec()))
+
+
+def _kinds(findings) -> set[str]:
+    return {f.kind for f in findings}
+
+
+# --- the case that matters most: nothing changed ----------------------------
+
+
+def test_identical_specs_produce_no_findings():
+    assert compare_snapshots(_snapshot(), _snapshot()) == []
+
+
+def test_reserialised_snapshot_still_produces_no_findings():
+    """A snapshot round-tripped through JSON must compare equal to a fresh one.
+
+    The committed snapshot is read back from disk as plain JSON, so if the
+    projection emits anything JSON cannot represent losslessly (a tuple, a set,
+    a non-string key) the monitor would report drift on every single run.
+    """
+    import json
+
+    fresh = _snapshot()
+    round_tripped = json.loads(json.dumps(fresh))
+    assert compare_snapshots(round_tripped, fresh) == []
+
+
+def test_an_unconsumed_part_of_the_spec_changing_is_not_reported():
+    """The projection is a lens: churn outside the manifest must stay invisible."""
+
+    def mutate(spec):
+        spec["paths"]["/sprockets"] = {"get": {"operationId": "GetSprockets"}}
+        spec["components"]["schemas"]["Unrelated"] = {"type": "object"}
+
+    assert _findings(mutate) == []
+
+
+# --- the required drift kinds -----------------------------------------------
+
+
+def test_removed_field_is_reported_with_its_consumer():
+    def mutate(spec):
+        del spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"]
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["required"] = ["widget_id"]
+
+    findings = _findings(mutate)
+    removed = [f for f in findings if f.kind == "FIELD_REMOVED"]
+    assert len(removed) == 1
+    assert removed[0].endpoint == "GET /widgets/{widget_id}"
+    assert removed[0].subject == "colour"
+    assert removed[0].severity == "breaking"
+    assert "widget_service._build_rows -> Widget.colour" in removed[0].consumer
+
+
+def test_added_field_is_reported_as_informational():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["hue"] = {
+            "type": "string"
+        }
+
+    findings = _findings(mutate)
+    added = [f for f in findings if f.kind == "FIELD_ADDED"]
+    assert len(added) == 1
+    assert added[0].subject == "hue"
+    assert added[0].severity == "informational"
+
+
+def test_changed_field_type_is_reported():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["widget_id"][
+            "type"
+        ] = "string"
+
+    findings = _findings(mutate)
+    changed = [f for f in findings if f.kind == "FIELD_TYPE_CHANGED"]
+    assert len(changed) == 1
+    assert changed[0].subject == "widget_id"
+    assert changed[0].severity == "breaking"
+    assert "integer" in changed[0].detail and "string" in changed[0].detail
+
+
+def test_removed_endpoint_is_reported():
+    def mutate(spec):
+        del spec["paths"]["/widgets/{widget_id}"]
+
+    findings = _findings(mutate)
+    assert "ENDPOINT_MISSING" in _kinds(findings)
+    missing = [f for f in findings if f.kind == "ENDPOINT_MISSING"][0]
+    assert missing.severity == "breaking"
+    # The call path is what a reader greps for, so the report must quote it.
+    assert "/v1/widgets/{widget_id}/" in missing.detail
+    # One clear headline, not a field-by-field teardown of the vanished endpoint.
+    assert [f for f in findings if f.endpoint == "GET /widgets/{widget_id}"] == [missing]
+
+
+def test_added_auth_requirement_is_reported():
+    def mutate(spec):
+        spec["paths"]["/widgets/{widget_id}"]["get"]["security"] = [
+            {"OAuth2": ["esi-widgets.read_widgets.v1"]}
+        ]
+
+    findings = _findings(mutate)
+    auth = [f for f in findings if f.kind == "AUTH_CHANGED"]
+    assert len(auth) == 1
+    assert auth[0].severity == "breaking"
+    assert "esi-widgets.read_widgets.v1" in auth[0].detail
+
+
+# --- the rest of the drift surface ------------------------------------------
+
+
+def test_required_field_becoming_optional_is_reported():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["required"] = ["widget_id"]
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["FIELD_BECAME_OPTIONAL"]
+    assert findings[0].subject == "colour"
+    # A field we read losing its guarantee is a real hazard, not a note.
+    assert findings[0].severity == "breaking"
+
+
+def test_optional_field_becoming_required_is_reported():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["required"].append("mass")
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["FIELD_BECAME_REQUIRED"]
+    assert findings[0].subject == "mass"
+    assert findings[0].severity == "informational"
+
+
+def test_enum_change_is_reported():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"][
+            "enum"
+        ] = ["red", "green", "blue"]
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["FIELD_ENUM_CHANGED"]
+    assert "blue" in findings[0].detail
+    # We branch on enum values, so a new member can silently fall through.
+    assert findings[0].severity == "breaking"
+
+
+def test_nested_field_is_projected_and_its_removal_reported():
+    def mutate(spec):
+        del spec["components"]["schemas"]["GadgetsPost"]["items"]["properties"]["name"]
+        spec["components"]["schemas"]["GadgetsPost"]["items"]["required"] = ["id"]
+
+    findings = _findings(mutate)
+    removed = [f for f in findings if f.kind == "FIELD_REMOVED"]
+    assert [f.subject for f in removed] == ["[].name"]
+
+
+def test_removed_query_parameter_is_reported():
+    def mutate(spec):
+        spec["paths"]["/widgets/{widget_id}"]["get"]["parameters"] = [
+            p
+            for p in spec["paths"]["/widgets/{widget_id}"]["get"]["parameters"]
+            if p["name"] != "page"
+        ]
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["PARAMETER_REMOVED"]
+    assert findings[0].subject == "query:page"
+    assert findings[0].severity == "breaking"
+
+
+def test_changed_response_status_set_is_reported():
+    def mutate(spec):
+        spec["paths"]["/widgets/{widget_id}"]["get"]["responses"]["204"] = {
+            "content": {"application/json": {"schema": {}}}
+        }
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["RESPONSE_STATUS_ADDED"]
+    assert findings[0].subject == "204"
+
+
+def test_request_body_change_is_reported():
+    def mutate(spec):
+        body = spec["paths"]["/gadgets"]["post"]["requestBody"]
+        body["content"]["application/json"]["schema"]["maxItems"] = 100
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["REQUEST_BODY_CHANGED"]
+    assert "100" in findings[0].detail
+
+
+def test_server_cache_mode_change_is_reported():
+    """ESI-2: routes are converting from clock expiry to event-driven invalidation."""
+
+    def mutate(spec):
+        spec["paths"]["/widgets/{widget_id}"]["get"][
+            "x-server-cache-mode"
+        ] = "event-based"
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["CACHE_MODE_CHANGED"]
+    assert "event-based" in findings[0].detail
+
+
+def test_operation_compatibility_date_change_is_reported():
+    def mutate(spec):
+        spec["paths"]["/widgets/{widget_id}"]["get"]["x-compatibility-date"] = "2026-07-21"
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["OPERATION_COMPATIBILITY_DATE_CHANGED"]
+
+
+def test_pinned_compatibility_date_change_is_reported():
+    """Omitting X-Compatibility-Date pins us to the oldest date; CCP can raise that floor."""
+    before = _snapshot()
+    spec = _spec()
+    spec["info"]["version"] = "2025-04-01"
+    findings = compare_snapshots(before, _snapshot(spec))
+    assert [f.kind for f in findings] == ["PINNED_COMPATIBILITY_DATE_CHANGED"]
+    assert findings[0].severity == "breaking"
+
+
+def test_drift_at_the_newest_compatibility_date_is_reported_separately():
+    """Our shape today is unchanged, but adopting the newest date would change it."""
+    newest = _spec()
+    del newest["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"]
+    newest["components"]["schemas"]["WidgetsWidgetIdGet"]["required"] = ["widget_id"]
+
+    findings = compare_snapshots(_snapshot(), _snapshot(newest=newest))
+    assert [f.kind for f in findings] == ["FIELD_REMOVED"]
+    assert findings[0].view == "newest_compatibility_date"
+    # It is not breaking *yet* — it only bites when the pinned floor moves.
+    assert findings[0].severity == "informational"
+
+
+def test_a_change_at_both_dates_is_reported_once_per_view():
+    """A route removal (ESI's spring cleaning) lands at every compatibility date."""
+    mutated = _spec()
+    del mutated["paths"]["/widgets/{widget_id}"]
+
+    findings = compare_snapshots(_snapshot(), _snapshot(mutated))
+    assert [f.kind for f in findings] == ["ENDPOINT_MISSING", "ENDPOINT_MISSING"]
+    assert [f.view for f in findings] == ["pinned", "newest_compatibility_date"]
+    # The one our client actually receives is the breaking one, and leads.
+    assert [f.severity for f in findings] == ["breaking", "informational"]
+
+
+# --- manifest/spec consistency (the ESI-3 family) ---------------------------
+
+
+def test_consumed_field_absent_from_the_spec_is_recorded_in_the_projection():
+    spec = _spec()
+    del spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"]
+    projection = project(spec, FIXTURE_MANIFEST)
+    entry = projection["GET /widgets/{widget_id}"]
+    assert entry["consumed_fields_absent_from_spec"] == ["colour"]
+
+
+def test_known_absent_field_appearing_is_reported():
+    """If ESI starts sending it, the filter it powers becomes implementable — that is news."""
+
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["sparkle"] = {
+            "type": "boolean"
+        }
+
+    findings = _findings(mutate)
+    kinds = _kinds(findings)
+    assert "KNOWN_ABSENT_FIELD_APPEARED" in kinds
+    appeared = [f for f in findings if f.kind == "KNOWN_ABSENT_FIELD_APPEARED"][0]
+    assert appeared.subject == "sparkle"
+    assert "sparkle filter matches zero rows" in appeared.consumer
+
+
+def test_known_absent_field_is_not_also_reported_as_a_plain_addition():
+    """One event, one finding — a declared-absent field arriving is not generic news."""
+
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["sparkle"] = {
+            "type": "boolean"
+        }
+
+    findings = _findings(mutate)
+    assert [f.kind for f in findings] == ["KNOWN_ABSENT_FIELD_APPEARED"]
+
+
+def test_a_known_absent_declaration_the_spec_contradicts_is_reported():
+    """Guards the monitor against understating its own coverage.
+
+    Declaring a field known-absent when ESI documents it would quietly exempt that
+    field from the drift checks. The spec here is unchanged — only the manifest is
+    wrong — so nothing else in the comparison would notice.
+    """
+    spec = _spec()
+    honest = build_snapshot(spec, spec, FIXTURE_MANIFEST)
+    mislabelled = build_snapshot(
+        spec,
+        spec,
+        (
+            Endpoint(
+                spec_path=WIDGET.spec_path,
+                method=WIDGET.method,
+                call_path=WIDGET.call_path,
+                caller=WIDGET.caller,
+                consumed_fields=WIDGET.consumed_fields,
+                known_absent_fields=WIDGET.known_absent_fields
+                + (
+                    KnownAbsentField(
+                        name="mass",
+                        consumer="widget_service -> Widget.mass",
+                        consequence="claimed absent, but the spec has carried it all along",
+                    ),
+                ),
+            ),
+            GADGET,
+        ),
+    )
+
+    findings = compare_snapshots(honest, mislabelled)
+    stale = [f for f in findings if f.kind == "KNOWN_ABSENT_DECLARATION_STALE"]
+    assert [f.subject for f in stale] == ["mass", "mass"]  # once per compatibility view
+    assert stale[0].severity == "breaking"
+
+
+def test_baseline_projection_declares_no_missing_consumed_fields():
+    projection = project(_spec(), FIXTURE_MANIFEST)
+    for entry in projection.values():
+        assert entry["consumed_fields_absent_from_spec"] == []
+        assert entry["known_absent_fields_now_present"] == []
+
+
+# --- reporting --------------------------------------------------------------
+
+
+def test_report_names_endpoint_field_change_and_consumer():
+    def mutate(spec):
+        del spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"]
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["required"] = ["widget_id"]
+
+    report = format_report(_findings(mutate))
+    assert "/v1/widgets/{widget_id}/" in report
+    assert "colour" in report
+    assert "FIELD_REMOVED" in report
+    assert "widget_service._build_rows -> Widget.colour" in report
+
+
+def test_report_leads_with_breaking_findings():
+    def mutate(spec):
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["hue"] = {
+            "type": "string"
+        }
+        del spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["colour"]
+        spec["components"]["schemas"]["WidgetsWidgetIdGet"]["required"] = ["widget_id"]
+
+    report = format_report(_findings(mutate))
+    assert report.index("FIELD_REMOVED") < report.index("FIELD_ADDED")
+
+
+def test_report_for_no_findings_says_so_and_mentions_no_endpoint():
+    report = format_report([])
+    assert "no drift" in report.lower()
+    assert "/widgets/" not in report
+
+
+# --- projection details worth pinning ---------------------------------------
+
+
+def test_the_compatibility_date_headers_enum_is_not_snapshotted():
+    """That enum echoes the date the spec copy was served for, not a route's shape.
+
+    Snapshotting it would make every operation restate the served date, so publishing
+    a new compatibility date — a calendar event CCP performs every few weeks, usually
+    touching none of our routes — would fire the monitor. That is precisely the
+    cry-wolf failure that gets a monitor muted.
+    """
+    pinned = _spec()
+    newest = _spec()
+    for spec, date in ((pinned, "2020-01-01"), (newest, "2026-07-21")):
+        spec["paths"]["/widgets/{widget_id}"]["get"]["parameters"].append(
+            {
+                "in": "header",
+                "name": "X-Compatibility-Date",
+                "required": True,
+                "schema": {"type": "string", "format": "date", "enum": [date]},
+            }
+        )
+
+    projected = project(pinned, FIXTURE_MANIFEST)["GET /widgets/{widget_id}"]
+    assert "enum" not in projected["parameters"]["header:X-Compatibility-Date"]
+    assert projected["parameters"]["header:X-Compatibility-Date"]["required"] is True
+    assert compare_snapshots(_snapshot(pinned), _snapshot(pinned, newest=newest)) == []
+
+
+def test_array_of_scalars_records_its_element_type():
+    """Otherwise a list of enum strings and a list of integers project identically."""
+    spec = _spec()
+    spec["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["services"] = {
+        "type": "array",
+        "items": {"type": "string", "enum": ["docking", "market"]},
+    }
+    projected = project(spec, FIXTURE_MANIFEST)["GET /widgets/{widget_id}"]
+    assert projected["response_fields"]["services"]["items"] == {
+        "type": "string",
+        "enum": ["docking", "market"],
+    }
+
+
+def test_changed_array_element_type_is_reported():
+    baseline_with_tags = _spec()
+    baseline_with_tags["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"][
+        "tags"
+    ] = {"type": "array", "items": {"type": "string"}}
+    widened = copy.deepcopy(baseline_with_tags)
+    widened["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]["tags"][
+        "items"
+    ] = {"type": "integer"}
+
+    findings = compare_snapshots(
+        _snapshot(baseline_with_tags), _snapshot(widened, newest=baseline_with_tags)
+    )
+    assert [f.kind for f in findings] == ["FIELD_TYPE_CHANGED"]
+    assert findings[0].subject == "tags"
+
+
+def test_projection_records_public_endpoints_as_unauthenticated():
+    projection = project(_spec(), FIXTURE_MANIFEST)
+    assert projection["GET /widgets/{widget_id}"]["security"] == []
+
+
+def test_projection_marks_a_missing_endpoint_rather_than_omitting_it():
+    """An absent endpoint must be an explicit False, not a missing key.
+
+    A key that simply disappears from the snapshot would compare as "nothing there
+    before, nothing there now" against a stale baseline, which is how a monitor
+    goes quiet at the exact moment it should shout.
+    """
+    spec = _spec()
+    del spec["paths"]["/gadgets"]
+    projection = project(spec, FIXTURE_MANIFEST)
+    assert projection["POST /gadgets"] == {"present": False}
+
+
+def test_projection_is_stable_across_key_ordering():
+    """Snapshot equality must not depend on the order the spec happens to list things.
+
+    Path keys, schema properties and the parameter *list* are all orderings CCP can
+    change without changing meaning. If any of them leaked into the projection, the
+    monitor would report drift for a cosmetic reshuffle — noise that trains readers
+    to update the snapshot without reading it.
+    """
+    spec = _spec()
+    shuffled = copy.deepcopy(spec)
+    shuffled["paths"] = dict(reversed(list(shuffled["paths"].items())))
+    props = shuffled["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"]
+    shuffled["components"]["schemas"]["WidgetsWidgetIdGet"]["properties"] = dict(
+        reversed(list(props.items()))
+    )
+    operation = shuffled["paths"]["/widgets/{widget_id}"]["get"]
+    operation["parameters"] = list(reversed(operation["parameters"]))
+
+    assert compare_snapshots(_snapshot(spec), _snapshot(shuffled)) == []
+    # And the committed artifact itself: a reshuffle must not produce a file diff.
+    assert serialize(_snapshot(spec)) == serialize(_snapshot(shuffled))
+
+
+def test_unresolvable_ref_raises_rather_than_projecting_an_empty_shape():
+    """A broken $ref must not silently project as "this endpoint has no fields".
+
+    That failure mode would look identical to "CCP removed every field", and the
+    quiet version of it — projecting {} and comparing clean — is worse still.
+    """
+    spec = _spec()
+    spec["paths"]["/widgets/{widget_id}"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"] = {"$ref": "#/components/schemas/DoesNotExist"}
+    with pytest.raises(KeyError):
+        project(spec, FIXTURE_MANIFEST)

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -29,7 +29,7 @@ This document serves three audiences. Start here, then go directly to the sectio
 | 1 | [API & Request Binding](#section-1-api--request-binding) | FastAPI request/query binding, filter params, dev-proxy routing | FASTAPI-1, FASTAPI-2, FASTAPI-3, PROXY-1 | §1.C |
 | 2 | [Data & Persistence](#section-2-data--persistence) | SQLAlchemy queries, pagination over joins | SQLA-1, SQLA-2, SQLA-3 | §2.C |
 | 3 | [Environment & Dev Loop](#section-3-environment--dev-loop) | Settings/env loading, startup ingestion, dev-server hygiene | ENV-1, ENV-2, ENV-3, ENV-4, ENV-5, ENV-6, ENV-7, ENV-8, ENV-9, ENV-10 | §3.C |
-| 4 | [External Integrations (ESI)](#section-4-external-integrations-esi) | Calling EVE's ESI API — route versions, deprecations, caching headers, upstream status | ESI-1, ESI-2, ESI-3 | §4.C |
+| 4 | [External Integrations (ESI)](#section-4-external-integrations-esi) | Calling EVE's ESI API — route versions, deprecations, caching headers, upstream status, spec drift | ESI-1, ESI-2, ESI-3, ESI-4 | §4.C |
 | 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3, DEPLOY-4 | §5.C |
 | — | [Orchestration](#orchestration) | Parallel subagent dispatch and output persistence | ORCH-1 | §Orchestration.C |
 | A | [Historical Changelog](#appendix-a-historical-changelog) | Provenance, validation dates, review process meta-observations | — | — |
@@ -346,6 +346,20 @@ One expression negated makes the branches exact complements *by construction*, i
 
 **Where It Bit Us:** `is_bpc=false` returned `total: 0` in production for the entire life of the filter (fixed 2026-08-01: `contract_service._has_blueprint_copy_item`, applied in `_apply_contract_filters`). The neighbouring `min_runs`/`max_runs` filter reads `ContractItem.raw_quantity`, a column no public payload can ever populate, and is inert for the same family of reasons. Verified against `https://esi.evetech.net/meta/openapi.json` and a live sample of 7,292 contracts / 1,658 item rows: `is_blueprint_copy` was `true` 1,396 times and absent 262 times — never once `false`.
 
+### ESI-4: Omitting `X-Compatibility-Date` pins the client to the OLDEST published date
+
+**The Flaw:** ESI replaced route versioning with a date header. A request that omits `X-Compatibility-Date` is not served "the current shape" — it is served the **oldest** date ESI still publishes, today `2020-01-01`. Hangar Bay sends no such header, so every call the `ESIClient` makes is answered from a five-year-old contract, chosen for us by default rather than by decision. CCP can raise that floor with notice, and the day they do, our routes change shape with no commit on our side.
+
+**Why It Matters:** It is an unmanaged, invisible dependency in the exact shape of the traps this section already catalogues — nothing in the codebase names the date, nothing fails when it moves, and the effect lands at ingestion where a missing field becomes a NULL column rather than an error (ESI-3). It also silently withholds routes: `/meta/status`, which ESI-1 tells us to use for upstream health, **does not exist at `2020-01-01`**. It first appears at a later compatibility date, so adopting it requires sending the header, not just changing a URL. The same date range removes `/sovereignty/map` and renames `/route/{origin}/{destination}` — proof that the date dimension moves real routes, not just field descriptions.
+
+**The Fix:**
+*   Treat the served date as a tracked value, not an accident. `app/backend/tools/esi_spec_monitor/` fetches `https://esi.evetech.net/meta/openapi.json` on a schedule, projects it down to the routes and fields we consume, and diffs that projection against a committed snapshot. The snapshot records the date served with no header (so a moved floor is an alarm) and the shape at the newest published date (so "what changes if we adopt a newer date" is answerable without a spike). Run it locally with `pdm run esi-spec-monitor` from `app/backend`; `--update` rewrites the snapshot, and that update belongs in a PR with a reason, like a lockfile bump.
+*   Before adopting a route that is absent from the spec you are reading, check `https://esi.evetech.net/meta/compatibility-dates` and re-fetch the spec with the header set. An "ESI does not have that route" conclusion drawn from a header-less fetch is a conclusion about 2020, not about ESI.
+*   Diff the **shape**, never the prose. The spec's `description` strings are unreliable (ESI-3: `collateral` is documented "for Couriers only" but ships on every item_exchange contract; `runs`'s documented `-1` for originals never occurs). The machine-readable `properties`, `required`, `security` and `x-server-cache-mode` fields have been accurate every time we have checked them against live payloads.
+*   Diff a **projection**, not the whole document. The spec is 182 paths and churns constantly in areas we never call; a whole-spec diff produces noise, noise gets ignored, and an ignored monitor rots. The manifest at `tools/esi_spec_monitor/manifest.py` names the nine operations we consume and the fields each one feeds, so a failure can say which function breaks.
+
+**Where It Stands:** Discovered 2026-08-01 while building the monitor; nothing has broken yet. The header-less floor is `2020-01-01` and the newest published date is `2026-07-21`; every route Hangar Bay consumes is byte-identical across that whole range and all nine are unauthenticated, so adopting a newer date would currently be a no-op for us. The monitor exists so that the *next* answer to that question does not require a spike. It replaces a set of VCR cassettes that were deleted in PR #110 — they had been intended to catch this class of drift and could not, because they recorded our own app talking to itself (testing-pitfalls TEST-14) and because a live sample can only reveal drift the sample happens to contain.
+
 ### §4.C — Review Checklist
 
 - [ ] **Every ESI request names an explicit version prefix** (`/v1`, `/v3`, …), not `/latest` (ESI-1)
@@ -357,6 +371,9 @@ One expression negated makes the branches exact complements *by construction*, i
 - [ ] **Filters over ESI-fed nullable columns treat NULL explicitly** — a present-when-true flag is never sent as false, so `col == False` matches zero rows (ESI-3)
 - [ ] **Every filtered column is actually populated by the route ingestion calls** — the public and authenticated contract-item routes carry disjoint field sets; `raw_quantity` is authenticated-only (ESI-3)
 - [ ] **No response field is served that the ingesting route cannot populate** — a wire field that is always NULL or always a placeholder publishes information the corpus does not have, and every client that reads it inherits the lie. Drop it from the response schema; keep the COLUMN when a known future ingestion path would fill it (ESI-3)
+- [ ] **A new or changed ESI dependency is added to `tools/esi_spec_monitor/manifest.py` in the same PR** — an endpoint or field outside the manifest is outside the drift monitor's lens (ESI-4)
+- [ ] **A conclusion about what ESI does or does not offer is drawn from a spec fetched with an explicit `X-Compatibility-Date`** — a header-less fetch answers for the oldest published date, currently 2020-01-01 (ESI-4)
+- [ ] **A snapshot update in `tools/esi_spec_monitor/snapshot.json` comes with a stated reason** — it is a lockfile-shaped artifact; re-generating it to silence a red run defeats the monitor (ESI-4)
 
 ---
 
@@ -455,6 +472,13 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 
 - Added ENV-9. `7dce47f` bumped the dev compose pin from `postgres:16-alpine` to `postgres:18-alpine` without moving the volume mount; Postgres 18 stores data at `PGDATA=/var/lib/postgresql/18/docker` and refuses to start when a volume is mounted at the pre-18 `/var/lib/postgresql/data`, even an empty one. `compose.dependencies.yml` now mounts the parent. CI was unaffected throughout (ephemeral service container, no volume), which is why it stayed green while local dev was broken.
 
+## 2026-08-01 — ESI-4 added: the compatibility-date floor, and a monitor for spec drift
+
+- Added ESI-4. Building a drift monitor surfaced that omitting `X-Compatibility-Date` is not "no opinion" — it pins the client to the OLDEST published date (`2020-01-01`), a floor CCP can raise with notice. It also explains a puzzle in ESI-1: `/meta/status` is absent from a header-less spec fetch and appears only at a later date, so adopting it needs the header, not just the URL.
+- Landed `app/backend/tools/esi_spec_monitor/` — a manifest of the nine operations we consume, a projection of the published spec down to those, a committed snapshot, and a daily GitHub Actions job that diffs them and files a self-closing issue. The comparison logic carries 35 unit tests against constructed fixture specs, mutation-verified.
+- Deliberately NOT a live-ESI test lane. The VCR cassettes deleted in PR #110 were the previous attempt at this and failed twice over (testing-pitfalls TEST-14); beyond that, detecting a spec lie live requires the sample to contain the case, which is inherently flaky, and flaky monitors get muted.
+- The monitor's manifest records five fields our ingestion reads that no public ESI route documents: `status` and `date_completed` on contracts, `raw_quantity` and `is_singleton` on contract items (`runs` remains unimplemented). Recorded as known-absent rather than fixed — see the ESI-3 note above on `raw_quantity`.
+
 ## 2026-08-01 — SQLA-3 added; ESI-3's prescribed fix corrected
 
 - Added SQLA-3 (a per-row predicate over a one-to-many join classifies the CHILD, not the parent, so a condition and its negation can both match the same parent). Found by adversarial review of PR #98: the first `is_bpc=false` fix corrected the NULL half but kept the per-item form, so a contract bundling a BPC with a hull matched `is_bpc=true` AND `is_bpc=false`. Re-fixed as a correlated EXISTS negated for the false branch, which also removes the filter's join and with it the SQLA-1 pagination hazard.
@@ -551,6 +575,7 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 | ESI-1 | Pin ESI route versions; avoid removed legacy/meta routes | LOW | VALIDATED | External Integrations (ESI) |
 | ESI-2 | `Expires` deprecated by event-driven invalidation; read `Cache-Control` | MEDIUM | VALIDATED | External Integrations (ESI) |
 | ESI-3 | ESI omits fields rather than sending falsy values; `== False` matches nothing | HIGH | VALIDATED | External Integrations (ESI) |
+| ESI-4 | No `X-Compatibility-Date` pins the client to the oldest published date | MEDIUM | VALIDATED | External Integrations (ESI) |
 | DEPLOY-1 | Managed platforms inject postgresql:// URLs; async stack needs +asyncpg | HIGH | VALIDATED | Deployment & Platform |
 | DEPLOY-2 | uvicorn stays --workers 1 (in-process scheduler) | MEDIUM | VALIDATED | Deployment & Platform |
 | DEPLOY-3 | Durable coordination state must not live in an evicting cache | HIGH | VALIDATED | Deployment & Platform |


### PR DESCRIPTION
Turns "we found out the hard way" into "CI told us."

In one session we discovered four ESI shape facts by debugging: `raw_quantity`
does not exist on the public contract-items route, `runs` is *omitted* for
blueprint originals rather than sent as the documented `-1`, `Expires` is being
deprecated in favour of `Cache-Control`, and CCP's March 2026 spring cleaning
removed several routes outright. This watches for the next one.

## What it does

`app/backend/tools/esi_spec_monitor/` fetches `https://esi.evetech.net/meta/openapi.json`,
projects it down to the nine operations Hangar Bay actually calls, and diffs
that projection against a committed snapshot. A daily GitHub Actions job runs
it; drift fails the run and files a labelled, self-closing issue.

**A projection, not a whole-spec diff.** The document is 182 paths and churns
constantly in areas we never call. A whole-spec diff is noise, noise gets
ignored, and an ignored monitor rots — which is exactly how the predecessor
died. `manifest.py` names the routes and the response fields each one feeds,
derived by grepping `core/esi_client_class.py`,
`services/background_aggregation.py`, `services/watchlist_service.py` and the
frontend's `scripts/generate-regions.mjs` — not from anyone's memory.

**Actionable failures.** Every consumed field carries the code that reads it, so
the report says which function breaks. This is the real snapshot with
`system_id` removed from the stations route:

```
[BREAKING] FIELD_REMOVED — /v2/universe/stations/{station_id}/
           field: system_id
           change: was {"format": "int64", "required": true, "type": "integer"}
           consumed by: background_aggregation._resolve_station_systems ->
                        Contract.start_location_system_id, which backs the system_ids filter
```

**Cheap and safe.** Three requests to static meta documents (rate-limit group
`meta`, 150/15m). No data endpoint is touched, so ESI's shared error budget —
100 errors in 60 s buys a blanket 420 across every endpoint — is untouched. A
descriptive `User-Agent` with contact info, per ESI best practices. Standard
library only, so the scheduled job needs no dependency install.

## The compatibility-date finding — new ESI-4

Investigating this dimension turned up something worth its own pitfall entry.
Omitting `X-Compatibility-Date` is not "no opinion": ESI serves the **oldest**
published date, today `2020-01-01`, which is what every `ESIClient` call
currently gets. CCP can raise that floor with notice.

It also resolves a puzzle in ESI-1. `/meta/status`, which ESI-1 tells us to use
for upstream health, **does not exist at 2020-01-01** — it appears only at a
later date. Adopting it needs the header, not just a URL change. The same range
removes `/sovereignty/map` and renames `/route/{origin}/{destination}`, so the
date dimension moves real routes, not just prose.

So the snapshot holds two views: `pinned` (what our client receives today) and
`newest_compatibility_date` (what we would receive if we adopted the newest
published date). Today every route we consume is byte-identical across the whole
2020-01-01 → 2026-07-21 range and all nine are unauthenticated — so adopting a
newer date would currently be a no-op. The monitor exists so the *next* answer
to that question is not a spike.

The list of published dates is deliberately **not** snapshotted, and the
`X-Compatibility-Date` parameter's enum is stripped from the projection: CCP
publishes a date every few weeks and almost none touch our routes, so
snapshotting either would fire the monitor on a calendar rather than on news.
That is the cry-wolf failure that gets monitors muted.

## Why an issue, not just a red run

Scheduled-workflow failure mail goes only to whoever last touched the workflow
file and is trivially filtered — an unread red run is exactly the thing to
avoid. An issue is durable and lands in the repo's normal work surface. The
label is the dedup key, so a standing drift does not file a new issue every
morning, and a green run closes any open one. Exit code 2 (ESI unreachable)
fails the run but files no issue: a network blip is not drift, and reporting it
as drift trains readers to ignore the issue.

## Not a live-ESI lane

No cassettes, no VCR, no live test. The deleted PR #110 cassettes were the
previous attempt and failed twice over — they recorded our own app talking to
itself (testing-pitfalls TEST-14), and replay made five tests structurally
unable to fail. Beyond that, detecting a spec lie live requires the sample to
contain the case, which is inherently flaky, and flaky monitors get muted. The
now-unused `esi_live` marker keeps its registration but gains a comment saying
what replaced it.

## Testing

35 unit tests against constructed fixture specs, covering field removed / added
/ type changed / enum changed / required changed, endpoint removed, auth added,
parameter removed, response-status changed, request-body changed, cache-mode
changed (ESI-2's conversion signal), compatibility-date floor moved, and the
no-change cases — including that churn *outside* the manifest stays invisible
and that a JSON round-trip of the snapshot compares clean.

Mutation-verified: 15 mutations, 15 killed, `cp`-snapshot restore, ending green.
Two rounds found real problems rather than confirming what I already believed:

- A first run reported a mutation as surviving. The cause was stale bytecode —
  two mutations produced files of identical size within the same second, and
  CPython's `.pyc` validity check is (source mtime, source size), so the second
  run executed the first mutation's bytecode. Fixed in the driver; the mutation
  then died correctly. Worth knowing for any future mutation campaign here.
- The ordering-stability test could not be killed by removing any single sort.
  Investigation showed three redundant layers hold that invariant (the parameter
  sort, the property sort, and `sort_keys` at serialization) and removing all
  three together does break the test. Defense in depth rather than dead code, and
  the comment now says so instead of claiming the wrong thing.

Also `pdm run lint` clean, and a live `--check` against the committed snapshot
reports no drift.

## Notes

- `/universe/stations/{station_id}` **is** in the manifest — PR #116 merged
  while this was in review. The consumer was re-derived from the merged code
  rather than assumed: `ESIClient.get_universe_station` calls **`/v2`** (not
  `/v1`), and `background_aggregation._resolve_station_systems` reads exactly
  one field, `system_id`, into `Contract.start_location_system_id`.
- `/universe/structures/{structure_id}` is deliberately absent and the manifest
  says why: it needs the `esi-universe.read_structures.v1` scope, and it names
  the field **`solar_system_id`**, not `system_id`. Copying the station entry
  unchanged would read an absent key, write NULL, and look like it worked.
- The manifest records four fields our ingestion reads that no public route
  documents. Two (`status`, `date_completed`) were taken off the wire by
  PR #115; `is_singleton` and `raw_quantity` are still served and violate the
  checklist bullet #115 itself added. Flagged separately rather than fixed here
  — this PR touches no application code.

## Merge classification

Routine — new tooling plus a scheduled CI workflow. No application behavior
changes; the only edits outside `tools/` and `.github/` are pytest paths, a pdm
script, the pitfalls entry, and the command list in CLAUDE.md/AGENTS.md.