### PR TITLE
fix(web): close the parser junk-tolerance gaps

### DIFF
--- a/app/frontend/web/e2e/filters.spec.ts
+++ b/app/frontend/web/e2e/filters.spec.ts
@@ -219,9 +219,10 @@ test.describe('contract filters', () => {
     // field the courier set can disclose (its header showed it, aria-sort and
     // all), and Clear preserves the current sort — sort is not a filter. Had
     // the flow never entered a segment, the default Issued sort would survive
-    // untouched instead.
+    // untouched instead. The direction is Time-left's own default, soonest
+    // first, not a flat desc.
     await expect(page).toHaveURL(/[?&]sort_by=date_expired(&|$)/)
-    await expect(page).toHaveURL(/[?&]sort_direction=desc(&|$)/)
+    await expect(page).toHaveURL(/[?&]sort_direction=asc(&|$)/)
     await expect(page).not.toHaveURL(/search=/)
     await expect(page).not.toHaveURL(/min_price=/)
     await expect(page).not.toHaveURL(/max_price=/)

--- a/app/frontend/web/e2e/sorting.spec.ts
+++ b/app/frontend/web/e2e/sorting.spec.ts
@@ -17,7 +17,7 @@ import { rowLinks } from './helpers/ui'
  *   'Ship / Contract' → ship_name, 'Price (ISK)' → price,
  *   'Time left' → date_expired, 'Issued' → date_issued —
  * and the active header carries aria-sort ('ascending' | 'descending').
- * A new field starts in ContractsPage's DEFAULT_DIRECTION (date_issued: desc,
+ * A new field starts in DEFAULT_DIRECTION (filters.ts; date_issued: desc,
  * everything used here: asc); re-clicking the active field flips it.
  *
  * The frontend never sorts client-side — handleSort only navigates and the
@@ -277,17 +277,26 @@ const byRate = (direction: 'asc' | 'desc'): string[] => {
     .map((contract) => contract.primary_label)
 }
 
-// The order the backend would return, for the two keys this block exercises.
+// The order the backend would return, for the two keys this block exercises:
+// the rate column, and the Time-left fallback the courier segment reconciles
+// its sortless entry to.
 const courierResponder: ListResponder = (params) => {
   const factor = params.get('sort_direction') === 'asc' ? 1 : -1
   const ordered = [...COURIER_CONTRACTS].sort((a, b) => {
     const delta =
       params.get('sort_by') === 'reward_per_volume'
         ? (a.reward_per_volume ?? 0) - (b.reward_per_volume ?? 0)
-        : a.date_issued.localeCompare(b.date_issued)
+        : a.date_expired.localeCompare(b.date_expired)
     return delta * factor
   })
   return pageOf(ordered)
+}
+
+const byExpiry = (direction: 'asc' | 'desc'): string[] => {
+  const factor = direction === 'asc' ? 1 : -1
+  return [...COURIER_CONTRACTS]
+    .sort((a, b) => a.date_expired.localeCompare(b.date_expired) * factor)
+    .map((contract) => contract.primary_label)
 }
 
 const rateHeader = (page: import('@playwright/test').Page) =>
@@ -302,8 +311,10 @@ test.describe('courier column sorting', () => {
 
     await page.goto('/contracts?contract_type=courier&ships_only=false')
     await expect(page.getByRole('heading', { level: 1, name: 'Courier Contracts' })).toBeVisible()
-    // Default sort, date_issued desc, which the fixture declares in array order.
-    await expect(rowLinks(page)).toHaveText(COURIER_CONTRACTS.map((c) => c.primary_label))
+    // Sortless courier entry reconciles to the Time-left field (no Issued
+    // column here), in that column's own default direction: expiring soonest
+    // first — the same direction its header click gives.
+    await expect(rowLinks(page)).toHaveText(byExpiry('asc'))
 
     await page.getByRole('button', { name: 'Reward/m³', exact: true }).click()
 

--- a/app/frontend/web/e2e/sorting.spec.ts
+++ b/app/frontend/web/e2e/sorting.spec.ts
@@ -313,8 +313,12 @@ test.describe('courier column sorting', () => {
     await expect(page.getByRole('heading', { level: 1, name: 'Courier Contracts' })).toBeVisible()
     // Sortless courier entry reconciles to the Time-left field (no Issued
     // column here), in that column's own default direction: expiring soonest
-    // first — the same direction its header click gives.
+    // first — the same direction its header click gives. The fixture's issued
+    // and expiry orders coincide, so the wire params are asserted too — the
+    // render alone could not tell date_expired asc from date_issued asc.
     await expect(rowLinks(page)).toHaveText(byExpiry('asc'))
+    expect(calls[0].params.get('sort_by')).toBe('date_expired')
+    expect(calls[0].params.get('sort_direction')).toBe('asc')
 
     await page.getByRole('button', { name: 'Reward/m³', exact: true }).click()
 

--- a/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
+++ b/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
@@ -5,28 +5,13 @@ import { timeAgo } from '../../../lib/timeAgo'
 import { useDocumentTitle } from '../../../lib/useDocumentTitle'
 import { columnsFor } from '../columns'
 import { regionNames } from '../format'
-import { DEFAULT_PAGE, DEFAULT_SIZE, type ContractSearch, type SortField } from '../filters'
+import { DEFAULT_DIRECTION, DEFAULT_PAGE, DEFAULT_SIZE, type ContractSearch, type SortField } from '../filters'
 import { SaveSearchControl } from '../../saved-searches/components/SaveSearchControl'
 import { useContracts } from '../hooks/useContracts'
 import { ContractTable, ContractTableSkeleton } from './ContractTable'
 import { FilterRail } from './FilterRail'
 import { Pagination } from './Pagination'
 import { SegmentTabs, listTitle } from './SegmentTabs'
-
-/** New sort field starts in its most useful direction: newest/soonest for dates, cheap-first for ISK. */
-const DEFAULT_DIRECTION: Record<SortField, 'asc' | 'desc'> = {
-  date_issued: 'desc',
-  date_expired: 'asc',
-  price: 'asc',
-  collateral: 'asc',
-  ship_name: 'asc',
-  volume: 'desc',
-  // Hauling figures read best-offer-first: the most ISK per m³ and the most
-  // days to deliver in. Buyout follows the price convention, cheap-first.
-  reward_per_volume: 'desc',
-  days_to_complete: 'desc',
-  buyout: 'asc',
-}
 
 /**
  * Why the page is empty, and which of the two reasons it is (Criterion 7.2).

--- a/app/frontend/web/src/features/contracts/filters.test.ts
+++ b/app/frontend/web/src/features/contracts/filters.test.ts
@@ -7,6 +7,7 @@ import {
   ITEM_LESS_TYPES,
   MIN_SEARCH_LENGTH,
   SORT_FIELDS,
+  activeSegment,
   parseContractSearch,
   toApiQuery,
 } from './filters'
@@ -234,9 +235,53 @@ describe('parseContractSearch', () => {
       sort_direction: 'asc',
     })
   })
+
+  it('drops non-integer blueprint bounds instead of sending a value the wire rejects', () => {
+    // All six bounds are Optional[int] server-side; a decimal would 422 and
+    // collapse the list view, so it is junk and falls back like any other junk.
+    for (const key of ['min_runs', 'max_runs', 'min_me', 'max_me', 'min_te', 'max_te'] as const) {
+      expect(parseContractSearch({ [key]: '2.5' })[key]).toBeUndefined()
+      expect(parseContractSearch({ [key]: 2.5 })[key]).toBeUndefined()
+      expect(parseContractSearch({ [key]: '0' })[key]).toBe(0)
+    }
+  })
+
+  it('keeps decimal prices — only the blueprint bounds are integer-typed on the wire', () => {
+    const parsed = parseContractSearch({ min_price: '99.5', max_price: '1000000.25' })
+    expect(parsed.min_price).toBe(99.5)
+    expect(parsed.max_price).toBe(1000000.25)
+  })
+
+  it('defaults the sort direction to the default of the reconciled field, not a flat desc', () => {
+    // The courier set carries no Issued column, so its sortless fallback is the
+    // Time-left field — whose own default direction is expiring-soonest-first,
+    // the same direction its header click gives.
+    const courier = parseContractSearch({ contract_type: 'courier' })
+    expect(courier.sort_by).toBe('date_expired')
+    expect(courier.sort_direction).toBe('asc')
+    // An explicit direction in the URL still wins.
+    const explicit = parseContractSearch({ contract_type: 'courier', sort_direction: 'desc' })
+    expect(explicit.sort_direction).toBe('desc')
+    // The default view is untouched: date_issued's own default is desc.
+    expect(parseContractSearch({}).sort_direction).toBe('desc')
+  })
+
+  it('collapses duplicated contract_type values so single-segment identity holds', () => {
+    const parsed = parseContractSearch({ contract_type: ['courier', 'courier'] })
+    expect(parsed.contract_type).toEqual(['courier'])
+    expect(activeSegment(parsed)).toBe('courier')
+  })
 })
 
 describe('toApiQuery', () => {
+  it('sends nothing for a blueprint bound the parser dropped as junk', () => {
+    // openapi-fetch omits undefined-valued params at serialization, so
+    // undefined here IS "not sent" — the same convention toEqual relies on
+    // throughout this file.
+    const query = toApiQuery(parseContractSearch({ min_me: '5.5' }))
+    expect(query.min_me).toBeUndefined()
+  })
+
   it('gates search below the backend min_length of 3', () => {
     expect(MIN_SEARCH_LENGTH).toBe(3)
     const base = parseContractSearch({})

--- a/app/frontend/web/src/features/contracts/filters.ts
+++ b/app/frontend/web/src/features/contracts/filters.ts
@@ -184,9 +184,32 @@ function toNumber(value: unknown): number | undefined {
  * sentinel, but no control in this UI produces a negative, so a sub-zero value
  * in the URL is junk and falls back rather than filtering on a sentinel.
  */
+/** New sort field starts in its most useful direction: newest/soonest for dates, cheap-first for ISK. */
+export const DEFAULT_DIRECTION: Record<SortField, 'asc' | 'desc'> = {
+  date_issued: 'desc',
+  date_expired: 'asc',
+  price: 'asc',
+  collateral: 'asc',
+  ship_name: 'asc',
+  volume: 'desc',
+  // Hauling figures read best-offer-first: the most ISK per m³ and the most
+  // days to deliver in. Buyout follows the price convention, cheap-first.
+  reward_per_volume: 'desc',
+  days_to_complete: 'desc',
+  buyout: 'asc',
+}
+
 function toNonNegativeNumber(value: unknown): number | undefined {
   const n = toNumber(value)
   return n !== undefined && n >= 0 ? n : undefined
+}
+
+// The six blueprint bounds are integers on the wire (Optional[int]); a decimal
+// would 422 the whole request, so it is junk and falls back like any other junk.
+// Prices stay on the decimal helper above.
+function toNonNegativeInt(value: unknown): number | undefined {
+  const n = toNonNegativeNumber(value)
+  return n !== undefined && Number.isInteger(n) ? n : undefined
 }
 
 function toBoundedInt(value: unknown, min: number, max: number, fallback: number): number {
@@ -207,7 +230,10 @@ function toContractTypes(value: unknown): ContractTypeValue[] | undefined {
   const types = raw.filter((entry): entry is ContractTypeValue =>
     CONTRACT_TYPES.includes(entry as ContractTypeValue),
   )
-  return types.length > 0 ? types : undefined
+  // Deduped: a URL repeating one type must still read as a single-segment
+  // selection, or activeSegment sees "several" and segment identity breaks.
+  const unique = [...new Set(types)]
+  return unique.length > 0 ? unique : undefined
 }
 
 /**
@@ -237,6 +263,7 @@ export function parseContractSearch(raw: Record<string, unknown>): ContractSearc
   // A filter that cannot match an item-less segment now yields an honest empty
   // result with an explanation (Criterion 7.2), which is what that criterion
   // asks for and what 1.7 does not license extending to nine other params.
+  const sortBy = reconcileSort(raw.sort_by, contractTypes)
   return {
     search: typeof raw.search === 'string' && raw.search.length > 0 ? raw.search : undefined,
     min_price: toNonNegativeNumber(raw.min_price),
@@ -245,21 +272,21 @@ export function parseContractSearch(raw: Record<string, unknown>): ContractSearc
     contract_type: contractTypes,
     category_id: toIdArray(raw.category_id),
     group_id: toIdArray(raw.group_id),
-    min_runs: toNonNegativeNumber(raw.min_runs),
-    max_runs: toNonNegativeNumber(raw.max_runs),
-    min_me: toNonNegativeNumber(raw.min_me),
-    max_me: toNonNegativeNumber(raw.max_me),
-    min_te: toNonNegativeNumber(raw.min_te),
-    max_te: toNonNegativeNumber(raw.max_te),
+    min_runs: toNonNegativeInt(raw.min_runs),
+    max_runs: toNonNegativeInt(raw.max_runs),
+    min_me: toNonNegativeInt(raw.min_me),
+    max_me: toNonNegativeInt(raw.max_me),
+    min_te: toNonNegativeInt(raw.min_te),
+    max_te: toNonNegativeInt(raw.max_te),
     is_bpc: typeof raw.is_bpc === 'boolean' ? raw.is_bpc : undefined,
     // Default ON; only an explicit false in the URL widens to all contracts.
     ships_only: itemLessOnly ? false : raw.ships_only !== false,
     page: toBoundedInt(raw.page, 1, Number.MAX_SAFE_INTEGER, DEFAULT_PAGE),
     size: toBoundedInt(raw.size, 1, MAX_SIZE, DEFAULT_SIZE),
-    sort_by: reconcileSort(raw.sort_by, contractTypes),
+    sort_by: sortBy,
     sort_direction: SORT_DIRECTIONS.includes(raw.sort_direction as SortDirection)
       ? (raw.sort_direction as SortDirection)
-      : 'desc',
+      : DEFAULT_DIRECTION[sortBy],
   }
 }
 

--- a/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
+++ b/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
@@ -104,7 +104,7 @@ notes and commit messages.
 
 ## Phase 1 — Parser junk-tolerance gaps (B3, B5, B7) — branch `fix/contract-search-parser-gaps`
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS — claimed 2026-08-08T20:55Z (branch `fix/contract-search-parser-gaps`)
 
 **Files:** `app/frontend/web/src/features/contracts/filters.ts`,
 `src/features/contracts/components/ContractsPage.tsx`, `src/features/contracts/filters.test.ts`


### PR DESCRIPTION
## Summary

Remediation plan Phase 1 (bugs B3, B5, B7 of `docs/bug-hunts/2026-08-08-f008-prerelease-consolidated.md`):

- **Integer guard on the six blueprint bounds** — a decimal (`min_me=5.5`, typeable or URL-borne) previously reached the wire, 422'd, and collapsed the whole list view to the error card. Junk now falls back per the parser's own documented contract. `min_price`/`max_price` keep decimals (regression-pinned).
- **Per-field default sort direction** — the absent-direction fallback was a flat `desc`, contradicting `DEFAULT_DIRECTION[date_expired]='asc'` on the courier segment's sortless entry. `DEFAULT_DIRECTION` moved to `filters.ts` (single source; `ContractsPage` imports it) and the fallback uses the reconciled field's own default. Default view unchanged by construction.
- **`contract_type` dedupe** — repeated values no longer break single-segment identity (`activeSegment`'s exactly-one check).

## Test evidence

- TDD: 5 new vitest cases watched RED (4 failed + 1 regression pin green-by-design), then GREEN. Full suite 315×2 lanes.
- **Two e2e assertions UPDATED, not weakened**: `filters.spec.ts` clear-filters and `sorting.spec.ts` courier-entry pinned the old flat-`desc` fallback; both now pin the per-field default (`asc` on Time-left), and the courier responder models the `date_expired` key the segment actually requests. All 138 e2e pass.
- eslint, tsc clean.

## Merge classification

Routine

Frontend-only, parser + one constant move; no API or schema change. Plan banner updated in the same PR per the Living Document Contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)