### PR TITLE
release: security dependency bumps, contract-list perf fix, pitfalls and planning docs

### DIFF
--- a/app/backend/pdm.lock
+++ b/app/backend/pdm.lock
@@ -153,34 +153,28 @@ files = [
 
 [[package]]
 name = "black"
-version = "25.1.0"
-requires_python = ">=3.9"
+version = "26.5.1"
+requires_python = ">=3.10"
 summary = "The uncompromising code formatter."
 groups = ["dev"]
 dependencies = [
     "click>=8.0.0",
     "mypy-extensions>=0.4.3",
     "packaging>=22.0",
-    "pathspec>=0.9.0",
+    "pathspec>=1.0.0",
     "platformdirs>=2",
+    "pytokens~=0.4.0",
     "tomli>=1.1.0; python_version < \"3.11\"",
     "typing-extensions>=4.0.1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
-    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
-    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
-    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
-    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
-    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
-    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
-    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
-    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
-    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
-    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
-    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
-    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
-    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
+    {file = "black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168"},
+    {file = "black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3"},
+    {file = "black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18"},
+    {file = "black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50"},
+    {file = "black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae"},
+    {file = "black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2"},
+    {file = "black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73"},
 ]
 
 [[package]]
@@ -297,7 +291,7 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.2"
 requires_python = ">=3.10"
 summary = "Composable command line interface toolkit"
 groups = ["default", "dev"]
@@ -305,8 +299,8 @@ dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
 files = [
-    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
-    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [[package]]
@@ -323,7 +317,7 @@ files = [
 
 [[package]]
 name = "cryptography"
-version = "49.0.0"
+version = "50.0.0"
 requires_python = "!=3.9.0,!=3.9.1,>=3.9"
 summary = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 groups = ["default"]
@@ -332,52 +326,46 @@ dependencies = [
     "typing-extensions>=4.13.2; python_full_version < \"3.11\"",
 ]
 files = [
-    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
-    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
-    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
-    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
-    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
-    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
-    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
-    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
-    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
-    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
-    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
-    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
-    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
-    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
-    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
-    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
-    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
+    {file = "cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169"},
+    {file = "cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f"},
+    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105"},
+    {file = "cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef"},
+    {file = "cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30"},
+    {file = "cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d"},
+    {file = "cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c"},
+    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c"},
+    {file = "cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95"},
+    {file = "cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269"},
+    {file = "cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708"},
+    {file = "cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47"},
+    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9"},
+    {file = "cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7"},
+    {file = "cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba"},
+    {file = "cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9"},
 ]
 
 [[package]]
@@ -571,16 +559,16 @@ files = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
-requires_python = ">=3.8"
+version = "1.4.1"
+requires_python = ">=3.10"
 summary = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 groups = ["default"]
 dependencies = [
-    "MarkupSafe>=0.9.2",
+    "MarkupSafe>=2.0",
 ]
 files = [
-    {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
-    {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
+    {file = "mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617"},
+    {file = "mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27"},
 ]
 
 [[package]]
@@ -645,84 +633,6 @@ files = [
 ]
 
 [[package]]
-name = "multidict"
-version = "6.6.0"
-requires_python = ">=3.9"
-summary = "multidict implementation"
-groups = ["dev"]
-dependencies = [
-    "typing-extensions>=4.1.0; python_version < \"3.11\"",
-]
-files = [
-    {file = "multidict-6.6.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5eb5444dd0dc4c2e0f180d7e216fe2a713d45b5648fec2832ff4a78100270d6a"},
-    {file = "multidict-6.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:522cafe660896c471fc667c53d5081416c435a7ab88e183d8bcd75c6f993fb27"},
-    {file = "multidict-6.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b4898814f97d28c2a6a5989cb605840ad0545a8f2bad38a5d3a75071b673ec6"},
-    {file = "multidict-6.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec93a0f75742ffcb14a0c15dedcafb37e69860a76fc009d0463c534701443f2f"},
-    {file = "multidict-6.6.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:db158941bbed55f980a30125cc9d027f272af76e11f4c7204e3c458c277a5098"},
-    {file = "multidict-6.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:561164b6e0998a49b72b17dd9f484ef785bcf836a5ce525b58a0970c563cbb6e"},
-    {file = "multidict-6.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aed62dc3bf5bba3c64f123e15d05005e22a18b3d95b990996b1c3a9aa12c4611"},
-    {file = "multidict-6.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c38f0b501487246b1ac68cd6159459789af9f95ac6b35eb14f7f74e41b3f8eb5"},
-    {file = "multidict-6.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5737e9abbde209f7f9805fed605f9623d65b7822bfa9e18cb0f94b6f8fa6c0fd"},
-    {file = "multidict-6.6.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:8fad001e4fbda4a14f6f6466e78c73f51dad18da0a831378a564050b9790b7de"},
-    {file = "multidict-6.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0c9e7ce1fff62bd094b5adb349336fc965e29ae401e0db413986a85cfbfeb11d"},
-    {file = "multidict-6.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1f9fb3a923d84843807a24f0250028f5802e97469c496a6ed0eee9ef7ed455a2"},
-    {file = "multidict-6.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:50f62cd84cf042a7d586759bc83059d1c2b1c00ae3f2481d112cdf711e6cb15c"},
-    {file = "multidict-6.6.0-cp311-cp311-win32.whl", hash = "sha256:855fc84169a98ee9dde3805716c3a18959a8803069866e48512edd6a5a59fffc"},
-    {file = "multidict-6.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:e86d6f67647159f6b96df10504b7f00c17f12370588ea7202b78fc3867d1c900"},
-    {file = "multidict-6.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:afbb6d962c355863a6f39a1558db875fcaa0cc1116acbb7086e8fa0e86a642ed"},
-    {file = "multidict-6.6.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0b95809f30d197efa899b5e08a38cf8d6658f3acfa5f5c984e0fe6bc21245aeb"},
-    {file = "multidict-6.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c146b37f0a719df5f82e0dccc2ecbcbcccae75e762d696b5b26990aef65e6ac4"},
-    {file = "multidict-6.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d36d3cd27eba1f7aa209839ccce79b9601abbd82e9b503f33f16652072e347da"},
-    {file = "multidict-6.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2e1676ed48d42e3db21a18030a149bff12ed564185453777814722ec8c67f26"},
-    {file = "multidict-6.6.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1201db24a4b55921cf5db90cbd9a31a44c0bb2eba8ee5f50e330c0b2080fa00"},
-    {file = "multidict-6.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9a2a7242da589b5879857646847e806dad51b6de6fab8de3c0330ea60656d915"},
-    {file = "multidict-6.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8175c3ec6a7ed880ccf576a80a95f2b559a97158662698db6c8fbeffdf982123"},
-    {file = "multidict-6.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a5e7c0e6ef7e98ea7601c672f067e491bd286531293c62930b10ade50120af2"},
-    {file = "multidict-6.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cfb725d2379d7c54958cce23a0fd8ff5b3d8dd1f4e2741a44a548eddefad6eae"},
-    {file = "multidict-6.6.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6dbff377ce9e67a5cae6c5989a4963816d70d52a9f6bf01dd04aadaa9ca31dba"},
-    {file = "multidict-6.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b04670b6d3251dfc1761e8a8c58cd1ccb28c1fc8041ed7dc0b1e741bd7753b02"},
-    {file = "multidict-6.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:20da2c7faa1bddc3fda31258debcbcc7033f33094f4d89b3b6269570bd7b132d"},
-    {file = "multidict-6.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7a848558168b6c39bca54c57dacc27eac708b479b1ff92469a7465ead6619334"},
-    {file = "multidict-6.6.0-cp312-cp312-win32.whl", hash = "sha256:a066dc45b29ce247a2ddbccc2cf20ce99f95e849a7624cf3cdfd7d50b1261098"},
-    {file = "multidict-6.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:74fa779e729bb20dd7ce9bbc2b4b704f4134b6763ea8f4a13d259aed044812fd"},
-    {file = "multidict-6.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:860ddc224123efb788812f16329d629722c68ca687c0d4410f4ad26a9197cc73"},
-    {file = "multidict-6.6.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e26114b8e3da8137bb39e2820eef09005c0ab468b2cca384f429a2104c48f6d1"},
-    {file = "multidict-6.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bf72082eba16b22f63ef8553e1d245c56bf92868976f089ae3f572e91e2dd197"},
-    {file = "multidict-6.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:57afe4cdc5ee0c001af224f259a20b906df8ddbb9b9af932817a374bf98cd857"},
-    {file = "multidict-6.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d18cde7f12df1f9d42bafbe01ed0af48e8f6605ee632aaf3788ada861193175"},
-    {file = "multidict-6.6.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:11ccf3fa5cdf0475706307be90ab60bb1865cd8814c7cac6f3c9e54dda094a57"},
-    {file = "multidict-6.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:690e7fd86c1def94f080ce514922fb6b62b6327ab10b229e1a8a7ecfc4e88200"},
-    {file = "multidict-6.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c92cb8bc15c3152ccdb53093c12eb56e661bf404f5674c055007dc979c869f7"},
-    {file = "multidict-6.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:760a4970d6ce435b0c71a68c4a86fcd0fad50c760c948891d60af4d3486401f6"},
-    {file = "multidict-6.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:606b94703e1949fd0044ea72aab11a7b9d92492e86fd5886c099d1a7655961ca"},
-    {file = "multidict-6.6.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9c73131cd1f46669c9b28632be3ee3be611aef38c0fe5ee9f8d5632e9722229f"},
-    {file = "multidict-6.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3f76f25eea979b6e39993380acb56422eb8a10c44e13ef4f5d3c82c797cb157d"},
-    {file = "multidict-6.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b9a1135f8a0bf7959fb03bca6b98308521cecc6883e4a334a9ae4edecf3d90c"},
-    {file = "multidict-6.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ff8f1043a727649ce698642065b279ee18b36e0d7cbdb7583d7edac6ae804392"},
-    {file = "multidict-6.6.0-cp313-cp313-win32.whl", hash = "sha256:e53dcb79923cc0c7ef0ac41aac6e4ea4cf8aa1c7bc7f354c014cf386e9c28639"},
-    {file = "multidict-6.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:c0ac2049db3dca5fade0390817f94e1945e248297c90bf0b7596127105f3f54f"},
-    {file = "multidict-6.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:fe16f2823f50a10f13cf094cc09c9e76c3b483064975c482eda0d830175746bc"},
-    {file = "multidict-6.6.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:55243ada517cd453ede3be68ab65260af5389adcb8be5f4c1c7cdec63bbeef5d"},
-    {file = "multidict-6.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d614de950f7dd9d295590a5b3017dd1f0a5278a97d15a10d037a2f24e7f6d65b"},
-    {file = "multidict-6.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d12ce09473c3f497d8944c210899043686f88b811970edc5eb6486f413caa267"},
-    {file = "multidict-6.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d5a2c6f673c0b5f8bd1049208a313d7e038972aa2ab898bd486f1d29a8c62130"},
-    {file = "multidict-6.6.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ff27fc5526b8740735612ea32d8fab2f79e83824b8f9e7f2b88c9e1db28d6f79"},
-    {file = "multidict-6.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:279bfd45fecc0d9cdb6926b2a58381cae0514689d6fab67e39a88304301da90a"},
-    {file = "multidict-6.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b28f421e6f8b444f636bbf4b99e01db5adeb673691ebb764eb39c17dc64179cd"},
-    {file = "multidict-6.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11537e9e25241a98746f265230569d7230ad2d8f0d26e863f974e1c991ff5a45"},
-    {file = "multidict-6.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e5b1647506370075513fb19424141853f5cc68dbba38559655dcaafce4d99f27"},
-    {file = "multidict-6.6.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fe2bab539a912c3aa24dd3f96e4f6a45b9fac819184fa1d09aec8f289bd7f3ab"},
-    {file = "multidict-6.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:9d30a1ef323867e71e96c62434cc52b072160e4f9be0169ec2fea516d61003dd"},
-    {file = "multidict-6.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:0b9cc871bc3e580224f9f3c0cd172a1d91e5f4e6c1164d039e3e6f9542f09bf3"},
-    {file = "multidict-6.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:aa98b25a25eaefd8728cffab14066bdc10b30168d4dd32039c5191d2dc863631"},
-    {file = "multidict-6.6.0-cp313-cp313t-win32.whl", hash = "sha256:b62d2907e8014c3e65b7725271029085aaf8885d34f5bab526cd960bcf40905f"},
-    {file = "multidict-6.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:954591356227721d7557a9f9ea0f80235608f2dc99c5bb1869f654e890528358"},
-    {file = "multidict-6.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:14b3d44838170996d217b168de2c9dd1cefbb9de6a18c8cfd07cec141b489e41"},
-    {file = "multidict-6.6.0-py3-none-any.whl", hash = "sha256:447df643754e273681fda37764a89880d32c86cab102bfc05c1e8359ebcf0980"},
-    {file = "multidict-6.6.0.tar.gz", hash = "sha256:460b213769cb8691b5ba2f12e53522acd95eb5b2602497d4d7e64069a61e5941"},
-]
-
-[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 requires_python = ">=3.8"
@@ -746,13 +656,13 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
-requires_python = ">=3.8"
+version = "1.1.1"
+requires_python = ">=3.9"
 summary = "Utility library for gitignore style pattern matching of file paths."
 groups = ["dev"]
 files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
+    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
 ]
 
 [[package]]
@@ -801,81 +711,6 @@ dependencies = [
 files = [
     {file = "prometheus_fastapi_instrumentator-8.0.2-py3-none-any.whl", hash = "sha256:746002ec1e2c58b93f61444e1d104de959a9463a6a3f1c8909ac3757e16c3866"},
     {file = "prometheus_fastapi_instrumentator-8.0.2.tar.gz", hash = "sha256:3c252e748151768a7aefd66824a04a870144f71de48a67aed211749a9ca2a548"},
-]
-
-[[package]]
-name = "propcache"
-version = "0.3.2"
-requires_python = ">=3.9"
-summary = "Accelerated property cache"
-groups = ["dev"]
-files = [
-    {file = "propcache-0.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0b8d2f607bd8f80ddc04088bc2a037fdd17884a6fcadc47a96e334d72f3717be"},
-    {file = "propcache-0.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:06766d8f34733416e2e34f46fea488ad5d60726bb9481d3cddf89a6fa2d9603f"},
-    {file = "propcache-0.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2dc1f4a1df4fecf4e6f68013575ff4af84ef6f478fe5344317a65d38a8e6dc9"},
-    {file = "propcache-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be29c4f4810c5789cf10ddf6af80b041c724e629fa51e308a7a0fb19ed1ef7bf"},
-    {file = "propcache-0.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59d61f6970ecbd8ff2e9360304d5c8876a6abd4530cb752c06586849ac8a9dc9"},
-    {file = "propcache-0.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62180e0b8dbb6b004baec00a7983e4cc52f5ada9cd11f48c3528d8cfa7b96a66"},
-    {file = "propcache-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c144ca294a204c470f18cf4c9d78887810d04a3e2fbb30eea903575a779159df"},
-    {file = "propcache-0.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5c2a784234c28854878d68978265617aa6dc0780e53d44b4d67f3651a17a9a2"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5745bc7acdafa978ca1642891b82c19238eadc78ba2aaa293c6863b304e552d7"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c0075bf773d66fa8c9d41f66cc132ecc75e5bb9dd7cce3cfd14adc5ca184cb95"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5f57aa0847730daceff0497f417c9de353c575d8da3579162cc74ac294c5369e"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:eef914c014bf72d18efb55619447e0aecd5fb7c2e3fa7441e2e5d6099bddff7e"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2a4092e8549031e82facf3decdbc0883755d5bbcc62d3aea9d9e185549936dcf"},
-    {file = "propcache-0.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85871b050f174bc0bfb437efbdb68aaf860611953ed12418e4361bc9c392749e"},
-    {file = "propcache-0.3.2-cp311-cp311-win32.whl", hash = "sha256:36c8d9b673ec57900c3554264e630d45980fd302458e4ac801802a7fd2ef7897"},
-    {file = "propcache-0.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:e53af8cb6a781b02d2ea079b5b853ba9430fcbe18a8e3ce647d5982a3ff69f39"},
-    {file = "propcache-0.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de106b6c84506b31c27168582cd3cb3000a6412c16df14a8628e5871ff83c10"},
-    {file = "propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154"},
-    {file = "propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce26862344bdf836650ed2487c3d724b00fbfec4233a1013f597b78c1cb73615"},
-    {file = "propcache-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca54bd347a253af2cf4544bbec232ab982f4868de0dd684246b67a51bc6b1db"},
-    {file = "propcache-0.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55780d5e9a2ddc59711d727226bb1ba83a22dd32f64ee15594b9392b1f544eb1"},
-    {file = "propcache-0.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c"},
-    {file = "propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee6f22b6eaa39297c751d0e80c0d3a454f112f5c6481214fcf4c092074cecd67"},
-    {file = "propcache-0.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ca3aee1aa955438c4dba34fc20a9f390e4c79967257d830f137bd5a8a32ed3b"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4f30862869fa2b68380d677cc1c5fcf1e0f2b9ea0cf665812895c75d0ca3b8"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b77ec3c257d7816d9f3700013639db7491a434644c906a2578a11daf13176251"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cab90ac9d3f14b2d5050928483d3d3b8fb6b4018893fc75710e6aa361ecb2474"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0b504d29f3c47cf6b9e936c1852246c83d450e8e063d50562115a6be6d3a2535"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ce2ac2675a6aa41ddb2a0c9cbff53780a617ac3d43e620f8fd77ba1c84dcfc06"},
-    {file = "propcache-0.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b4239611205294cc433845b914131b2a1f03500ff3c1ed093ed216b82621e1"},
-    {file = "propcache-0.3.2-cp312-cp312-win32.whl", hash = "sha256:df4a81b9b53449ebc90cc4deefb052c1dd934ba85012aa912c7ea7b7e38b60c1"},
-    {file = "propcache-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7046e79b989d7fe457bb755844019e10f693752d169076138abf17f31380800c"},
-    {file = "propcache-0.3.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca592ed634a73ca002967458187109265e980422116c0a107cf93d81f95af945"},
-    {file = "propcache-0.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9ecb0aad4020e275652ba3975740f241bd12a61f1a784df044cf7477a02bc252"},
-    {file = "propcache-0.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f08f1cc28bd2eade7a8a3d2954ccc673bb02062e3e7da09bc75d843386b342f"},
-    {file = "propcache-0.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1a342c834734edb4be5ecb1e9fb48cb64b1e2320fccbd8c54bf8da8f2a84c33"},
-    {file = "propcache-0.3.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a544caaae1ac73f1fecfae70ded3e93728831affebd017d53449e3ac052ac1e"},
-    {file = "propcache-0.3.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:310d11aa44635298397db47a3ebce7db99a4cc4b9bbdfcf6c98a60c8d5261cf1"},
-    {file = "propcache-0.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1396592321ac83157ac03a2023aa6cc4a3cc3cfdecb71090054c09e5a7cce3"},
-    {file = "propcache-0.3.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cabf5b5902272565e78197edb682017d21cf3b550ba0460ee473753f28d23c1"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0a2f2235ac46a7aa25bdeb03a9e7060f6ecbd213b1f9101c43b3090ffb971ef6"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:92b69e12e34869a6970fd2f3da91669899994b47c98f5d430b781c26f1d9f387"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:54e02207c79968ebbdffc169591009f4474dde3b4679e16634d34c9363ff56b4"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4adfb44cb588001f68c5466579d3f1157ca07f7504fc91ec87862e2b8e556b88"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fd3e6019dc1261cd0291ee8919dd91fbab7b169bb76aeef6c716833a3f65d206"},
-    {file = "propcache-0.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c181cad81158d71c41a2bce88edce078458e2dd5ffee7eddd6b05da85079f43"},
-    {file = "propcache-0.3.2-cp313-cp313-win32.whl", hash = "sha256:8a08154613f2249519e549de2330cf8e2071c2887309a7b07fb56098f5170a02"},
-    {file = "propcache-0.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:e41671f1594fc4ab0a6dec1351864713cb3a279910ae8b58f884a88a0a632c05"},
-    {file = "propcache-0.3.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9a3cf035bbaf035f109987d9d55dc90e4b0e36e04bbbb95af3055ef17194057b"},
-    {file = "propcache-0.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:156c03d07dc1323d8dacaa221fbe028c5c70d16709cdd63502778e6c3ccca1b0"},
-    {file = "propcache-0.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74413c0ba02ba86f55cf60d18daab219f7e531620c15f1e23d95563f505efe7e"},
-    {file = "propcache-0.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f066b437bb3fa39c58ff97ab2ca351db465157d68ed0440abecb21715eb24b28"},
-    {file = "propcache-0.3.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1304b085c83067914721e7e9d9917d41ad87696bf70f0bc7dee450e9c71ad0a"},
-    {file = "propcache-0.3.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab50cef01b372763a13333b4e54021bdcb291fc9a8e2ccb9c2df98be51bcde6c"},
-    {file = "propcache-0.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fad3b2a085ec259ad2c2842666b2a0a49dea8463579c606426128925af1ed725"},
-    {file = "propcache-0.3.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:261fa020c1c14deafd54c76b014956e2f86991af198c51139faf41c4d5e83892"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:46d7f8aa79c927e5f987ee3a80205c987717d3659f035c85cf0c3680526bdb44"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:6d8f3f0eebf73e3c0ff0e7853f68be638b4043c65a70517bb575eff54edd8dbe"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:03c89c1b14a5452cf15403e291c0ccd7751d5b9736ecb2c5bab977ad6c5bcd81"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cc17efde71e12bbaad086d679ce575268d70bc123a5a71ea7ad76f70ba30bba"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:acdf05d00696bc0447e278bb53cb04ca72354e562cf88ea6f9107df8e7fd9770"},
-    {file = "propcache-0.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4445542398bd0b5d32df908031cb1b30d43ac848e20470a878b770ec2dcc6330"},
-    {file = "propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394"},
-    {file = "propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198"},
-    {file = "propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f"},
-    {file = "propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168"},
 ]
 
 [[package]]
@@ -1097,13 +932,13 @@ files = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
-requires_python = ">=3.8"
+version = "2.20.0"
+requires_python = ">=3.9"
 summary = "Pygments is a syntax highlighting package written in Python."
 groups = ["dev"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [[package]]
@@ -1138,7 +973,7 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 requires_python = ">=3.9"
 summary = "pytest: simple powerful testing with Python"
 groups = ["dev"]
@@ -1152,8 +987,8 @@ dependencies = [
     "tomli>=1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
-    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
 ]
 
 [[package]]
@@ -1216,13 +1051,34 @@ files = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
-requires_python = ">=3.9"
+version = "1.2.2"
+requires_python = ">=3.10"
 summary = "Read key-value pairs from a .env file and set them as environment variables"
 groups = ["default"]
 files = [
-    {file = "python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d"},
-    {file = "python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+requires_python = ">=3.8"
+summary = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
+groups = ["dev"]
+files = [
+    {file = "pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321"},
+    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa"},
+    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d"},
+    {file = "pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"},
+    {file = "pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9"},
+    {file = "pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb"},
+    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3"},
+    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975"},
+    {file = "pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a"},
+    {file = "pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918"},
+    {file = "pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de"},
+    {file = "pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a"},
 ]
 
 [[package]]
@@ -1437,18 +1293,6 @@ files = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "1.26.20"
-requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["dev"]
-marker = "python_version >= \"3.10\" or platform_python_implementation == \"PyPy\""
-files = [
-    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
-    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
-]
-
-[[package]]
 name = "uvicorn"
 version = "0.34.3"
 requires_python = ">=3.9"
@@ -1517,21 +1361,17 @@ files = [
 
 [[package]]
 name = "vcrpy"
-version = "7.0.0"
-requires_python = ">=3.9"
+version = "8.3.0"
+requires_python = ">=3.10"
 summary = "Automatically mock your HTTP interactions to simplify and speed up testing"
 groups = ["dev"]
 dependencies = [
     "PyYAML",
-    "urllib3; platform_python_implementation != \"PyPy\" and python_version >= \"3.10\"",
-    "urllib3<2; platform_python_implementation == \"PyPy\"",
-    "urllib3<2; python_version < \"3.10\"",
     "wrapt",
-    "yarl",
 ]
 files = [
-    {file = "vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124"},
-    {file = "vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50"},
+    {file = "vcrpy-8.3.0-py3-none-any.whl", hash = "sha256:bd66e6143746778157f00e2a922527a8d96b2fdc350be8988a45a29c843815b9"},
+    {file = "vcrpy-8.3.0.tar.gz", hash = "sha256:46d64e77e8d95e5c76c7d9a94ff05d8b38b2ae4e1d4869eb0235024b6fcb5212"},
 ]
 
 [[package]]
@@ -1737,88 +1577,4 @@ files = [
     {file = "wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c"},
     {file = "wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8"},
     {file = "wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3"},
-]
-
-[[package]]
-name = "yarl"
-version = "1.20.1"
-requires_python = ">=3.9"
-summary = "Yet another URL library"
-groups = ["dev"]
-dependencies = [
-    "idna>=2.0",
-    "multidict>=4.0",
-    "propcache>=0.2.1",
-]
-files = [
-    {file = "yarl-1.20.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:47ee6188fea634bdfaeb2cc420f5b3b17332e6225ce88149a17c413c77ff269e"},
-    {file = "yarl-1.20.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0f6500f69e8402d513e5eedb77a4e1818691e8f45e6b687147963514d84b44b"},
-    {file = "yarl-1.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7a8900a42fcdaad568de58887c7b2f602962356908eedb7628eaf6021a6e435b"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bad6d131fda8ef508b36be3ece16d0902e80b88ea7200f030a0f6c11d9e508d4"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:df018d92fe22aaebb679a7f89fe0c0f368ec497e3dda6cb81a567610f04501f1"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f969afbb0a9b63c18d0feecf0db09d164b7a44a053e78a7d05f5df163e43833"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:812303eb4aa98e302886ccda58d6b099e3576b1b9276161469c25803a8db277d"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98c4a7d166635147924aa0bf9bfe8d8abad6fffa6102de9c99ea04a1376f91e8"},
-    {file = "yarl-1.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12e768f966538e81e6e7550f9086a6236b16e26cd964cf4df35349970f3551cf"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fe41919b9d899661c5c28a8b4b0acf704510b88f27f0934ac7a7bebdd8938d5e"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:8601bc010d1d7780592f3fc1bdc6c72e2b6466ea34569778422943e1a1f3c389"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:daadbdc1f2a9033a2399c42646fbd46da7992e868a5fe9513860122d7fe7a73f"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:03aa1e041727cb438ca762628109ef1333498b122e4c76dd858d186a37cec845"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:642980ef5e0fa1de5fa96d905c7e00cb2c47cb468bfcac5a18c58e27dbf8d8d1"},
-    {file = "yarl-1.20.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:86971e2795584fe8c002356d3b97ef6c61862720eeff03db2a7c86b678d85b3e"},
-    {file = "yarl-1.20.1-cp311-cp311-win32.whl", hash = "sha256:597f40615b8d25812f14562699e287f0dcc035d25eb74da72cae043bb884d773"},
-    {file = "yarl-1.20.1-cp311-cp311-win_amd64.whl", hash = "sha256:26ef53a9e726e61e9cd1cda6b478f17e350fb5800b4bd1cd9fe81c4d91cfeb2e"},
-    {file = "yarl-1.20.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdcc4cd244e58593a4379fe60fdee5ac0331f8eb70320a24d591a3be197b94a9"},
-    {file = "yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b29a2c385a5f5b9c7d9347e5812b6f7ab267193c62d282a540b4fc528c8a9d2a"},
-    {file = "yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1112ae8154186dfe2de4732197f59c05a83dc814849a5ced892b708033f40dc2"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90bbd29c4fe234233f7fa2b9b121fb63c321830e5d05b45153a2ca68f7d310ee"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:680e19c7ce3710ac4cd964e90dad99bf9b5029372ba0c7cbfcd55e54d90ea819"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a979218c1fdb4246a05efc2cc23859d47c89af463a90b99b7c56094daf25a16"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255b468adf57b4a7b65d8aad5b5138dce6a0752c139965711bdcb81bc370e1b6"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd"},
-    {file = "yarl-1.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8570d998db4ddbfb9a590b185a0a33dbf8aafb831d07a5257b4ec9948df9cb0a"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:97c75596019baae7c71ccf1d8cc4738bc08134060d0adfcbe5642f778d1dca38"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c48912653e63aef91ff988c5432832692ac5a1d8f0fb8a33091520b5bbe19ef"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c3ae28f3ae1563c50f3d37f064ddb1511ecc1d5584e88c6b7c63cf7702a6d5f"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e9642f27036283550f5f57dc6156c51084b458570b9d0d96100c8bebb186a8"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c26b0c49220d5799f7b22c6838409ee9bc58ee5c95361a4d7831f03cc225b5a"},
-    {file = "yarl-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564ab3d517e3d01c408c67f2e5247aad4019dcf1969982aba3974b4093279004"},
-    {file = "yarl-1.20.1-cp312-cp312-win32.whl", hash = "sha256:daea0d313868da1cf2fac6b2d3a25c6e3a9e879483244be38c8e6a41f1d876a5"},
-    {file = "yarl-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:48ea7d7f9be0487339828a4de0360d7ce0efc06524a48e1810f945c45b813698"},
-    {file = "yarl-1.20.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b5ff0fbb7c9f1b1b5ab53330acbfc5247893069e7716840c8e7d5bb7355038a"},
-    {file = "yarl-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:14f326acd845c2b2e2eb38fb1346c94f7f3b01a4f5c788f8144f9b630bfff9a3"},
-    {file = "yarl-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f60e4ad5db23f0b96e49c018596707c3ae89f5d0bd97f0ad3684bcbad899f1e7"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49bdd1b8e00ce57e68ba51916e4bb04461746e794e7c4d4bbc42ba2f18297691"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:66252d780b45189975abfed839616e8fd2dbacbdc262105ad7742c6ae58f3e31"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59174e7332f5d153d8f7452a102b103e2e74035ad085f404df2e40e663a22b28"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e3968ec7d92a0c0f9ac34d5ecfd03869ec0cab0697c91a45db3fbbd95fe1b653"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1a4fbb50e14396ba3d375f68bfe02215d8e7bc3ec49da8341fe3157f59d2ff5"},
-    {file = "yarl-1.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11a62c839c3a8eac2410e951301309426f368388ff2f33799052787035793b02"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:041eaa14f73ff5a8986b4388ac6bb43a77f2ea09bf1913df7a35d4646db69e53"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:377fae2fef158e8fd9d60b4c8751387b8d1fb121d3d0b8e9b0be07d1b41e83dc"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1c92f4390e407513f619d49319023664643d3339bd5e5a56a3bebe01bc67ec04"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d25ddcf954df1754ab0f86bb696af765c5bfaba39b74095f27eececa049ef9a4"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:909313577e9619dcff8c31a0ea2aa0a2a828341d92673015456b3ae492e7317b"},
-    {file = "yarl-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:793fd0580cb9664548c6b83c63b43c477212c0260891ddf86809e1c06c8b08f1"},
-    {file = "yarl-1.20.1-cp313-cp313-win32.whl", hash = "sha256:468f6e40285de5a5b3c44981ca3a319a4b208ccc07d526b20b12aeedcfa654b7"},
-    {file = "yarl-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:495b4ef2fea40596bfc0affe3837411d6aa3371abcf31aac0ccc4bdd64d4ef5c"},
-    {file = "yarl-1.20.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f60233b98423aab21d249a30eb27c389c14929f47be8430efa7dbd91493a729d"},
-    {file = "yarl-1.20.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6f3eff4cc3f03d650d8755c6eefc844edde99d641d0dcf4da3ab27141a5f8ddf"},
-    {file = "yarl-1.20.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:69ff8439d8ba832d6bed88af2c2b3445977eba9a4588b787b32945871c2444e3"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cf34efa60eb81dd2645a2e13e00bb98b76c35ab5061a3989c7a70f78c85006d"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8e0fe9364ad0fddab2688ce72cb7a8e61ea42eff3c7caeeb83874a5d479c896c"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f64fbf81878ba914562c672024089e3401974a39767747691c65080a67b18c1"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6342d643bf9a1de97e512e45e4b9560a043347e779a173250824f8b254bd5ce"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dac5f452ed25eef0f6e3c6a066c6ab68971d96a9fb441791cad0efba6140d3"},
-    {file = "yarl-1.20.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7d7f497126d65e2cad8dc5f97d34c27b19199b6414a40cb36b52f41b79014be"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:67e708dfb8e78d8a19169818eeb5c7a80717562de9051bf2413aca8e3696bf16"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:595c07bc79af2494365cc96ddeb772f76272364ef7c80fb892ef9d0649586513"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7bdd2f80f4a7df852ab9ab49484a4dee8030023aa536df41f2d922fd57bf023f"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c03bfebc4ae8d862f853a9757199677ab74ec25424d0ebd68a0027e9c639a390"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:344d1103e9c1523f32a5ed704d576172d2cabed3122ea90b1d4e11fe17c66458"},
-    {file = "yarl-1.20.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:88cab98aa4e13e1ade8c141daeedd300a4603b7132819c484841bb7af3edce9e"},
-    {file = "yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d"},
-    {file = "yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f"},
-    {file = "yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77"},
-    {file = "yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac"},
 ]

--- a/app/backend/src/fastapi_app/services/contract_service.py
+++ b/app/backend/src/fastapi_app/services/contract_service.py
@@ -1,10 +1,11 @@
 import asyncio
 import time
-from sqlalchemy import func, or_
+from sqlalchemy import and_, case, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import aliased, selectinload
 
+from ..core.config import get_settings
 from ..core.logging import get_logger, log_key_event
 from ..models.contracts import Contract, ContractItem
 from ..schemas.contracts import (
@@ -78,6 +79,20 @@ def still_listed_by_esi():
     alternative is alerting on a contract someone already bought for as long as two weeks,
     which sends the reader to a dead listing over and over and teaches them the alerts are
     noise; a missed alert costs one opportunity and leaves the feature trustworthy.
+
+    The watermark written correlated to each row is the same value for every row of a
+    region, and PostgreSQL re-derives it once per candidate row: 61,874 index probes for
+    one unfiltered list request, ~5s of a 6s query on the production instance. Since the
+    regions ingestion refreshes are known up front, their watermarks are emitted as
+    UNCORRELATED subqueries — one index probe each, evaluated once for the whole query —
+    and the correlated form is kept as the fallback for any other region.
+
+    AGGREGATION_REGION_IDS is therefore an OPTIMIZATION HINT, never a semantic input: the
+    `case` guarantees a row whose region is not configured is judged by exactly the
+    predicate it is judged by today. Config drift changes which rows take the fast path,
+    never which rows are visible — verified against the production corpus by a both-way
+    EXCEPT under a deliberately wrong configuration. See
+    docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md.
     """
     newest_in_region = (
         select(func.max(_ContractWatermark.last_seen_at))
@@ -85,7 +100,48 @@ def still_listed_by_esi():
         .correlate(Contract)
         .scalar_subquery()
     )
-    return or_(Contract.last_seen_at.is_(None), Contract.last_seen_at >= newest_in_region)
+    unstamped_or_current = or_(
+        Contract.last_seen_at.is_(None), Contract.last_seen_at >= newest_in_region
+    )
+
+    ingested_region_ids = get_settings().AGGREGATION_REGION_IDS
+    if not ingested_region_ids:
+        return unstamped_or_current
+
+    at_a_known_regions_watermark = or_(
+        *[
+            and_(
+                Contract.start_location_region_id == region_id,
+                Contract.last_seen_at >= _newest_in(region_id),
+            )
+            for region_id in ingested_region_ids
+        ]
+    )
+    return or_(
+        Contract.last_seen_at.is_(None),
+        case(
+            (
+                Contract.start_location_region_id.in_(ingested_region_ids),
+                at_a_known_regions_watermark,
+            ),
+            else_=Contract.last_seen_at >= newest_in_region,
+        ),
+    )
+
+
+def _newest_in(region_id: int):
+    """The newest ingestion stamp in one named region, as an uncorrelated subquery.
+
+    Uncorrelated is the whole point: with the region a literal rather than a reference to
+    the outer row, PostgreSQL hoists this to an InitPlan and runs it once per query — an
+    index-only probe on ix_contracts_region_last_seen — instead of once per candidate row.
+    """
+    watermark_source = aliased(Contract)
+    return (
+        select(func.max(watermark_source.last_seen_at))
+        .where(watermark_source.start_location_region_id == region_id)
+        .scalar_subquery()
+    )
 
 
 def _has_blueprint_copy_item():

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -500,6 +500,24 @@ DELISTED_REGION_A = 99999911
 DELISTED_REGION_B = 99999912
 
 
+# The predicate has two branches that must agree. A region named in
+# AGGREGATION_REGION_IDS is judged by an UNCORRELATED per-region watermark, evaluated
+# once per query; any other region falls back to the correlated form. Configuration is an
+# optimization hint, so every delisting case below runs under both branches and must give
+# the same answer. Without this parametrisation the fast branch has no coverage at all —
+# the default config names only The Forge, and these fixtures use two private region ids.
+@pytest.fixture(params=["region-configured", "region-not-configured"])
+def liveness_branch(request, monkeypatch):
+    """Run a delisting case under the fast branch and the fallback branch alike."""
+    configured = (
+        [DELISTED_REGION_A, DELISTED_REGION_B] if request.param == "region-configured" else []
+    )
+    monkeypatch.setattr(
+        contract_service.get_settings(), "AGGREGATION_REGION_IDS", configured
+    )
+    return request.param
+
+
 def _seen_contract(contract_id: int, *, region: int, seen: datetime | None) -> Contract:
     now = datetime.now(timezone.utc)
     return Contract(
@@ -521,7 +539,7 @@ def _seen_contract(contract_id: int, *, region: int, seen: datetime | None) -> C
     )
 
 
-async def test_contracts_missing_from_the_latest_run_are_excluded(db_session: AsyncSession):
+async def test_contracts_missing_from_the_latest_run_are_excluded(db_session: AsyncSession, liveness_branch):
     """A contract not restamped by the most recent run for its region was not in ESI's
     public list any more — sold or withdrawn — so it must stop being offered."""
     latest = datetime.now(timezone.utc)
@@ -539,7 +557,7 @@ async def test_contracts_missing_from_the_latest_run_are_excluded(db_session: As
     assert result.total == 2
 
 
-async def test_a_region_whose_run_failed_keeps_all_its_contracts(db_session: AsyncSession):
+async def test_a_region_whose_run_failed_keeps_all_its_contracts(db_session: AsyncSession, liveness_branch):
     """THE case that can take the site down. Region A refreshed; region B's fetch failed,
     so nothing in B was restamped. B's contracts must all remain visible — judging them
     against A's newer watermark would erase an entire region at once."""
@@ -560,7 +578,7 @@ async def test_a_region_whose_run_failed_keeps_all_its_contracts(db_session: Asy
     assert result.total == 3
 
 
-async def test_never_stamped_contracts_stay_visible(db_session: AsyncSession):
+async def test_never_stamped_contracts_stay_visible(db_session: AsyncSession, liveness_branch):
     """Rows predating the last_seen_at column carry NULL. Treating NULL as 'not in the
     latest run' would blank the entire site between the migration and the first run —
     the migration backfills, and this pins the belt-and-braces behaviour besides."""

--- a/app/frontend/web/package-lock.json
+++ b/app/frontend/web/package-lock.json
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -690,29 +690,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -980,9 +957,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -991,7 +968,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -2132,16 +2109,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2706,9 +2683,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3551,9 +3528,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3625,9 +3602,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4686,9 +4663,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -5235,9 +5212,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -5626,9 +5603,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5645,7 +5622,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6567,9 +6544,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/design/user-feedback/2026-08-01-capital-ship-order-workflow.md
+++ b/design/user-feedback/2026-08-01-capital-ship-order-workflow.md
@@ -1,11 +1,11 @@
 <!-- ABOUTME: The only direct user feedback Hangar Bay has received — an EVE capital-ship builder describing a -->
-<!-- ABOUTME: build-to-order workflow, with technical assessment of his suggestions and the questions sent back. -->
+<!-- ABOUTME: build-to-order workflow, with technical assessment, the questions sent back, and his answers. -->
 
 # User feedback: a capital-ship builder
 
 **Received:** before 2026-08-01 (relayed 2026-08-01)
 **Source:** direct conversation, in response to Sam asking "would anyone even plausibly use this?"
-**Status:** follow-up questions sent 2026-08-02; awaiting reply
+**Status:** answers received 2026-08-06; recorded and assessed below
 
 ## Why this document exists
 
@@ -87,6 +87,31 @@ Two things he did not mention:
 
 **Q2 and Q3 test whether the pain is real.** Three orders a month in a spreadsheet does not need a web application.
 
+## Answers received (2026-08-06)
+
+Relayed by Sam; his words verbatim apart from bolded question summaries.
+
+1. **Still building and selling caps? Alliance still who'd be ordering?** — "No and yes, respectively."
+2. **How an order works today; which part annoys most?** — "Someone pings us on discord and says 'I want an X please'. We convey price, they agree and send a deposit, we build it and contract it to them when done. Could easily be turned into an order form interface with zero discussion."
+3. **Orders per month, people placing them?** — "In our hayday we were probably doing 30-40/mo across 15-20 people."
+4. **Would you use a ME/TE/runs-filtered contract browser to source capital component BPCs?** — "It would be handy but is a nice to have. We own BPOs for virtually all hulls and only need to buy BPCs for select supercaps or faction caps."
+5. **Corp-wallet deposit tracking needs an Accountant sign-off — realistic?** — "Completely fine, realistic."
+6. **Handover at station or citadel?** — "For our immediate need, low sec NPC station. For a holistic solution it should support citadels too. Null sec groups live out of citadels almost exclusively."
+
+### What the answers change
+
+**Q4 came back "nice to have" — the directions do not converge.** By this document's own decision rule, that is the no branch: the order system and F008's blueprint surface are two products competing for the same time, and the choice must now be made deliberately. His reason generalizes beyond one alliance: an established builder owns BPOs for virtually every hull and buys BPCs only for select supercaps or faction caps. If that holds broadly, the audience for a BPC-sourcing surface is newer or occasional builders — a segment nobody has spoken to — not established shops.
+
+**The demand evidence is now retrospective, with one contradiction worth resolving.** Q1 says he is no longer building and selling caps, and Q3's volume figures are explicitly peak-era ("in our hayday") — 30-40 orders a month across 15-20 buyers. At peak, that volume across that many buyers comfortably clears the does-this-need-a-web-application bar this document set. But it describes a dormant operation — except that Q6 answers in the present tense about "our immediate need," which reads like a live plan. Whether the operation is restarting, and whether tooling matters to that decision, is the open follow-up.
+
+**The product shape is validated in his own words.** Today's flow — Discord ping, price conveyed, agreement, deposit, build, contract on completion — maps step-for-step onto the order-form flow sketched above, and his unprompted conclusion was that it "could easily be turned into an order form interface with zero discussion." The pain is the manual negotiation loop, not any individual step.
+
+**Q5 clears the design-killer.** Corp-wallet read access with an Accountant/Director authorization is "completely fine, realistic." Automatic deposit verification via the wallet journal survives.
+
+**Q6 bounds an MVP.** Immediate need is handover at a low-sec NPC station: public ESI resolves it, no structure ACLs involved. Citadel support — `esi-universe.read_structures.v1`, docking ACLs, and the ~9–10% unresolvable-structure rate measured in the [courier spike](../../docs/superpowers/specs/2026-08-01-courier-route-jumps-spike.md) — is required for a general product because null-sec groups live almost exclusively in citadels, but it is not on the critical path for this alliance.
+
 ## What this does not establish
 
 One player in one alliance is not product-market fit, and this feedback predates its relay by an unknown interval. It is recorded because it is the only signal of its kind, not because it settles anything.
+
+The answers sharpen rather than soften that caution: the one prospective user's operation is currently dormant, so even the order-system direction rests on a workflow that worked in the past plus a stated intent, not on active present-day pain.

--- a/docs/git-strategy.md
+++ b/docs/git-strategy.md
@@ -437,7 +437,14 @@ Therefore: **confirm all checks have concluded successfully, then merge explicit
 # ALWAYS --merge. NEVER --squash. NEVER --rebase.
 # Full history preserved on dev; squash destroys the per-commit trail
 # agents and users both rely on for bisecting.
-gh pr merge <number> --merge --delete-branch
+#
+# --body "" is REQUIRED, and is not cosmetic. GitHub writes the PR title into
+# every merge commit's message, release-please parses merge commits, and the
+# result is two changelog entries per PR — the real commit and its merge
+# commit. Clearing the body makes the merge commit non-conventional so it is
+# skipped. No repository setting can fix this: GitHub allows only three
+# title/message combinations and all three carry the PR title.
+gh pr merge <number> --merge --delete-branch --body ""
 
 # Then in the root checkout:
 cd <repo-root>
@@ -598,11 +605,16 @@ gh pr create --base main --head dev \
     --body  "<publication-quality body>"
 
 # Wait for CI; merge with the standard mechanic:
-gh pr merge <number> --merge --delete-branch=false
+gh pr merge <number> --merge --delete-branch=false --body ""
 #   --delete-branch=false: dev is the persistent integration branch,
 #   NOT ephemeral. The dev → main PR merges integration
 #   history into release but does NOT delete dev — work continues on
-#   dev for the next publication cycle.
+#   dev for the next publication cycle. The repository now has
+#   delete_branch_on_merge enabled, so this flag is what makes the
+#   intent explicit; dev is additionally protected as the default
+#   branch and by a deletion rule, so it cannot be removed either way.
+#   --body "": same reason as §Mechanics — keeps the merge commit out
+#   of the generated changelog.
 ```
 
 The `--delete-branch=false` flag is the one explicit deviation from §Mechanics for auto-merge. The rest of the merge discipline (always `--merge`, never `--squash` or `--rebase`; preserve full per-commit history; `gh pr merge` rather than the GitHub UI) applies identically.

--- a/docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md
+++ b/docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md
@@ -3,7 +3,9 @@
 
 # The unfiltered contract list takes 6 seconds (2026-08-02)
 
-**Status:** root cause confirmed against production; design chosen; awaiting review.
+**Status:** root cause confirmed against production; **first design proposed here was rejected
+by review and replaced** (§5); replacement implemented and measured. See §8 for what the
+reviews changed, and §9 for what remains open.
 
 **Symptom that surfaced it:** the post-deploy live smoke against production failed on
 `e2e/live-smoke.spec.ts:71` — "pagination crosses a real page boundary when the dataset has
@@ -33,7 +35,7 @@ SubPlan 2 -> ... Index Only Scan Backward using ix_contracts_region_last_seen
              Index Searches: 61874
 ```
 
-61,874 executions × 0.081 ms ≈ **5.0 s of the 6.0 s**. That subplan is the per-region
+61,874 executions × 0.075 ms ≈ **4.6 s of the 6.0 s**. That subplan is the per-region
 watermark in `still_listed_by_esi()` — `last_seen_at >= (SELECT max(last_seen_at) FROM
 contracts WHERE region = outer.region)` — which PostgreSQL evaluates once per candidate
 row because it is correlated.
@@ -59,14 +61,18 @@ Three plausible explanations were tested and eliminated, each with direct eviden
   and `contract_items`, a 34 MB heap, and an autovacuum at 06:30:25Z. The count plan shows
   227,590 shared **hits** and zero reads — the working set is entirely in cache. This was
   the leading hypothesis (ingestion restamps `last_seen_at` on every row every few minutes,
-  which looks like a bloat generator) and it is wrong.
+  which looks like a bloat generator) and the evidence does not support it. Stated
+  precisely, since review pushed back on the original wording: `n_dead_tup` is an estimate
+  of *currently* dead tuples and buffer hits prove residency rather than compactness, so
+  this rules bloat out as the *dominant* cost — which the third bullet establishes
+  independently — rather than proving the heap is perfectly compact.
 - **Not scan cost.** Two queries filtering the *unindexed* `start_location_id` force the
   same scan but differ in how many rows survive to the watermark predicate:
   `station_ids=1` (matches nothing) returns in **0.6 s**; `station_ids=60003760` (Jita 4-4,
   30,867 rows) takes **6.1 s**. Same scan, 10× the time, and the only variable is how many
   rows reach the subplan.
 
-## 3. It is a regression, and it crossed the test's threshold today
+## 3. It got worse over time and crossed the test's threshold today
 
 `still_listed_by_esi()` arrived in `4b9957f` ("fix(api): stop watchlist alerts outliving a
 contract's purchase"), which was **not** in the previous production release (`7a95118`) and
@@ -79,13 +85,19 @@ production logs:
 | 2026-08-02 06:07 | `fe43bda` (watermark predicate) | 3,182 ms / 3,045 ms |
 | 2026-08-02 06:35+ | `0edea19` (code-identical to `fe43bda`) | 5,338–10,007 ms |
 
-Two things are true at once and both matter:
+**Do not read that table as proof the release caused it.** Review was right to flag the
+original wording here. The predicate-bearing code logged 3.0–3.2 s at 06:07 and the
+*code-identical* commit logged 5.3–10.0 s half an hour later, so something other than the
+predicate moved between those rows — corpus growth and a 06:30:25Z autovacuum/analyze are
+both candidates, and no controlled with/without comparison on one snapshot was ever run. The
+honest claims are narrower:
 
 1. **The unfiltered path was already slow before this release** — 3–4 s — so the watermark
-   predicate did not create the problem, it enlarged one that was already one bad day away
-   from the 5 s assertion budget.
-2. **The corpus grew.** 76,599 rows now, of which 34,116 are live. The predicate's cost is
-   linear in rows examined, so this gets worse on its own schedule regardless of releases.
+   predicate did not create the problem.
+2. **The predicate is nonetheless the dominant cost now**, which §1 and §2 establish
+   directly from the plan rather than from the history.
+3. **The cost is linear in rows examined**, and the corpus is at 76,599 rows / 34,116 live,
+   so it worsens on its own schedule regardless of releases.
 
 The smoke test passed on 2026-07-27 at 8.4 s of test time and on 2026-08-02 06:07 at 7.2 s.
 It is not a flake that started failing; it is a threshold that was always going to be
@@ -94,9 +106,13 @@ crossed. Raising the timeout would hide the next crossing rather than the curren
 ## 4. Candidates measured against production
 
 Every candidate below was run against the live database with `EXPLAIN (ANALYZE)` and
-checked for set equality against the current predicate. **All candidates that returned
-selected identically** (34,109–34,111 contracts, varying only because ingestion ran between
-measurements).
+checked for set equality against the current predicate. All of them selected identically
+(34,101–34,111 contracts, varying between runs only because ingestion kept committing).
+
+**Those equality checks are weaker evidence than they look**, and review said so: they are
+two counts taken seconds apart on a moving dataset, not a set comparison. Only the chosen
+design (§5) is backed by a both-way `EXCEPT` inside a single snapshot. Treat this table as
+a *performance* comparison; the correctness argument lives in §5.
 
 | Candidate | Unfiltered COUNT | Unfiltered PAGE | Ships COUNT | Ships PAGE |
 |---|---|---|---|---|
@@ -127,78 +143,104 @@ SELECT max(last_seen_at) FROM contracts WHERE start_location_region_id = 1000000
 ```
 
 So the whole problem reduces to one question: **how do we learn the region ids without
-scanning the contracts table?** Everything expensive above is expensive only because it
-answers that question by scanning.
+scanning the contracts table?** Every *candidate rewrite* above is expensive only because it
+answers that question by scanning. (Note the precise claim: the **current** query is slow
+because it repeats a cheap one-row probe 61,874 times, not because anything scans to
+discover regions. Those are two different costs and an earlier draft of this document
+conflated them.)
 
 The `NOT EXISTS` anti-join deserves its own note: it reads as the most natural rewrite
 ("no contract in my region carries a newer stamp"), it is semantically identical, and it is
 catastrophic — the inequality join defeats hashing and the planner produced something that
 had not finished after five minutes. It is recorded here so nobody re-proposes it.
 
-## 5. The design: a maintained per-region watermark
+## 5. The design: configured regions as an optimization hint
 
-Ingestion already knows the answer. `_build_contract_rows` stamps **one `seen_at` for the
-whole run** (its docstring says so explicitly: "a contract is judged present by matching the
-newest stamp in its region, which only works if one run writes one value"), and
-`_fetch_regions` already tracks which regions succeeded. The read path is recomputing, at
-1,000× the cost, a value the write path had in hand.
+**This replaces an earlier proposal in this document — a maintained `contract_region_watermarks`
+table written by ingestion — which two independent reviews rejected and a measurement
+confirmed was also slower. §8 records why, because the reasons generalize.**
 
-**Add a `contract_region_watermarks` table** — one row per region, `region_id` primary key,
-`last_seen_at` — upserted by the aggregation run inside the same transaction as the contract
-upsert, for each region it successfully fetched.
+The shipped change keeps `still_listed_by_esi()` a standalone boolean expression and changes
+nothing about what it means. It only changes *how PostgreSQL is asked to compute it*:
 
-`still_listed_by_esi()` keeps its exact shape and stays a single boolean expression usable
-from both call sites (the contract service and the watchlist matcher). Only the source of
-the watermark changes: a correlated lookup against a table of ≤5 rows resolved by primary
-key, instead of an aggregate over 76,599 rows.
+```python
+case(
+    (Contract.start_location_region_id.in_(ingested_region_ids),
+     # fast path: one UNCORRELATED subquery per configured region, hoisted to an
+     # InitPlan and evaluated once for the whole query
+     or_(*[and_(Contract.start_location_region_id == r,
+                Contract.last_seen_at >= _newest_in(r)) for r in ingested_region_ids])),
+    # fallback: exactly today's correlated predicate, for any other region
+    else_=Contract.last_seen_at >= newest_in_region,
+)
+```
 
-Why this and not the alternatives:
+`AGGREGATION_REGION_IDS` is an **optimization hint, never a semantic input.** The `case`
+guarantees that a row whose region is not configured is judged by precisely the predicate
+that judges it today. Configuration drift changes which rows take the fast path; it cannot
+change which rows are visible.
 
-- **vs. any query-time derivation** — it is the only option that is fast on *both* the
-  selective and the broad path, because it removes the scan rather than relocating it.
-- **vs. reading `AGGREGATION_REGION_IDS` from settings** — that also gives a cheap region
-  list, but it couples the read path to a config value that can drift from the data. A
-  region dropped from the config leaves its contracts in the table with no watermark; a
-  maintained table simply keeps the last one it wrote.
-- **vs. caching the watermark in Valkey** — no schema change, but it puts a TTL between the
-  data and a *visibility* predicate. Contracts already sold would keep being offered for the
-  length of the TTL, and the cache becomes a correctness dependency for a path that has none
-  today.
-- **vs. upsizing the database** — `basic_256mb` is genuinely small and this would get
-  cheaper on a bigger plan, but 61,874 redundant evaluations of a constant is a defect at
-  any instance size, and the corpus grows.
+That property is the whole point, and it is what makes this safe to ship without a
+behaviour decision. It was verified against the production corpus, not argued:
 
-### Failure behaviour, chosen deliberately
+```
+-- both-way EXCEPT, single snapshot, correct config
+current_rows | new_rows | lost | gained
+      34,100 |   34,100 |    0 |      0
 
-- **No watermark row for a region ⇒ its contracts are visible.** The predicate must treat a
-  missing watermark as "show it", matching the existing rule that a NULL `last_seen_at` is
-  visible. The opposite default would blank the site in the window between deploying the
-  migration and the first ingestion run.
-- **The watermark write shares the contract upsert's transaction**, so the table can never
-  be ahead of the rows it describes. A watermark ahead of its contracts would hide every
-  contract in the region at once; a watermark behind them merely keeps sold contracts
-  visible a little longer, which is the failure this codebase already prefers (see
-  `still_listed_by_esi`'s docstring on missed alerts vs. dead listings).
-- **The migration backfills** from `SELECT region, max(last_seen_at) ... GROUP BY region` so
-  there is no window with an empty table. That backfill costs ~600 ms, once.
+-- same, with a DELIBERATELY WRONG config (the real region omitted)
+drift_hidden | drift_shown
+           0 |           0
+```
+
+### Measured on production
+
+| Path | Before | After |
+|---|---|---|
+| Unfiltered COUNT | 6,022 ms | **1,565 ms** |
+| Unfiltered PAGE | 0.5 ms | **0.155 ms** |
+| Ships-only COUNT | 8.4 ms | 64 ms |
+| Ships-only PAGE | 60.6 ms | ~63 ms |
+
+The unfiltered list — the path that failed the smoke test and the path F008 turns into the
+main one — goes from ~6.0 s to ~1.6 s, roughly a quarter of the 5 s assertion budget. The
+page query keeps its early exit, which every "compute once" candidate in §4 destroyed
+(0.5 ms → 264–372 ms). The default ships-only view moves by tens of milliseconds inside a
+request that is ~400 ms end to end; the numbers on this instance vary by more than that
+between runs.
+
+### Why not the alternatives
+
+- **vs. the rejected watermark table** — measured *slower* (1,270 ms vs 1,565 ms is within
+  noise, but the table's correlated PK lookup still re-executes ~61,874 times, which is the
+  very mechanism being fixed), and it costs a migration, an ingestion write, a second source
+  of truth, and the failure modes in §8.
+- **vs. using the uncorrelated form only for the broad count** (codex's first suggestion) —
+  it works, but it makes the liveness rule two expressions that must be kept in agreement.
+  The hint-with-fallback shape gets the same win with one expression.
+- **vs. "unconfigured region ⇒ visible"** — a simpler predicate, measured at 861 ms, but it
+  makes configuration a *semantic* input: dropping a region from the config would change
+  visibility. Rejected for that reason alone, despite being the faster option.
+- **vs. upsizing the database** — `basic_256mb` is genuinely small and everything here would
+  get cheaper on a bigger plan. Still worth considering (§9), but 61,874 redundant
+  evaluations of a constant is a defect at any instance size.
 
 ### What this does not fix
 
-Even with the predicate free, the unfiltered count still scans and de-duplicates ~34,000
-rows, which measured **663 ms** in the closest equivalent shape. That is acceptable and
-under the assertion budget, but it is not fast, and it is the number that will grow with the
-corpus. Two follow-ups are worth their own decisions, neither taken here:
+The unfiltered count still scans and de-duplicates ~34,000 rows. Two follow-ups, neither
+taken here:
 
-1. **The `DISTINCT` wrapper in `_count_distinct_contracts` is a no-op on the no-join path**
-   and measurably expensive (1,304 ms → 663 ms in the tuple-`IN` shape; ~100 ms in the
-   current shape). `contract_id` is the primary key, so without an item join no duplicates
-   are possible. Removing it conditionally is safe but is a separate change with its own
-   test obligations.
-2. **F008 makes this the main path.** Type-aware browsing is precisely about making the
-   ~98.8% of contracts that are not ships a designed surface, which turns today's secondary
-   6-second path into the primary one. Whatever is decided about exact counts at corpus
-   scale — cached totals, approximate counts above a threshold, or keyset pagination —
-   belongs in the F008 plan rather than here.
+1. **The `DISTINCT` wrapper in `_count_distinct_contracts` is a no-op on the no-join path.**
+   `contract_id` is the primary key, so without an item join no duplicates are possible.
+   Both reviews independently said to do it, and one argued for doing it in this change.
+   It is deferred only to keep this diff to a single mechanism; it needs its own test that
+   the joined path still de-duplicates (SQLA-1).
+2. **`_count_unknown_system_excluded` applies the same predicate a third time.** When
+   `system_ids` is set, the endpoint pays the count twice — once for the user's filter and
+   once for a residual over an *unindexed* column — and it runs before the `total == 0`
+   short-circuit. Neither review's author nor this document's original draft spotted this;
+   it means "All Contracts + a system filter" was roughly double the headline 6 s. The fast
+   path helps it equally, but it deserves its own look.
 
 ## 6. Reproduction
 
@@ -224,3 +266,69 @@ literal after seeding.
 - Predicate introduced in `4b9957f`; first reached production in the `0.2.0` release.
 - Production plans, equivalence checks, and per-candidate timings: §1 and §4 above, all from
   `EXPLAIN (ANALYZE)` against `dpg-d9fj14btqb8s73d71r10-a` on 2026-08-02.
+
+## 8. What the reviews changed
+
+The design in §5 is the second one. The first — a `contract_region_watermarks` table
+(`region_id` PK, `last_seen_at`) upserted by ingestion in the contract-upsert transaction and
+read through a correlated primary-key lookup — was reviewed independently by an Opus agent
+and by codex, and both rejected it. Recorded because the failure modes generalize to any
+"denormalize a derived value into a side table" proposal in this codebase.
+
+**Two ways it would have taken the site down.**
+
+1. **"Write a watermark for each region successfully fetched" is not the same set as
+   "regions whose contracts were restamped."** `get_public_contracts` returns an empty list
+   *without raising* for a 404, a 204, and — the reachable one — a 304 whose cached body has
+   been evicted from Valkey. That cache is `allkeys-lru` by design (DEPLOY-3), so eviction is
+   expected. `_fetch_regions` counts all of those as `regions_ok`. Advancing a watermark for
+   a region where nothing was restamped hides **every contract in that region**; with a
+   single configured region, that is the whole site, silently.
+2. **"The predicate keeps its exact shape" contradicts "a missing watermark row means
+   visible."** A correlated scalar subquery over a table with no matching row returns SQL
+   NULL, and `last_seen_at >= NULL` is NULL, which `WHERE` rejects. Missing watermark would
+   have meant *hidden* — the exact inverse of the stated intent, and reachable on every dev
+   boot, since the dev startup path drops and recreates all tables (ENV-2/ENV-3).
+
+**A claim in the first draft was simply false.** It asserted `_fetch_regions` "already tracks
+which regions succeeded"; it returns `tuple[List[dict], int, int]` — a flattened contract
+list and two counters. Both reviewers caught it independently. The lesson is the one already
+in this repo's memory: open the function before writing "X already does Y" into a durable
+artifact.
+
+**And the proposal was never measured.** Both reviews noted the projected win was
+extrapolated from a *different* plan shape. Measuring it (`C5` in the working notes) put the
+correlated PK lookup at **1,270 ms** — no better than the far simpler §5 change, because it
+still re-executes ~61,874 times. The mechanism being fixed is the repetition, not the cost of
+each probe, and a smaller table does not remove repetition.
+
+**The chosen design came out of the reviews, not the original analysis.** Both independently
+proposed some form of "use the configured regions without letting configuration decide
+visibility"; codex's phrasing — configured region ids as an optimization hint with the
+existing predicate as the `ELSE` fallback — is what shipped. The original document had
+dismissed the config-based option in a single line about coupling; that dismissal was wrong,
+because the coupling it feared is exactly what the `case` fallback removes.
+
+**Other findings applied to this document:** the equality checks in §4 were counts on a
+moving dataset rather than set comparisons (§4 now says so, and §5 carries a real `EXCEPT`);
+the release-regression claim was overstated (§3 rewritten); the `n_dead_tup` argument proved
+less than claimed (§2 narrowed); the arithmetic used 0.081 ms where the plan says 0.075 ms
+(§1 corrected); and `_count_unknown_system_excluded` is a third application of the predicate
+that nothing in the original draft mentioned (§5, "What this does not fix").
+
+## 9. Open items
+
+- **Remove the temporary IP allow rule** on `hangar-bay-db` — `198.37.143.189/32`,
+  described "temp troubleshooting 2026-08-02 - REMOVE". It was added with explicit
+  authorization to run the production `EXPLAIN`s above, and the Render API key stopped
+  authenticating before it could be reverted. The allow list was empty before.
+- **Drop the `DISTINCT` wrapper on the no-join count path** (§5). Safe, measured, and both
+  reviews asked for it.
+- **Look at `_count_unknown_system_excluded`** — a third execution of the predicate, over an
+  unindexed column, ahead of the `total == 0` short-circuit.
+- **Decide whether `basic_256mb` is the right plan.** A per-execution cost of 0.075 ms for a
+  fully-cached three-level index probe is CPU starvation, not a query defect. Everything here
+  is ~100× slower than the same shapes on a laptop.
+- **Exact counts at corpus scale belong to the F008 plan.** F008 makes the unfiltered list
+  the primary surface, so cached totals, approximate counts above a threshold, or keyset
+  pagination should be decided there rather than bolted on here.

--- a/docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md
+++ b/docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md
@@ -1,0 +1,226 @@
+<!-- ABOUTME: Root-cause investigation of the 6-second unfiltered contract list in production, -->
+<!-- ABOUTME: the five candidate rewrites measured against the live database, and the design chosen. -->
+
+# The unfiltered contract list takes 6 seconds (2026-08-02)
+
+**Status:** root cause confirmed against production; design chosen; awaiting review.
+
+**Symptom that surfaced it:** the post-deploy live smoke against production failed on
+`e2e/live-smoke.spec.ts:71` — "pagination crosses a real page boundary when the dataset has
+one" — in Deploy run
+[30735956450](https://github.com/scarson/hangar-bay/actions/runs/30735956450). The
+assertion that timed out is `announcedTotal()`, which waits 5 s for the polite live region
+to publish "N contracts match". The region only fills once the list query resolves, so the
+failure is a latency failure wearing an assertion's clothes.
+
+## 1. What is actually slow
+
+The `/contracts/` list endpoint issues two queries per request: an exact `total` count over
+every matching row, and a page fetch of 50 rows. Measured on the production database
+(`dpg-d9fj14btqb8s73d71r10-a`, plan `basic_256mb`, PostgreSQL 18) with `EXPLAIN (ANALYZE)`:
+
+| Query | Unfiltered ("All Contracts") | Ships-only (the default view) |
+|---|---|---|
+| COUNT | **6,022 ms** | 8.4 ms |
+| PAGE | 0.5 ms | 60.6 ms |
+
+The count is the entire problem, and only on the unfiltered path. Within that count plan,
+the cost is one node:
+
+```
+SubPlan 2 -> ... Index Only Scan Backward using ix_contracts_region_last_seen
+             (actual time=0.075..0.075 rows=1 loops=61874)
+             Index Searches: 61874
+```
+
+61,874 executions × 0.081 ms ≈ **5.0 s of the 6.0 s**. That subplan is the per-region
+watermark in `still_listed_by_esi()` — `last_seen_at >= (SELECT max(last_seen_at) FROM
+contracts WHERE region = outer.region)` — which PostgreSQL evaluates once per candidate
+row because it is correlated.
+
+Production currently ingests exactly one region (`AGGREGATION_REGION_IDS` defaults to
+`[10000002]`, The Forge), so those 61,874 executions all recompute **the same single
+value**.
+
+### Why the ships-only path is fine
+
+`is_ship_contract = true` selects 426 of 34,116 live contracts through
+`ix_contracts_is_ship_contract`, so only ~424 rows ever reach the subplan. The cost of the
+predicate is proportional to the number of rows that reach it, not to the corpus.
+
+## 2. What it is not
+
+Three plausible explanations were tested and eliminated, each with direct evidence:
+
+- **Not the network, the proxy, or serialization.** The `duration_ms` that
+  `contract_search_executed` logs is measured inside `get_contracts()`, and it tracks the
+  wall-clock TTFB (6,469 ms logged against a 6.5 s curl). `size=1` is as slow as `size=50`.
+- **Not table bloat.** `pg_stat_user_tables` reports `n_dead_tup = 0` for both `contracts`
+  and `contract_items`, a 34 MB heap, and an autovacuum at 06:30:25Z. The count plan shows
+  227,590 shared **hits** and zero reads — the working set is entirely in cache. This was
+  the leading hypothesis (ingestion restamps `last_seen_at` on every row every few minutes,
+  which looks like a bloat generator) and it is wrong.
+- **Not scan cost.** Two queries filtering the *unindexed* `start_location_id` force the
+  same scan but differ in how many rows survive to the watermark predicate:
+  `station_ids=1` (matches nothing) returns in **0.6 s**; `station_ids=60003760` (Jita 4-4,
+  30,867 rows) takes **6.1 s**. Same scan, 10× the time, and the only variable is how many
+  rows reach the subplan.
+
+## 3. It is a regression, and it crossed the test's threshold today
+
+`still_listed_by_esi()` arrived in `4b9957f` ("fix(api): stop watchlist alerts outliving a
+contract's purchase"), which was **not** in the previous production release (`7a95118`) and
+shipped in today's. Server-side `duration_ms` for the same unfiltered query, from the
+production logs:
+
+| When | Release | Unfiltered count |
+|---|---|---|
+| 2026-07-27 08:26 | `7a95118` (no watermark predicate) | 4,235 ms / 3,096 ms |
+| 2026-08-02 06:07 | `fe43bda` (watermark predicate) | 3,182 ms / 3,045 ms |
+| 2026-08-02 06:35+ | `0edea19` (code-identical to `fe43bda`) | 5,338–10,007 ms |
+
+Two things are true at once and both matter:
+
+1. **The unfiltered path was already slow before this release** — 3–4 s — so the watermark
+   predicate did not create the problem, it enlarged one that was already one bad day away
+   from the 5 s assertion budget.
+2. **The corpus grew.** 76,599 rows now, of which 34,116 are live. The predicate's cost is
+   linear in rows examined, so this gets worse on its own schedule regardless of releases.
+
+The smoke test passed on 2026-07-27 at 8.4 s of test time and on 2026-08-02 06:07 at 7.2 s.
+It is not a flake that started failing; it is a threshold that was always going to be
+crossed. Raising the timeout would hide the next crossing rather than the current one.
+
+## 4. Candidates measured against production
+
+Every candidate below was run against the live database with `EXPLAIN (ANALYZE)` and
+checked for set equality against the current predicate. **All candidates that returned
+selected identically** (34,109–34,111 contracts, varying only because ingestion ran between
+measurements).
+
+| Candidate | Unfiltered COUNT | Unfiltered PAGE | Ships COUNT | Ships PAGE |
+|---|---|---|---|---|
+| **Current** — correlated `max()` per row | 6,022 ms | 0.5 ms | 8.4 ms | 60.6 ms |
+| Uncorrelated `(region, last_seen) IN (SELECT region, max(...) GROUP BY region)` | 1,304 ms | 264 ms | 371 ms | 169 ms |
+| …same, without the `DISTINCT` wrapper | 663 ms | 264 ms | — | — |
+| `LEFT JOIN` to a grouped watermark derived table | 1,259 ms | — | — | — |
+| `NOT EXISTS` anti-join ("no newer stamp in my region") | **>5 min** | — | — | — |
+| CTE: per-region `max()` driven by `SELECT DISTINCT region` | 1,132 ms | 367 ms | 499 ms | 372 ms |
+
+Two results decide the design.
+
+**Every "compute the watermark once" rewrite regresses the default view.** The ships-only
+path goes from 69 ms total to 539 ms (tuple-`IN`) or 871 ms (CTE). The reason is structural:
+computing the watermark set costs ~500–600 ms *unconditionally*, because PostgreSQL has to
+scan 76,599 index entries to discover which regions exist — `SELECT DISTINCT
+start_location_region_id` alone measures **602 ms**, and PostgreSQL 18's btree skip scan
+does not kick in here. The correlated form pays per surviving row and so is *cheaper*
+whenever the query is selective. Neither shape wins everywhere, and the default view — the
+one every real user loads — is the selective one. Trading a 7.8× regression on the default
+path for a 6.5× win on a secondary path is a bad trade taken blind.
+
+**A per-region `max()` against a *known* region id is essentially free: 0.073 ms.**
+
+```
+SELECT max(last_seen_at) FROM contracts WHERE start_location_region_id = 10000002;
+-- Execution Time: 0.073 ms  (index probe on ix_contracts_region_last_seen)
+```
+
+So the whole problem reduces to one question: **how do we learn the region ids without
+scanning the contracts table?** Everything expensive above is expensive only because it
+answers that question by scanning.
+
+The `NOT EXISTS` anti-join deserves its own note: it reads as the most natural rewrite
+("no contract in my region carries a newer stamp"), it is semantically identical, and it is
+catastrophic — the inequality join defeats hashing and the planner produced something that
+had not finished after five minutes. It is recorded here so nobody re-proposes it.
+
+## 5. The design: a maintained per-region watermark
+
+Ingestion already knows the answer. `_build_contract_rows` stamps **one `seen_at` for the
+whole run** (its docstring says so explicitly: "a contract is judged present by matching the
+newest stamp in its region, which only works if one run writes one value"), and
+`_fetch_regions` already tracks which regions succeeded. The read path is recomputing, at
+1,000× the cost, a value the write path had in hand.
+
+**Add a `contract_region_watermarks` table** — one row per region, `region_id` primary key,
+`last_seen_at` — upserted by the aggregation run inside the same transaction as the contract
+upsert, for each region it successfully fetched.
+
+`still_listed_by_esi()` keeps its exact shape and stays a single boolean expression usable
+from both call sites (the contract service and the watchlist matcher). Only the source of
+the watermark changes: a correlated lookup against a table of ≤5 rows resolved by primary
+key, instead of an aggregate over 76,599 rows.
+
+Why this and not the alternatives:
+
+- **vs. any query-time derivation** — it is the only option that is fast on *both* the
+  selective and the broad path, because it removes the scan rather than relocating it.
+- **vs. reading `AGGREGATION_REGION_IDS` from settings** — that also gives a cheap region
+  list, but it couples the read path to a config value that can drift from the data. A
+  region dropped from the config leaves its contracts in the table with no watermark; a
+  maintained table simply keeps the last one it wrote.
+- **vs. caching the watermark in Valkey** — no schema change, but it puts a TTL between the
+  data and a *visibility* predicate. Contracts already sold would keep being offered for the
+  length of the TTL, and the cache becomes a correctness dependency for a path that has none
+  today.
+- **vs. upsizing the database** — `basic_256mb` is genuinely small and this would get
+  cheaper on a bigger plan, but 61,874 redundant evaluations of a constant is a defect at
+  any instance size, and the corpus grows.
+
+### Failure behaviour, chosen deliberately
+
+- **No watermark row for a region ⇒ its contracts are visible.** The predicate must treat a
+  missing watermark as "show it", matching the existing rule that a NULL `last_seen_at` is
+  visible. The opposite default would blank the site in the window between deploying the
+  migration and the first ingestion run.
+- **The watermark write shares the contract upsert's transaction**, so the table can never
+  be ahead of the rows it describes. A watermark ahead of its contracts would hide every
+  contract in the region at once; a watermark behind them merely keeps sold contracts
+  visible a little longer, which is the failure this codebase already prefers (see
+  `still_listed_by_esi`'s docstring on missed alerts vs. dead listings).
+- **The migration backfills** from `SELECT region, max(last_seen_at) ... GROUP BY region` so
+  there is no window with an empty table. That backfill costs ~600 ms, once.
+
+### What this does not fix
+
+Even with the predicate free, the unfiltered count still scans and de-duplicates ~34,000
+rows, which measured **663 ms** in the closest equivalent shape. That is acceptable and
+under the assertion budget, but it is not fast, and it is the number that will grow with the
+corpus. Two follow-ups are worth their own decisions, neither taken here:
+
+1. **The `DISTINCT` wrapper in `_count_distinct_contracts` is a no-op on the no-join path**
+   and measurably expensive (1,304 ms → 663 ms in the tuple-`IN` shape; ~100 ms in the
+   current shape). `contract_id` is the primary key, so without an item join no duplicates
+   are possible. Removing it conditionally is safe but is a separate change with its own
+   test obligations.
+2. **F008 makes this the main path.** Type-aware browsing is precisely about making the
+   ~98.8% of contracts that are not ships a designed surface, which turns today's secondary
+   6-second path into the primary one. Whatever is decided about exact counts at corpus
+   scale — cached totals, approximate counts above a threshold, or keyset pagination —
+   belongs in the F008 plan rather than here.
+
+## 6. Reproduction
+
+The production measurements need the requesting IP on the database's allow list. A local
+scale model that reproduces the *plan shape* (though not the absolute timings — a laptop is
+~100× faster than `basic_256mb` here) is:
+
+```bash
+docker exec hangar_bay_postgres psql -U hangar_bay_user -d postgres -c "CREATE DATABASE hangar_bay_perf"
+# seed 34k live + 17k expired contracts in 5 regions, then compare plans
+```
+
+The trap worth recording: seeding the corpus with two separate `INSERT` statements gives the
+two batches **different `now()` values**, because `now()` is transaction time. Every live row
+then fails the watermark predicate, all the plans short-circuit to zero rows, and the
+measurements are meaningless while looking plausible. Normalize `last_seen_at` to a single
+literal after seeding.
+
+## 7. Evidence index
+
+- Failing CI run: Deploy [30735956450](https://github.com/scarson/hangar-bay/actions/runs/30735956450), job `smoke`.
+- Passing prior run on the code-identical predecessor: Deploy [30735261942](https://github.com/scarson/hangar-bay/actions/runs/30735261942) (pagination test 7.2 s).
+- Predicate introduced in `4b9957f`; first reached production in the `0.2.0` release.
+- Production plans, equivalence checks, and per-candidate timings: §1 and §4 above, all from
+  `EXPLAIN (ANALYZE)` against `dpg-d9fj14btqb8s73d71r10-a` on 2026-08-02.

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -30,7 +30,7 @@ This document serves three audiences. Start here, then go directly to the sectio
 | 2 | [Data & Persistence](#section-2-data--persistence) | SQLAlchemy queries, pagination over joins | SQLA-1, SQLA-2, SQLA-3 | §2.C |
 | 3 | [Environment & Dev Loop](#section-3-environment--dev-loop) | Settings/env loading, startup ingestion, dev-server hygiene | ENV-1, ENV-2, ENV-3, ENV-4, ENV-5, ENV-6, ENV-7, ENV-8, ENV-9, ENV-10 | §3.C |
 | 4 | [External Integrations (ESI)](#section-4-external-integrations-esi) | Calling EVE's ESI API — route versions, deprecations, caching headers, upstream status, spec drift | ESI-1, ESI-2, ESI-3, ESI-4 | §4.C |
-| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3, DEPLOY-4, DEPLOY-5 | §5.C |
+| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3, DEPLOY-4, DEPLOY-5, DEPLOY-6 | §5.C |
 | — | [Orchestration](#orchestration) | Parallel subagent dispatch and output persistence | ORCH-1 | §Orchestration.C |
 | A | [Historical Changelog](#appendix-a-historical-changelog) | Provenance, validation dates, review process meta-observations | — | — |
 | B | [Unified Summary Table](#appendix-b-unified-summary-table) | All pitfalls at a glance, with severity and status | — | — |
@@ -445,6 +445,12 @@ One expression negated makes the branches exact complements *by construction*, i
 
 ---
 
+### DEPLOY-6: Dependabot does not index `pdm.lock` — zero backend alerts is silence, not health
+
+GitHub's Dependabot alerts cover `app/frontend/web/package-lock.json` but not the backend's `pdm.lock`, so the repo's security tab can show zero Python alerts while the lock holds vulnerable pins. On 2026-08-06 a direct OSV audit found nine vulnerable locked versions — four in production scope, including the `cryptography` build backing pyjwt's EVE SSO token validation — none of them surfaced by GitHub. When triaging security posture, audit the backend lock directly: `pdm export -f requirements --without-hashes -o reqs.txt`, then batch-query the OSV API (or run `pip-audit -r`) against the pins. Treat "no Dependabot alerts" as a statement about the npm tree only.
+
+---
+
 ### §5.C — Review Checklist
 
 - [ ] **`DATABASE_URL` reaches the engine driver-qualified** — the Settings validator normalizes `postgresql://`; no code assumes the platform sends `+asyncpg` (DEPLOY-1)
@@ -452,6 +458,7 @@ One expression negated makes the branches exact complements *by construction*, i
 - [ ] **Nothing the app must retain lives in the evicting Valkey** — job stores and other silent-loss durable state stay out of `allkeys-lru` instances; every cross-run lock TTL derives from that job's own interval plus a margin (never equal to the interval, never a standalone constant) and is pinned by a test that reconfigures the interval and asserts the TTL follows (DEPLOY-3)
 - [ ] **Deploys are timed into the post-ingestion idle window, and same-commit redeploys go through the CD workflow's `workflow_dispatch` `sha` input** — a `pre_deploy_failed` ~38s in is the lock_timeout collision signature, not a migration bug (DEPLOY-4)
 - [ ] **`alembic heads` prints exactly one revision** — work split across parallel tasks authored its schema changes as a single migration up front, rather than one per task (DEPLOY-5)
+- [ ] **The backend lock was audited directly (OSV or pip-audit over a `pdm export`), not inferred clean from Dependabot** — Dependabot does not index `pdm.lock`, so its silence covers only the npm tree (DEPLOY-6)
 
 ---
 
@@ -478,6 +485,10 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 ---
 
 # Appendix A: Historical Changelog
+
+## 2026-08-06 — DEPLOY-6 added: Dependabot does not index pdm.lock
+
+- Added DEPLOY-6. Triage of five open Dependabot alerts (all npm, all undici) included a due-diligence OSV audit of the backend lock, which found nine vulnerable pins Dependabot had never surfaced — four in production scope, including the cryptography build backing EVE SSO token validation. All but a plugin-capped pytest advisory were fixed in the same PR; the entry records the blind spot so future triage never reads GitHub's zero as a backend result.
 
 ## 2026-08-02 — DEPLOY-5 added: parallel tasks each authoring a migration break the deploy
 
@@ -606,6 +617,7 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 | DEPLOY-3 | Durable coordination state must not live in an evicting cache | HIGH | VALIDATED | Deployment & Platform |
 | DEPLOY-4 | Pre-deploy migrations collide with in-flight ingestion; redeploy via CD dispatch | MEDIUM | VALIDATED | Deployment & Platform |
 | DEPLOY-5 | Parallel tasks each authoring a migration leave two alembic heads; `upgrade head` aborts the deploy | HIGH | UNIMPLEMENTED | Deployment & Platform |
+| DEPLOY-6 | Dependabot does not index pdm.lock; backend deps need a direct OSV/pip-audit pass | MEDIUM | VALIDATED | Deployment & Platform |
 | ORCH-1 | Analysis Dispatches Must Persist Findings | HIGH | VALIDATED | Orchestration |
 
 Severity levels: `CRITICAL` (production data loss / security), `HIGH` (correctness bug under predictable conditions), `MEDIUM` (correctness bug under edge cases), `LOW` (cleanliness / clarity / dev-loop hazard).

--- a/docs/pitfalls/implementation-pitfalls.md
+++ b/docs/pitfalls/implementation-pitfalls.md
@@ -30,7 +30,7 @@ This document serves three audiences. Start here, then go directly to the sectio
 | 2 | [Data & Persistence](#section-2-data--persistence) | SQLAlchemy queries, pagination over joins | SQLA-1, SQLA-2, SQLA-3 | §2.C |
 | 3 | [Environment & Dev Loop](#section-3-environment--dev-loop) | Settings/env loading, startup ingestion, dev-server hygiene | ENV-1, ENV-2, ENV-3, ENV-4, ENV-5, ENV-6, ENV-7, ENV-8, ENV-9, ENV-10 | §3.C |
 | 4 | [External Integrations (ESI)](#section-4-external-integrations-esi) | Calling EVE's ESI API — route versions, deprecations, caching headers, upstream status, spec drift | ESI-1, ESI-2, ESI-3, ESI-4 | §4.C |
-| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3, DEPLOY-4 | §5.C |
+| 5 | [Deployment & Platform](#section-5-deployment--platform) | Production config, managed-platform URLs, process topology | DEPLOY-1, DEPLOY-2, DEPLOY-3, DEPLOY-4, DEPLOY-5 | §5.C |
 | — | [Orchestration](#orchestration) | Parallel subagent dispatch and output persistence | ORCH-1 | §Orchestration.C |
 | A | [Historical Changelog](#appendix-a-historical-changelog) | Provenance, validation dates, review process meta-observations | — | — |
 | B | [Unified Summary Table](#appendix-b-unified-summary-table) | All pitfalls at a glance, with severity and status | — | — |
@@ -433,12 +433,25 @@ One expression negated makes the branches exact complements *by construction*, i
 
 ---
 
+### DEPLOY-5: Two tasks each authoring a migration leave two heads, and `alembic upgrade head` refuses to run
+
+**The Flaw:** `alembic/versions/` is a **linear chain** — every revision names the `down_revision` it was generated against. Two branches that each add a migration against the same parent both claim that parent, so once both are merged the chain has two heads and `alembic upgrade head` aborts with `Multiple head revisions are present for given argument 'head'`.
+
+**Why It Matters:** This is a production failure, not a test failure, and it appears only *after* both branches are merged and green. `alembic upgrade head` is `render.yaml`'s `preDeployCommand`, so the next deploy aborts before the new code starts, leaving the old code serving. Neither branch's CI can catch it: each has exactly one head in isolation. The parallel decomposition that makes a feature fast to build is precisely what produces it.
+
+**The Fix:** **All schema changes for one body of work are ONE migration, authored once, up front** — before the tasks that depend on it are dispatched. Treat `alembic/versions/` as a single-writer resource in any plan that fans work out to parallel agents. If a second head does land, do not hand-edit `down_revision` on a revision that has already been applied anywhere; generate a merge revision (`alembic merge -m "<why>" <head1> <head2>`). Confirm `alembic heads` prints exactly one line before merging anything that touches the directory.
+
+**Where It Bit Us:** Not yet — recorded pre-emptively, which is the point: the first occurrence would be a failed production deploy. Identified while decomposing F008 Type-Aware Contract Browsing, whose natural four-way task split has each task writing its own migration; `design/features/F008-Type-Aware-Contract-Browsing.md` §7.1 ("Single-writer resources — constraints on how the plan may decompose") lists `alembic/versions/` first for this reason. The hazard is general to any multi-task schema work, which is why it belongs here and not only in that spec.
+
+---
+
 ### §5.C — Review Checklist
 
 - [ ] **`DATABASE_URL` reaches the engine driver-qualified** — the Settings validator normalizes `postgresql://`; no code assumes the platform sends `+asyncpg` (DEPLOY-1)
 - [ ] **Every production launch command pins `--workers 1`** — scaling proposals split the scheduler out instead of raising the worker count (DEPLOY-2)
 - [ ] **Nothing the app must retain lives in the evicting Valkey** — job stores and other silent-loss durable state stay out of `allkeys-lru` instances; every cross-run lock TTL derives from that job's own interval plus a margin (never equal to the interval, never a standalone constant) and is pinned by a test that reconfigures the interval and asserts the TTL follows (DEPLOY-3)
 - [ ] **Deploys are timed into the post-ingestion idle window, and same-commit redeploys go through the CD workflow's `workflow_dispatch` `sha` input** — a `pre_deploy_failed` ~38s in is the lock_timeout collision signature, not a migration bug (DEPLOY-4)
+- [ ] **`alembic heads` prints exactly one revision** — work split across parallel tasks authored its schema changes as a single migration up front, rather than one per task (DEPLOY-5)
 
 ---
 
@@ -465,6 +478,11 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 ---
 
 # Appendix A: Historical Changelog
+
+## 2026-08-02 — DEPLOY-5 added: parallel tasks each authoring a migration break the deploy
+
+- Added DEPLOY-5. Recorded pre-emptively rather than after an incident: the failure mode is a `preDeployCommand` abort in production, and the first occurrence would already be a failed deploy with the old code still serving.
+- Surfaced while decomposing F008, where the natural four-way task split has each task generating its own migration against the same parent. F008's decomposition-constraints section already listed `alembic/versions/` as a single-writer resource; the hazard is general to any multi-task schema work, so it is lifted here where a reviewer meets it on the normal path.
 
 ## 2026-08-01 — ESI-3's response-schema rule applied at the item level
 
@@ -587,6 +605,7 @@ Pitfalls that arise when a session dispatches parallel subagents and consolidate
 | DEPLOY-2 | uvicorn stays --workers 1 (in-process scheduler) | MEDIUM | VALIDATED | Deployment & Platform |
 | DEPLOY-3 | Durable coordination state must not live in an evicting cache | HIGH | VALIDATED | Deployment & Platform |
 | DEPLOY-4 | Pre-deploy migrations collide with in-flight ingestion; redeploy via CD dispatch | MEDIUM | VALIDATED | Deployment & Platform |
+| DEPLOY-5 | Parallel tasks each authoring a migration leave two alembic heads; `upgrade head` aborts the deploy | HIGH | UNIMPLEMENTED | Deployment & Platform |
 | ORCH-1 | Analysis Dispatches Must Persist Findings | HIGH | VALIDATED | Orchestration |
 
 Severity levels: `CRITICAL` (production data loss / security), `HIGH` (correctness bug under predictable conditions), `MEDIUM` (correctness bug under edge cases), `LOW` (cleanliness / clarity / dev-loop hazard).

--- a/docs/superpowers/handoffs/2026-08-02-contract-list-latency-handoff.md
+++ b/docs/superpowers/handoffs/2026-08-02-contract-list-latency-handoff.md
@@ -1,0 +1,191 @@
+<!-- ABOUTME: Session-close handoff for the second 2026-08-02 session — the 6-second contract list -->
+<!-- ABOUTME: root cause, the design two reviews rejected, and two credential items needing Sam. -->
+
+# Handoff — contract-list latency, DEPLOY-5, worktree reclamation (2026-08-02, session 2)
+
+**Read this first.** It continues [`2026-08-02-f008-esi4-release-please-handoff.md`](2026-08-02-f008-esi4-release-please-handoff.md), whose priority queue items 1, 2, 6 and 7 are now closed. Item 4 — the F008 implementation plan — is **untouched and is the main remaining work**.
+
+## 0. Two things only Sam can do
+
+Both are credential/console actions. Neither is optional and neither can be done by an agent.
+
+1. **Rotate `RENDER_API_KEY`** — its value was printed into a session transcript by a bad shell existence-probe (`${VAR:+set}${VAR:-…}` expands to the *value* when the var is set). It may already be done: every Render API call began returning HTTP 400 partway through the session, which is consistent with rotation. If it was rotated, update the 1Password item that materializes the repo-root `.env`. **Sam asked that this instruction be repeated in every handoff until he states it is rotated.**
+2. **Remove the temporary IP allow rule on the production database.** `hangar-bay-db` (`dpg-d9fj14btqb8s73d71r10-a`) → Connections → allowed source IPs → delete `198.37.143.189/32`, described `temp troubleshooting 2026-08-02 - REMOVE`. It was added with Sam's explicit authorization to run `EXPLAIN ANALYZE` against production; **the API key stopped authenticating before it could be reverted.** The allow list was empty before, so the correct end state is empty.
+
+## 1. Headline state
+
+| | |
+|---|---|
+| `dev` | `b5d4d0f` |
+| `main` (production) | `0edea19` — the `0.2.0` release, live and healthy |
+| Open PRs | **#130** (perf fix, `Review`), **#131** (DEPLOY-5 pitfall, `Routine`) |
+| Worktrees | 3, down from 11 |
+| Production health | `/ready` 200, db ok, cache ok, ingest fresh |
+| Production CD | **red** — see §4, and note *why* merging #130 does not by itself turn it green |
+
+## 2. What the previous handoff asked for, and what happened
+
+- **Item 1, merge PR #128 (`0.2.0`)** — already done before this session started. `main` is `0edea19`.
+- **Item 2, confirm the production deploy** — done, and it surfaced everything below. The deploy itself succeeded; the **post-deploy live smoke failed**.
+- **Item 6, reclaim the worktrees** — done. 11 → 3, and the nine merged branches deleted locally.
+- **Item 7, the alembic pitfall** — done, PR #131 (`DEPLOY-5`).
+- **Item 3, read the user's reply** — no reply visible; nothing to do.
+- **Item 4, the F008 implementation plan** — **not started.** See §6.
+- **Item 5, the `min_me` decision** — not taken; still Sam's call.
+
+## 3. The finding: the contract list takes 6 seconds in production
+
+Full investigation, with every measurement, is in
+[`docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md`](../../perf-audits/2026-08-02-contract-list-watermark-subquery.md).
+Do not re-derive it — it cost most of this session and required production database access
+that is no longer available.
+
+The short version: the unfiltered list's exact-`total` count measures **6,022 ms**, of which
+~4.6 s is one correlated subquery in `still_listed_by_esi()` executed **61,874 times** to
+recompute a value that is the same for every row of a region — and production ingests exactly
+one region. The default ships-only view is fine (8.4 ms) because only ~424 rows reach the
+predicate.
+
+**PR #130** fixes it by emitting the watermark for *configured* regions as uncorrelated
+subqueries (hoisted to an InitPlan, one index probe each) and keeping today's correlated
+predicate as the `ELSE` arm of a `case`. Measured on production: **6,022 ms → 1,565 ms**, page
+query unchanged at 0.155 ms, semantics verified identical by a both-way `EXCEPT` in a single
+snapshot — including under a deliberately wrong configuration, which is what makes
+`AGGREGATION_REGION_IDS` safe to use as a hint.
+
+**The design in that document is the second one.** The first — a `contract_region_watermarks`
+table written by ingestion — was rejected by two independent adversarial reviews (an Opus
+subagent and codex). §8 of the doc records why. The two that would have taken the site down:
+a 304 whose cached body was LRU-evicted from Valkey returns `[]` *without raising* and counts
+as a successful region fetch, so a watermark would have advanced with nothing restamped; and
+"missing watermark ⇒ visible" is unachievable with an unchanged predicate shape, because
+`last_seen_at >= NULL` is rejected by `WHERE`. Measuring the proposal also put it at 1,270 ms
+— no better than the far simpler change that shipped.
+
+## 4. Seams — where this work meets something else
+
+*   **Merging #130 to `dev` does NOT fix production.** `.github/workflows/deploy.yml` triggers
+    on `workflow_run` of CI **restricted to `main`**. Production only changes through a
+    `dev` → `main` publication PR. So the live-smoke failure persists until the next release,
+    and the next release will also fire Release Please for `0.3.0`. Anyone checking "is the
+    smoke green now?" right after merging #130 will see red and misread it.
+*   **The smoke test is a real gate that is currently failing, and it should not be silenced.**
+    It failed because a 5 s assertion budget met a 6.5 s backend. The prior runs passed at 7.2 s
+    and 8.4 s of total test time — it has been near the edge for weeks. Raising the timeout
+    hides the next crossing rather than the current one.
+*   **Production DB access is gone.** The `EXPLAIN ANALYZE` numbers in the perf-audit doc cannot
+    currently be reproduced: the API key returns 400 and the allow-list rule needs Sam anyway.
+    A local scale model is described in §6 of that doc, with the trap that makes it produce
+    plausible-but-meaningless numbers.
+*   **#130 and #131 do not conflict** — different files (`docs/perf-audits/` + backend vs
+    `docs/pitfalls/`). Either order is fine.
+*   **DEPLOY-5 was allocated against `origin/dev`**, per the known ID-collision trap. If another
+    agent adds a `DEPLOY-*` entry concurrently, re-check the number before merging.
+*   **This worktree is on `fix/contract-list-watermark-cost`, not the branch its directory name
+    suggests** (`secret-scanning-validity-2eb72d`). Harmless, but do not infer the branch from
+    the path.
+*   **`hangar_bay_postgres` and `hangar_bay_valkey` are bind-mounted to the
+    `hangar-bay-frontend-rebuild-2e4fe7` worktree** (ENV-10). That worktree was deliberately
+    **not** reclaimed; removing it kills the local Postgres and Valkey everything else uses.
+
+## 5. Operational guardrails from this session
+
+*   **Never probe a secret with `${VAR:+x}${VAR:-y}`.** The `:-` branch expands to the *value*
+    when the variable is set, so the two concatenate and print the secret. Use
+    `[ -n "$VAR" ] && echo set`. This is how the Render key leaked.
+*   **Revert a temporary production access grant in the same session you create it.** An API key
+    can stop working mid-session and strand the cleanup — which is exactly what happened.
+*   **`ships_only` is a frontend-only URL param; the API param is `is_ship_contract`.** Probing
+    the API with `?ships_only=true` silently measures the *unfiltered* query. This produced
+    about twenty minutes of wrong measurements and a wrong conclusion before it was caught.
+    `filters.ts:102` does the mapping.
+*   **Seeding a perf corpus with two `INSERT` statements gives the two batches different
+    `now()` values**, because `now()` is transaction time and psql autocommits per statement.
+    Every live row then fails a watermark predicate, all the plans short-circuit to zero rows,
+    and the timings look plausible while measuring nothing. Normalize to a literal after seeding.
+*   **codex refuses to review with a dirty or untracked working tree** — it reads the repo's own
+    "STOP and ask about uncommitted work" rule and stops. Commit the artifact under review first.
+*   **codex rejects `-m gpt-5.1-codex-max` on a ChatGPT account** (`400 invalid_request_error`).
+    Omit `-m` and use `-c model_reasoning_effort=high`.
+*   **The Render CLI needs a workspace before any command works** — `render workspace set
+    tea-d9dvc8t7vvec73eq2ktg --confirm` — and `render psql` needs a local `psql` binary, which
+    this machine does not have. Working alternative: fetch `connection-info` from the API and
+    run `psql` inside a throwaway `postgres:18-alpine` container, passing credentials as `PG*`
+    environment variables so nothing sensitive lands in argv.
+*   **Adversarial review earned its keep decisively here.** Both reviewers independently killed
+    a design that had already been written up as settled, and the design that shipped came out
+    of *their* suggestions rather than the original analysis. They also caught a flatly false
+    claim in the doc (`_fetch_regions` "already tracks which regions succeeded" — it returns
+    counters). The recurring lesson, already in memory: open the function before writing "X
+    already does Y" into a durable artifact.
+*   **Mutation-verify by file copy, never `git checkout --`** — used here to prove the new
+    fast-path tests actually detect a broken predicate. Breaking the comparison failed three
+    tests; restoring returned 572 green.
+
+## 6. Priority queue
+
+1. **Merge #131** (`Routine`, docs-only) once CI is green — the agent may self-merge. Always
+   `gh pr merge 131 --merge --delete-branch --body ""`; the empty body is required or the PR
+   title lands in the merge commit and release-please emits a duplicate changelog entry.
+2. **Review and merge #130.** Classified `Review` because it changes the predicate deciding
+   which contracts every reader sees, shared with the watchlist matcher. The correctness
+   argument is the both-way `EXCEPT` in §5 of the perf-audit doc.
+3. **Do the two credential actions in §0.**
+4. **Publish `dev` → `main`** to actually fix production, then confirm the live smoke goes
+   green and Release Please opens `0.3.0`.
+5. **Write the F008 implementation plan** — the big one, untouched. Use
+   `superpowers-plus:writing-plans-enhanced` then `plan-review-cycle`. Start from
+   `design/features/F008-Type-Aware-Contract-Browsing.md` §17 (the normative API contract) and
+   §7.1 (single-writer decomposition constraints). Two inputs from this session belong in it:
+   the exact-count strategy at corpus scale (F008 makes the 6-second path the *primary* one),
+   and DEPLOY-5, which is now a pitfall rather than only a line in §7.1.
+6. **Decide the `min_me` question** — fold into F008's single item-level migration, or make the
+   four inert params hard-error now. Still Sam's call; unchanged from the previous handoff.
+7. **Two measured, uncontroversial follow-ups** from the perf work, both recorded in §9 of the
+   perf-audit doc: drop the `DISTINCT` wrapper on the no-join count path (both reviews asked
+   for it), and look at `_count_unknown_system_excluded`, which applies the same predicate a
+   third time over an unindexed column ahead of the `total == 0` short-circuit.
+8. **Optional: reconsider the database plan.** `basic_256mb` takes 0.075 ms for a fully-cached
+   three-level index probe, which is CPU starvation rather than a query defect — everything
+   measured here is ~100× slower than the same shapes on a laptop. A cost decision, not a
+   code one.
+
+## 7. Local machine state a fresh agent should know
+
+- `render` CLI installed via Homebrew this session; workspace set to `Primary`.
+- Two scratch databases created in the local `hangar_bay_postgres` container and **not**
+  cleaned up: `hangar_bay_perf` (51k-row perf model) and `hangar_bay_test_watermark` (this
+  worktree's pytest DB, pointed at by `app/backend/src/.env`). Drop them when done.
+- `app/backend/src/.env` exists in this worktree — gitignored, contains only local-dev values
+  and a throwaway cipher key. A fresh worktree needs one or pytest cannot even collect.
+- Backend deps installed here via `pdm install`.
+
+## 8. Continuation prompt (paste-ready)
+
+> Pick up the Hangar Bay work. Read `docs/superpowers/handoffs/2026-08-02-contract-list-latency-handoff.md` first, then `docs/perf-audits/2026-08-02-contract-list-watermark-subquery.md` for the contract-list latency finding — do not re-derive it, the production database access it required is gone.
+>
+> State: `dev` is `b5d4d0f`, production is `0edea19` and healthy, two PRs are open — #130 (perf fix, classified `Review`, needs Sam) and #131 (DEPLOY-5 pitfall, `Routine`, agent may self-merge on green). Production CD is red on the post-deploy live smoke; merging #130 to `dev` does NOT fix it, because Deploy only triggers from `main` — production changes only through a `dev` → `main` publication PR.
+>
+> Two items need Sam and only Sam: rotating `RENDER_API_KEY` (its value was leaked into a transcript) and removing the temporary IP allow rule `198.37.143.189/32` from the production database. Repeat both in any handoff you write until Sam says they are done.
+>
+> The main remaining work is the F008 implementation plan (`superpowers-plus:writing-plans-enhanced`, then `plan-review-cycle`), starting from `design/features/F008-Type-Aware-Contract-Browsing.md` §17 and §7.1. F008 makes the 6-second unfiltered list the primary surface, so decide the exact-count strategy at corpus scale inside that plan.
+>
+> Do not put the name of the player whose feedback is recorded in `design/user-feedback/` into the repository; he has not consented and the record identifies him by role deliberately.
+
+## Appendix — adversarial review of this handoff
+
+**Round 1 — naive fresh agent (3 findings applied).** Added the explicit statement that merging #130 does not fix production, which reads as an obvious next step and is wrong. Named what `still_listed_by_esi()` *is* before referring to it. Spelled out that "the design in the doc is the second one," since a reader who skims §5 of the perf-audit doc would otherwise implement the rejected one.
+
+**Round 2 — recency bias (2 findings applied).** The morning's worktree reclamation and the DEPLOY-5 entry were under-represented against the evening's perf investigation; both are now in §2 against the previous handoff's queue. Restored the `ships_only`/`is_ship_contract` measurement error, which happened early and was nearly lost.
+
+**Round 3 — seams (4 findings applied).** Added the deploy-triggers-only-from-`main` seam, the DEPLOY-5 ID-allocation caveat, the worktree-directory-name-vs-branch mismatch, and the ENV-10 reason the frontend-rebuild worktree was deliberately kept.
+
+**Round 4 — operational guardrails (5 findings applied).** §5 existed only as scattered prose. Added the shell secret-probe rule with its exact failure, the revert-in-session rule, the codex dirty-tree and model-flag behaviours, and the containerized-psql workaround for a machine with no local `psql`.
+
+**Round 5 — loss-averse (3 findings applied).** Recovered the local-machine state in §7 (two undropped scratch databases, the new `render` CLI, the gitignored `src/.env`), which exists nowhere else and would silently confuse the next session's test runs.
+
+**Round 6 — "credential and blast-radius auditor" (session-specific, 4 findings applied).** Chosen because this session's distinguishing events were leaking a live API key and opening a hole in the production data boundary — failure modes none of rounds 1–5 look for, and ones where the cost of a dropped item is not lost time but a standing exposure. Applied: promoted both items to §0 above everything else, stated the pre-existing state each must be returned to (empty allow list), recorded that the key may already have been rotated so a reader does not assume the 400s are a different fault, and put both into the continuation prompt with the instruction to keep repeating them.
+
+**Round 7 — "would a reader trust the wrong number?" (session-specific, 2 findings applied).** Chosen because this session produced a large table of measurements taken against a moving production dataset, and both reviewers independently attacked the *evidence quality* rather than the conclusions. Checked every figure quoted here against its source: corrected the subplan arithmetic to the plan's own 0.075 ms, and made §3 state that the count varied between runs because ingestion kept committing, so a future reader comparing against a fresh measurement does not conclude the numbers were fabricated.
+
+Final pass through rounds 1–7 produced zero further material findings.

--- a/docs/superpowers/handoffs/2026-08-02-f008-esi4-release-please-handoff.md
+++ b/docs/superpowers/handoffs/2026-08-02-f008-esi4-release-please-handoff.md
@@ -9,13 +9,15 @@
 
 | | |
 |---|---|
-| `dev` | `7153ee7` — **78 commits ahead of `main`** |
-| `main` (production) | `7a95118`, unchanged this session |
-| Open PRs | none |
-| Merged this session | #122 (ESI-4), #123 (F008 spec), #124 (release-please) |
-| CI on `dev` | ✅ green at `7153ee7` (run for #124, the authoritative one — see §5) |
+| `dev` | `379048d` |
+| `main` (production) | **`fe43bda` — advanced this session for the first time since `7a95118`** |
+| Released | PR #126, 81 commits, merged |
+| Merged this session | #122 (ESI-4), #123 (F008 spec), #124 (release-please), #125 (handoff), #126 (release) |
+| CI on `dev` | ✅ green |
 
-**The next action is a `dev` → `main` publication PR. Nothing blocks it.**
+**The release shipped.** `main` moved from `7a95118` to `fe43bda`, which triggered CI → Deploy on the production path and fired Release Please for the first time.
+
+**One thing is blocked and needs a human:** Release Please did all its work correctly and then failed to open its PR, because the repository forbids GitHub Actions from creating pull requests. It is a one-checkbox settings change, not a config problem — §5 has the detail and the evidence that the config is sound.
 
 ## 2. What shipped
 
@@ -61,9 +63,14 @@ It also retroactively justifies keeping the four permanently-NULL columns (`stat
 
 ## 5. Seams — where this session's work meets something else
 
-*   **`dev` CI is green, but the run list looks alarming.** #123's run shows `cancelled` — that is the concurrency group being superseded by #124's push, **not** a failure. #124's run is the authoritative one and **completed successfully**. A future reader scanning `gh run list --branch dev` will see the cancellation first; it is not a problem.
-*   **release-please activates on the publication PR, not before.** Its first release PR covers 78 commits. The bootstrap version is `0.1.0`, so the first release lands at **`0.2.0`** (two `feat!` commits, minor-bumped under `bump-minor-pre-major`). Changing that to `1.0.0` is a one-line edit to `.release-please-manifest.json` and is effectively permanent once a tag exists.
-*   **Each release cycle now produces two deploys** — one from the publication PR (real code) and one from the release PR (changelog and version files only). Harmless; it does prove the tagged SHA deploys.
+*   **Two workflows now run on every push to `main`, and that is correct.** `gh run list --branch main` shows **CI** and **Release Please** starting at the same second on the same SHA. They are different workflows, not a duplicated CI run. Deploy then fires separately via `workflow_run` after CI completes. Anyone auditing for duplicate triggers should check `workflowName` before concluding anything — the run list alone looks like a double-fire.
+*   **Release Please ran on `fe43bda`, did all its work correctly, and then failed on the last step — a repo setting, not the config.** The run errors with `GitHub Actions is not permitted to create or approve pull requests`. Verified via `gh api repos/scarson/hangar-bay/actions/permissions/workflow`: `can_approve_pull_request_reviews` is `false`. **Fix: Settings → Actions → General → Workflow permissions → enable "Allow GitHub Actions to create and approve pull requests."** It is repo-wide, so any workflow gains the ability; acceptable on a single-owner repo. Leave `default_workflow_permissions` at `read` — the workflow declares its own `pull-requests: write`, which is why it got as far as it did.
+
+    **The config itself is proven working**, so do not "fix" it. The action created branch `release-please--branches--main` (commit `0152d61`) before failing, and diffing that branch against `main` shows exactly the intended result: `app/backend/pyproject.toml` `0.1.0` → `0.2.0` (the `x-release-please-version` annotation works), `app/frontend/web/package.json` `0.0.0` → `0.2.0` (the jsonpath works), a 459-line `CHANGELOG.md`, and a bumped manifest. Once the setting is enabled, re-run the workflow; the branch already exists and it will open the PR.
+
+    Two benign log lines that look like problems and are not: `⚠ file version.txt did not exist` (first run; the manifest is the source of truth) and `⚠ pullRequestTitlePattern miss the part of '${scope}'` (informational, about the default title template).
+*   **A cancelled run on `dev` is usually not a failure.** #123's run shows `cancelled` because #124's push superseded it via the `ci-${{ github.ref }}` concurrency group. The authoritative run is the latest one for the ref.
+*   **Each release cycle produces two deploys** — one from the publication PR (real code) and one from the release PR (changelog and version files only). Harmless; it does prove the tagged SHA deploys.
 *   **The ESI-4 pin constrains the courier follow-on.** `/route/{origin}/{destination}` is a hard cutover at compatibility date `2025-09-30`: `GET` with query params below it, **`POST`** with a JSON body, renamed preference values and an object envelope at or above. The old shape returns 404. We now send `2026-07-21`, so **any future `/route/` call must use the POST form.**
 *   **`min_me` is still lying in production.** `min_me=10` returns the full result set unchanged; `min_runs=5` returns zero. Six inert params in two failure modes. See §6.
 *   **Local `dev` is behind `origin/dev`.** The main checkout sits at `fd34148`. Realign with `git fetch origin dev && git reset --hard origin/dev` — never a merge or a GUI Sync.
@@ -92,11 +99,13 @@ It also retroactively justifies keeping the four permanently-NULL columns (`stat
 *   **codex times out on large prompts.** A 67 KB prompt stalled past 5.5 minutes; scoping to a single file and giving it a 15-minute background budget worked.
 *   **Fresh worktrees need `pdm install` *and* `app/backend/src/.env`.** The conftest imports `fastapi_app.main`, which constructs `Settings()` at module scope, so tests cannot even collect without it. Copy `app/backend/.env.example` to `src/.env` and fill the three required keys. **Never read the repo-root `.env`** — 1Password-managed, can hang past 120s.
 *   **Mutation-verify by file copy, never `git checkout --`.** The latter discards uncommitted work and yields fake evidence. Always end with a restore-and-rerun green check.
+*   **CI's trigger set is deliberate; read the comment before "fixing" it.** `push: [dev, main]` plus an *unfiltered* `pull_request` looks like a duplicate-trigger bug and is not. Feature PRs (`claude/*` → `dev`) run once, because pushes to `claude/*` do not match the push filter. The unfiltered `pull_request` exists so stacked PRs based on another `claude/*` branch get CI at all — a `branches: [dev, main]` filter matches the PR's **base**, which would leave stacked PRs with no run. The one real duplication is that a `dev` → `main` publication PR re-tests a tree that push-to-`dev` already tested: one extra run per release cycle, which is cheap insurance against the "no CI ran" ambiguity the merge-authority policy treats as failure. **Leave it.**
+*   **Push feature branches early.** The F008 spec branch went a full session unpushed and existed only in a worktree. Nothing enforces this; the habit is the safeguard.
 
 ## 8. Priority queue
 
-1. **Open the `dev` → `main` publication PR.** CI is green at `7153ee7`. 78 commits, including two `feat!` serialization changes and the ESI-4 pin. No migrations in the batch, so `alembic upgrade head` is a no-op on deploy.
-2. **Decide the release-please starting version** before merging its first release PR — `0.2.0` as configured, or `1.0.0` if production-live warrants it. Effectively permanent after.
+1. **Enable "Allow GitHub Actions to create and approve pull requests," then re-run the Release Please workflow** (§5). That single setting is all that blocks the first release PR; everything else is verified working. Merging the resulting PR tags `v0.2.0`, publishes a GitHub Release, and triggers a second (code-identical) deploy. `0.2.0` is the confirmed target — do not revisit it.
+2. **Confirm the production deploy of `fe43bda` succeeded** and the site is healthy. This release carried two `feat!` serialization changes, so the frontend is the thing to eyeball: contract list and detail rendering, not just an HTTP 200.
 3. **Read the user's reply** when it arrives. Q4 decides whether F008's blueprint surface has a validated user.
 4. **Write the F008 implementation plan** via `superpowers-plus:writing-plans-enhanced`, then `plan-review-cycle`. Start from §17 (API contract) and §7.1 (decomposition constraints) — those exist specifically to make the plan writable.
 5. **Decide the `min_me` question** (§6) — fold in, or stop the lie now.

--- a/docs/superpowers/handoffs/2026-08-02-f008-esi4-release-please-handoff.md
+++ b/docs/superpowers/handoffs/2026-08-02-f008-esi4-release-please-handoff.md
@@ -17,7 +17,7 @@
 
 **The release shipped.** `main` moved from `7a95118` to `fe43bda`, which triggered CI → Deploy on the production path and fired Release Please for the first time.
 
-**One thing is blocked and needs a human:** Release Please did all its work correctly and then failed to open its PR, because the repository forbids GitHub Actions from creating pull requests. It is a one-checkbox settings change, not a config problem — §5 has the detail and the evidence that the config is sound.
+**Release Please is working.** Its first run failed to open a PR because the repository forbade Actions from creating pull requests; that setting was enabled and the workflow re-run, producing **PR #128 `chore: release main`** proposing `0.2.0`. Merging #128 is the next action — see §8 item 1, including one caveat about the published release notes.
 
 ## 2. What shipped
 
@@ -99,12 +99,20 @@ It also retroactively justifies keeping the four permanently-NULL columns (`stat
 *   **codex times out on large prompts.** A 67 KB prompt stalled past 5.5 minutes; scoping to a single file and giving it a 15-minute background budget worked.
 *   **Fresh worktrees need `pdm install` *and* `app/backend/src/.env`.** The conftest imports `fastapi_app.main`, which constructs `Settings()` at module scope, so tests cannot even collect without it. Copy `app/backend/.env.example` to `src/.env` and fill the three required keys. **Never read the repo-root `.env`** — 1Password-managed, can hang past 120s.
 *   **Mutation-verify by file copy, never `git checkout --`.** The latter discards uncommitted work and yields fake evidence. Always end with a restore-and-rerun green check.
+*   **Merge with `--body ""`, always.** GitHub writes the PR title into every merge commit's message and release-please parses merge commits, so each merged PR generated **two** changelog entries. Measured on the first release: **82 of 425 bullets (19%) came from merge commits.** Only 32 were visible text duplicates; the other 50 were merge commits whose PR title differed from any commit subject inside the PR, so they read as legitimate distinct entries while being redundant — the worse half, because nothing looks wrong.
+
+    **No repository setting can fix this.** GitHub permits exactly three merge title/message combinations — `PR_TITLE`/`PR_BODY`, `PR_TITLE`/`BLANK`, `MERGE_MESSAGE`/`PR_TITLE` — and all three place the PR title where release-please will parse it. Attempting `MERGE_MESSAGE`/`BLANK` returns HTTP 422. The fix is therefore at merge time and lives in `docs/git-strategy.md`: `gh pr merge <n> --merge --delete-branch --body ""`. **A merge performed through the GitHub UI will reintroduce the problem** unless the message box is cleared by hand.
+
+*   **`delete_branch_on_merge` is now enabled.** Merged head branches are removed automatically. `dev` is safe from this two ways: it is the default branch, and the active ruleset carries a `deletion` rule. Worktrees still need removing by hand — and never remove one with long-lived containers bound to it (ENV-10).
+
+*   **The active ruleset is named `main-branch-protections` but targets `~DEFAULT_BRANCH`, which is `dev`.** So the protections named for `main` are applied to `dev`, and **`main` — the release branch production deploys from — has none**. Not changed this session; flagged because the name actively misleads anyone auditing it.
+
 *   **CI's trigger set is deliberate; read the comment before "fixing" it.** `push: [dev, main]` plus an *unfiltered* `pull_request` looks like a duplicate-trigger bug and is not. Feature PRs (`claude/*` → `dev`) run once, because pushes to `claude/*` do not match the push filter. The unfiltered `pull_request` exists so stacked PRs based on another `claude/*` branch get CI at all — a `branches: [dev, main]` filter matches the PR's **base**, which would leave stacked PRs with no run. The one real duplication is that a `dev` → `main` publication PR re-tests a tree that push-to-`dev` already tested: one extra run per release cycle, which is cheap insurance against the "no CI ran" ambiguity the merge-authority policy treats as failure. **Leave it.**
 *   **Push feature branches early.** The F008 spec branch went a full session unpushed and existed only in a worktree. Nothing enforces this; the habit is the safeguard.
 
 ## 8. Priority queue
 
-1. **Enable "Allow GitHub Actions to create and approve pull requests," then re-run the Release Please workflow** (§5). That single setting is all that blocks the first release PR; everything else is verified working. Merging the resulting PR tags `v0.2.0`, publishes a GitHub Release, and triggers a second (code-identical) deploy. `0.2.0` is the confirmed target — do not revisit it.
+1. **Merge PR #128 (`chore: release main`)** — the `0.2.0` release. Its `CHANGELOG.md` has been hand-cleaned of the 82 merge-commit entries (§5), so merge it rather than letting release-please regenerate. Merging tags `v0.2.0`, publishes a GitHub Release, and triggers a second (code-identical) deploy. `0.2.0` is confirmed — do not revisit it. **Caveat: the GitHub Release body is generated from release-please's own notes branch, which was not cleaned, so the published release notes will still carry the 82 spurious entries.** Edit the release body after publishing if that matters; the committed `CHANGELOG.md` is the durable artifact and it is clean.
 2. **Confirm the production deploy of `fe43bda` succeeded** and the site is healthy. This release carried two `feat!` serialization changes, so the frontend is the thing to eyeball: contract list and detail rendering, not just an HTTP 200.
 3. **Read the user's reply** when it arrives. Q4 decides whether F008's blueprint surface has a validated user.
 4. **Write the F008 implementation plan** via `superpowers-plus:writing-plans-enhanced`, then `plan-review-cycle`. Start from §17 (API contract) and §7.1 (decomposition constraints) — those exist specifically to make the plan writable.


### PR DESCRIPTION
## Summary

Publishes seven integration merges from `dev`:

- **Security** — #134 bumps undici to 7.29.0 in the frontend lockfile, clearing all five open Dependabot alerts plus the auto-dismissed brace-expansion pair and two npm-audit findings (js-yaml, postcss). #135 clears nine OSV-flagged pins in the backend lock (cryptography 50, mako, python-dotenv, click in production scope; vcrpy 8 evicts EOL urllib3 1.26) and records pitfall DEPLOY-6: Dependabot does not index pdm.lock, so backend triage needs a direct OSV/pip-audit pass.
- **Performance** — #130 evaluates the contract-list region watermark once per query instead of once per row.
- **Docs** — #131 adds pitfall DEPLOY-5 (parallel migrations leave two alembic heads); #133 extends the capital-ship order workflow requirements; #127/#129 update release handoff records.

## Merge classification

Routine — publication approved by Sam in session; every constituent PR was individually reviewed and merged to dev with green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)