### PR TITLE
feat(api)!: stop serving contract item is_singleton and raw_quantity

### DIFF
--- a/app/backend/src/fastapi_app/schemas/contracts.py
+++ b/app/backend/src/fastapi_app/schemas/contracts.py
@@ -8,15 +8,21 @@ from .common import PaginatedResponse
 
 
 class ContractItemSchema(BaseModel):
-    """Schema for an item within a contract."""
+    """Schema for an item within a contract.
+
+    `is_singleton` and `raw_quantity` are deliberately absent. Both are fields of ESI's
+    AUTHENTICATED character/corporation contract-item routes; the public item route
+    Hangar Bay reads carries neither, so `is_singleton` is the mapping default and
+    `raw_quantity` is NULL for every item in the corpus today. The columns stay — they
+    fill in the moment a user's own contracts are ingested — but a wire field that can
+    only misinform is worse than no wire field (ESI-3).
+    """
 
     record_id: int
     type_id: int
     quantity: int
     is_included: bool
-    is_singleton: bool
     is_blueprint_copy: Optional[bool] = None
-    raw_quantity: Optional[int] = None
     type_name: Optional[str] = None
     category: Optional[str] = None
     market_group_id: Optional[int] = None

--- a/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
@@ -73,8 +73,10 @@ async def test_filter_by_bpc_runs(client: AsyncClient, setup_contracts):
     assert response.status_code == 200
     data = response.json()
     assert len(data["items"]) == 1
-    bpc_item = data["items"][0]["items"][0]
-    assert bpc_item["raw_quantity"] == 10
+    # raw_quantity is what the filter reads, but it is not served (ESI-3), so the
+    # matched contract itself is the only observable the response can carry.
+    assert data["items"][0]["contract_id"] == 102
+    assert any(i["is_blueprint_copy"] for i in data["items"][0]["items"])
 
 
 async def test_response_omits_fields_public_ingestion_cannot_populate(
@@ -103,6 +105,39 @@ async def test_detail_response_omits_fields_public_ingestion_cannot_populate(
     assert contract["contract_id"] == 101
     assert "status" not in contract
     assert "date_completed" not in contract
+
+
+async def test_item_response_omits_fields_public_ingestion_cannot_populate(
+    client: AsyncClient, setup_contracts
+):
+    """`is_singleton` and `raw_quantity` belong to ESI's authenticated character/corporation
+    contract-ITEM routes. The public item route carries neither, so under public ingestion
+    is_singleton is the mapping default on every row and raw_quantity is NULL on every row."""
+    response = await client.get("/contracts/")
+
+    assert response.status_code == 200
+    contracts = response.json()["items"]
+    assert contracts, "fixture must reach the endpoint for this to mean anything"
+    items = [item for contract in contracts for item in contract["items"]]
+    assert items, "contracts must carry items for this to mean anything"
+    for item in items:
+        assert "is_singleton" not in item
+        assert "raw_quantity" not in item
+
+
+async def test_detail_item_response_omits_fields_public_ingestion_cannot_populate(
+    client: AsyncClient, setup_contracts
+):
+    """The detail endpoint serializes the same item schema and must not drift from the list."""
+    response = await client.get("/contracts/101")
+
+    assert response.status_code == 200
+    contract = response.json()
+    assert contract["contract_id"] == 101
+    assert contract["items"], "fixture must carry items for this to mean anything"
+    for item in contract["items"]:
+        assert "is_singleton" not in item
+        assert "raw_quantity" not in item
 
 
 async def test_complex_filter_api(client: AsyncClient, setup_contracts):

--- a/app/frontend/web/e2e/fixtures/contracts.ts
+++ b/app/frontend/web/e2e/fixtures/contracts.ts
@@ -36,9 +36,7 @@ export interface WireContractItem {
   type_id: number
   quantity: number
   is_included: boolean
-  is_singleton: boolean
   is_blueprint_copy: boolean | null
-  raw_quantity: number | null
   type_name: string | null
   category: 'ship' | null
   market_group_id: number | null
@@ -84,9 +82,7 @@ export function makeItem(overrides: Partial<WireContractItem> = {}): WireContrac
     type_id: 24694,
     quantity: 1,
     is_included: true,
-    is_singleton: false,
     is_blueprint_copy: null,
-    raw_quantity: null,
     type_name: 'Maelstrom',
     category: 'ship',
     market_group_id: 78,

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -2,7 +2,7 @@
   "components": {
     "schemas": {
       "ContractItemSchema": {
-        "description": "Schema for an item within a contract.",
+        "description": "Schema for an item within a contract.\n\n`is_singleton` and `raw_quantity` are deliberately absent. Both are fields of ESI's\nAUTHENTICATED character/corporation contract-item routes; the public item route\nHangar Bay reads carries neither, so `is_singleton` is the mapping default and\n`raw_quantity` is NULL for every item in the corpus today. The columns stay \u2014 they\nfill in the moment a user's own contracts are ingested \u2014 but a wire field that can\nonly misinform is worse than no wire field (ESI-3).",
         "properties": {
           "category": {
             "anyOf": [
@@ -30,10 +30,6 @@
             "title": "Is Included",
             "type": "boolean"
           },
-          "is_singleton": {
-            "title": "Is Singleton",
-            "type": "boolean"
-          },
           "market_group_id": {
             "anyOf": [
               {
@@ -48,17 +44,6 @@
           "quantity": {
             "title": "Quantity",
             "type": "integer"
-          },
-          "raw_quantity": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Raw Quantity"
           },
           "record_id": {
             "title": "Record Id",
@@ -84,8 +69,7 @@
           "record_id",
           "type_id",
           "quantity",
-          "is_included",
-          "is_singleton"
+          "is_included"
         ],
         "title": "ContractItemSchema",
         "type": "object"

--- a/app/frontend/web/src/features/contracts/components/a11y.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/a11y.test.tsx
@@ -31,7 +31,6 @@ const CONTRACT = {
       type_id: 587,
       quantity: 1,
       is_included: true,
-      is_singleton: false,
       is_blueprint_copy: false,
       type_name: 'Tristan',
     },

--- a/app/frontend/web/src/features/contracts/components/pages.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/pages.test.tsx
@@ -25,7 +25,6 @@ const CONTRACT = {
       type_id: 587,
       quantity: 1,
       is_included: true,
-      is_singleton: false,
       type_name: 'Tristan',
     },
   ],

--- a/app/frontend/web/src/features/contracts/format.test.ts
+++ b/app/frontend/web/src/features/contracts/format.test.ts
@@ -28,7 +28,6 @@ function contract(items: Partial<Contract['items'][number]>[], title = ''): Cont
       type_id: 1,
       quantity: 1,
       is_included: true,
-      is_singleton: false,
       ...item,
     })),
   } as Contract

--- a/app/frontend/web/src/features/watchlists/components/WatchButton.test.tsx
+++ b/app/frontend/web/src/features/watchlists/components/WatchButton.test.tsx
@@ -13,7 +13,7 @@ const CONTRACT = {
   date_issued: '2026-07-01T00:00:00Z', date_expired: daysFromNow(7),
   price: 1000000, reward: 0, volume: 27, start_location_name: 'Jita IV - Moon 4', issuer_name: 'Sesta Hound',
   issuer_corporation_name: 'COB', is_ship_contract: true,
-  items: [{ record_id: 1011, type_id: 587, quantity: 1, is_included: true, is_singleton: false, is_blueprint_copy: false, raw_quantity: null, type_name: 'Rifter', category: 'ship', market_group_id: 61 }],
+  items: [{ record_id: 1011, type_id: 587, quantity: 1, is_included: true, is_blueprint_copy: false, type_name: 'Rifter', category: 'ship', market_group_id: 61 }],
 }
 
 interface Call { url: string; method?: string; body?: string }

--- a/app/frontend/web/src/lib/api/schema.d.ts
+++ b/app/frontend/web/src/lib/api/schema.d.ts
@@ -314,6 +314,13 @@ export interface components {
         /**
          * ContractItemSchema
          * @description Schema for an item within a contract.
+         *
+         *     `is_singleton` and `raw_quantity` are deliberately absent. Both are fields of ESI's
+         *     AUTHENTICATED character/corporation contract-item routes; the public item route
+         *     Hangar Bay reads carries neither, so `is_singleton` is the mapping default and
+         *     `raw_quantity` is NULL for every item in the corpus today. The columns stay — they
+         *     fill in the moment a user's own contracts are ingested — but a wire field that can
+         *     only misinform is worse than no wire field (ESI-3).
          */
         ContractItemSchema: {
             /** Category */
@@ -322,14 +329,10 @@ export interface components {
             is_blueprint_copy?: boolean | null;
             /** Is Included */
             is_included: boolean;
-            /** Is Singleton */
-            is_singleton: boolean;
             /** Market Group Id */
             market_group_id?: number | null;
             /** Quantity */
             quantity: number;
-            /** Raw Quantity */
-            raw_quantity?: number | null;
             /** Record Id */
             record_id: number;
             /** Type Id */

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -464,6 +464,11 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 
 # Appendix A: Historical Changelog
 
+## 2026-08-01 — ESI-3's response-schema rule applied at the item level
+
+- No new entry. `ContractItemSchema` still served `is_singleton` and `raw_quantity` after the contract-level pair (`status`, `date_completed`) was removed — the same always-empty wire fields one level down, violating the §4.C checklist bullet sitting beside them. Both are gone from the response schema; the columns and their model-level comments stay, per the keep-the-column-refuse-to-read-it decision in the ESI-3 fix.
+- Nothing read either field: no frontend component, only four unit-test mocks and the e2e wire fixture, all moved with the wire shape. `min_runs`/`max_runs` still filter on `ContractItem.raw_quantity` — a query concern, unaffected — so `test_filter_by_bpc_runs` now asserts the matched contract rather than a field the response no longer carries.
+
 ## 2026-08-01 — ENV-10 added: containers bind-mounted to reclaimed worktrees
 
 - Added ENV-10. The `alloy` telemetry container was created from the `grafana-cloud-migration-5a5464` worktree; reclaiming that worktree removed its bind-mount sources, and alloy exited 127 at its next restart and stayed dead ~11 days unnoticed. Exit 127 reads as "command not found"; the real cause is only in `docker inspect`'s `.State.Error`. Recovery is blocked on regenerating the gitignored `grafana-cloud.env` in the main checkout (ENV-8).


### PR DESCRIPTION
Finishes at the item level what [PR #115](https://github.com/scarson/hangar-bay/pull/115) did at the contract level.

## The gap

PR #115 removed `status` and `date_completed` from `ContractSchema` because ESI's *public* contract route cannot populate them, and added a review-checklist bullet under pitfall ESI-3 (`docs/pitfalls/implementation-pitfalls.md` §4.C): *no response field is served that the ingesting route cannot populate.*

`ContractItemSchema` still served **`is_singleton`** and **`raw_quantity`** — the same case one level down. Both appear only on the authenticated `/characters/{id}/contracts/{id}/items` and `/corporations/{id}/contracts/{id}/items` routes. The complete public item schema is `record_id, type_id, quantity, is_included, item_id, is_blueprint_copy, material_efficiency, time_efficiency, runs`. So `is_singleton` was the mapping default on every row in the corpus and `raw_quantity` was NULL on every row, and #115's own checklist bullet was being violated by the schema sitting next to it.

## What changed

- `ContractItemSchema` drops both fields, and gains a docstring mirroring `ContractSchema`'s explaining why they are absent.
- **The DB columns stay**, with the model-level comments #115 added. Per `docs/superpowers/specs/2026-08-01-contract-coverage-gap-analysis.md` §4.2 ("Keep them, don't drop them"), the authenticated routes populate both and character/corp contract ingestion is a live direction; dropping them was approved and then reversed.
- **No Alembic migration** — response shape only.
- Regenerated `openapi.json` and `schema.d.ts` from this worktree.
- E2E wire fixture (`e2e/fixtures/contracts.ts`) and four frontend unit-test mocks move with the wire shape.
- Pitfalls changelog entry recording the item-level application. No new pitfall ID — this is ESI-3's existing rule being applied, not a new trap.

## What read these fields

Nothing in production code. The full grep across `app/frontend/web/src`, `app/backend/src`, and `e2e/`:

- **No frontend component or hook** reads either field — only the generated `schema.d.ts` and the e2e `WireContractItem` interface declared them.
- Four frontend unit-test mocks (`format.test.ts`, `pages.test.tsx`, `a11y.test.tsx`, `WatchButton.test.tsx`) — updated.
- One backend test asserted the wire field: `test_filter_by_bpc_runs` checked `bpc_item["raw_quantity"] == 10`. It now asserts the matched contract (`contract_id == 102` plus a BPC item) instead.

`min_runs`/`max_runs` still filter on `ContractItem.raw_quantity` in `contract_service.py`. **That filter stays** — it is a query concern, not a response concern, and its params were deliberately left in place with their "NO MATCHES" descriptions. Only the response field goes.

## TDD + mutation evidence

Two new tests in `test_contract_filters.py` (list and detail, mirroring #115's pair):

- `test_item_response_omits_fields_public_ingestion_cannot_populate`
- `test_detail_item_response_omits_fields_public_ingestion_cannot_populate`

Both **failed before the fix**:

```
E   AssertionError: assert 'is_singleton' not in {'category': None, 'is_blueprint_copy': None,
                                                  'is_included': True, 'is_singleton': False, ...}
2 failed, 2 passed, 23 deselected
```

**Mutation-verified** (re-added both fields to `ContractItemSchema` via a `cp` snapshot, never `git checkout --`): `2 failed, 2 passed`. Restored from the snapshot: `4 passed`. Both new tests also assert their fixtures are non-empty, so they cannot pass vacuously on an empty item list.

## Gates

| Gate | Result |
|---|---|
| `pdm run pytest` | 566 passed (564 baseline + 2 new) |
| `pdm run lint` | clean |
| `npm run test` | 192 passed, 28 files |
| `npx tsc -b` | clean |
| `npx eslint .` | clean |
| `npm run e2e` | 92 passed, 7 skipped (live-smoke) |

All re-run after rebasing onto `origin/dev` @ `b94f935`.

## Note on the base

`origin/dev` advanced to PR #120 mid-work. The reverse-read of `git diff origin/dev..HEAD` caught the pre-rebase diff appearing to delete #120's handoff content; rebased onto current `dev` before pushing, and the diff now deletes only the intended fields.

## Merge classification

`Review — serialization contract`. This changes the wire shape, exactly as #115 did. **Do not auto-merge.**

BREAKING CHANGE: `ContractItemSchema` no longer carries `is_singleton` or `raw_quantity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)