### PR TITLE
test(web): stub the jsdom scrollTo and canvas gaps so test output is pristine

### DIFF
--- a/app/frontend/web/src/test/setup.ts
+++ b/app/frontend/web/src/test/setup.ts
@@ -2,6 +2,22 @@ import '@testing-library/jest-dom/vitest'
 import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
+// jsdom implements no layout scrolling, and TanStack Router's scroll handling
+// calls window.scrollTo on navigation (router-core scroll-restoration), so every
+// navigation a test performs makes jsdom log "Not implemented: Window's
+// scrollTo() method" to stderr. Test output must be pristine (CLAUDE.md
+// §Testing), so give the environment the no-op jsdom lacks. Nothing here
+// asserts on scrolling — this fills a platform gap, it does not mock behavior.
+window.scrollTo = () => {}
+
+// axe-core's color-contrast rule probes canvas pixels; without the optional
+// `canvas` native package jsdom logs "Not implemented: HTMLCanvasElement's
+// getContext() method" for every probe and then returns null, which axe
+// treats as "cannot determine" (incomplete, not a violation). Returning null
+// directly is behavior-identical minus the stderr noise — contrast is checked
+// in a real browser or not at all, never by jsdom.
+HTMLCanvasElement.prototype.getContext = () => null
+
 // vite.config.ts does not set `globals: true`, so React Testing Library's
 // auto-cleanup (which registers only when `afterEach` is a global) never runs.
 // Register it explicitly here — the canonical RTL-without-globals pattern — so


### PR DESCRIPTION
## Summary

Handoff §2 item 5: the frontend vitest lanes violated the pristine-output rule with jsdom "Not implemented" stderr lines. Two sources, both platform gaps rather than app errors:

- `Window's scrollTo()` — TanStack Router's scroll restoration (`router-core`) calls it on every test navigation.
- `HTMLCanvasElement's getContext()` — axe-core's color-contrast rule probes canvas in the a11y specs.

Both stubs in `src/test/setup.ts` reproduce jsdom's existing return behavior exactly (undefined / null) minus the stderr line, so no test's semantics change: nothing asserts on scrolling, and axe already treated the null context as "cannot determine". Color contrast was never actually checked under jsdom, with or without this change.

## Test evidence

All five lanes green after the change, with noise counts measured at zero:

- `npx eslint .` — clean
- `npx tsc -b` — clean
- `npm run test` — 310 passed, **0** "Not implemented" lines (was 14)
- `npm run test:future-clock` — 310 passed, **0** noise lines
- `npm run e2e` (fixture lane) — 138 passed, 7 skipped (live-smoke auto-skip)

TDD does not apply (test-infrastructure/config, per CLAUDE.md §TDD scope). Playwright never loads this setup file, so the e2e lane is unaffected by construction.

## Merge classification

Routine

Two-line test-environment stub; no production code touched. Codex adversarial review deliberately skipped as below the "meaningful PR" bar — reasoning in the overnight decision log (OD5, lands in the follow-up docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)