### PR TITLE
fix(web): hide item-bearing segment counts the click cannot deliver

### DIFF
--- a/app/frontend/web/e2e/segments.spec.ts
+++ b/app/frontend/web/e2e/segments.spec.ts
@@ -77,6 +77,26 @@ test.describe('contract-type segments', () => {
     await expect(page.getByRole('button', { name: /^Unknown/ })).toHaveCount(0)
   })
 
+  test('the item-bearing controls drop their counts while Courier is active', async ({
+    page,
+  }) => {
+    await interceptCurrentUser(page, { status: 401 })
+    await interceptContractList(page, respond)
+
+    await page.goto('/contracts')
+    await expect(rowLinks(page)).toHaveCount(7)
+    await segment(page, 'Courier 3').click()
+
+    // The courier request carried no ships-only filter, so this envelope's
+    // item-bearing counts are lifted — and clicking either button restores
+    // ships-only. No numeral beats a wrong one; Courier's own count is the
+    // lifted figure for the lifted view it serves, so it stays.
+    await expect(segment(page, 'Item exchange')).toHaveAttribute('aria-pressed', 'false')
+    await expect(page.getByRole('button', { name: /^Item exchange \d/ })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^Auction \d/ })).toHaveCount(0)
+    await expect(segment(page, 'Courier 3')).toHaveAttribute('aria-pressed', 'true')
+  })
+
   test('selecting Courier clears Ships only visibly and asks the API for couriers', async ({
     page,
   }) => {

--- a/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
+++ b/app/frontend/web/src/features/contracts/components/ContractsPage.tsx
@@ -229,7 +229,7 @@ export function ContractsPage({ search, from }: { search: ContractSearch; from: 
             first response and stay through later ones (keepPreviousData holds
             the previous page while a new segment loads). */}
         {data !== undefined ? (
-          <SegmentTabs search={search} counts={data.segment_counts} onSelect={update} />
+          <SegmentTabs search={search} countsSearch={data.countsSearch} counts={data.segment_counts} onSelect={update} />
         ) : null}
 
         {/* A shared URL can carry a taxonomy or blueprint filter into a corpus

--- a/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
+++ b/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
@@ -107,6 +107,12 @@ export function SegmentTabs({
   // them, not of the URL: while an item-less selection's envelope is on
   // screen, the item-bearing figures in it are ships-lifted.
   const countsFromItemLess = isItemLessSelection(countsSearch)
+  // A numeral has to be honest about two things at once — what the on-screen
+  // figures ARE (the captured search) and what clicking would DELIVER (the
+  // live one). Either being an item-less selection poisons the pairing:
+  // captured item-less means the figures are lifted, live item-less means the
+  // click restores ships-only. Hide on either, in both transition directions.
+  const suppressLiftedNumerals = countsFromItemLess || leavingItemLess
   const selected = activeSegment(search)
   // What All would land on decides what All may claim: every route into it from
   // an item-less segment restores ships-only, so only a view the reader has
@@ -133,10 +139,10 @@ export function SegmentTabs({
         // honest, and the empty state it leads to explains itself.
         const count =
           segment.type === undefined
-            ? countsFromItemLess
+            ? suppressLiftedNumerals
               ? undefined
               : sumCounts(counts, allCountsEveryType ? CONTRACT_TYPES : ITEM_BEARING_TYPES)
-            : countsFromItemLess && ITEM_BEARING_TYPES.includes(segment.type)
+            : suppressLiftedNumerals && ITEM_BEARING_TYPES.includes(segment.type)
               ? undefined
               : (counts[segment.type] ?? 0)
         return (

--- a/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
+++ b/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
@@ -92,10 +92,10 @@ export function SegmentTabs({
   /**
    * The search `counts` was served under, captured at fetch time (WEB-1).
    * keepPreviousData holds an envelope on screen for the whole of the next
-   * request, so numeral interpretation MUST read the captured search — the
-   * live one describes counts that have not arrived yet. Clicks and pressed
-   * states stay on the live search: they are about where the reader goes,
-   * not about what the numbers mean.
+   * request, so what the figures ARE is read off this captured search, while
+   * what a click DELIVERS is read off the live one — the numeral logic below
+   * consults both. Clicks and pressed states stay on the live search alone:
+   * they are about where the reader goes, not about what the numbers mean.
    */
   countsSearch: ContractSearch
   /** The envelope's per-type counts, keyed by every type the server enumerates. */
@@ -109,9 +109,18 @@ export function SegmentTabs({
   const countsFromItemLess = isItemLessSelection(countsSearch)
   // A numeral has to be honest about two things at once — what the on-screen
   // figures ARE (the captured search) and what clicking would DELIVER (the
-  // live one). Either being an item-less selection poisons the pairing:
-  // captured item-less means the figures are lifted, live item-less means the
-  // click restores ships-only. Hide on either, in both transition directions.
+  // live one). An item-less selection on the captured side means the
+  // item-bearing figures are lifted; on the live side it means a click
+  // restores ships-only. Hiding on either covers both transition directions
+  // around the item-less segments, at two accepted residual costs: a
+  // ships-only → item-less transition hides a numeral that happened to be
+  // honest (hidden beats wrong, and this is merely hidden-though-right for
+  // one request), and a ships-only ↔ widened toggle keeps showing the held
+  // envelope's figures for its own one-request window — the same
+  // keepPreviousData semantics as every other number on the page, coherent
+  // with the held rows beside it. The complete per-request answer is the
+  // mirror-counts envelope recorded as an open design decision in D11 and
+  // the 2026-08-08 bug-hunt report.
   const suppressLiftedNumerals = countsFromItemLess || leavingItemLess
   const selected = activeSegment(search)
   // What All would land on decides what All may claim: every route into it from
@@ -125,14 +134,14 @@ export function SegmentTabs({
       {SEGMENTS.map((segment) => {
         const active =
           segment.type === undefined ? search.contract_type === undefined : segment.type === selected
-        // While an item-less selection's envelope is on screen, its request
-        // carried no ships-only filter, so the item-bearing counts in it are
-        // lifted — but clicking All OR a typed item-bearing segment RESTORES
-        // ships-only, a population those counts cannot describe. No numeral
-        // beats a wrong one: All and the typed item-bearing controls all go
-        // count-less in that state, and the counts return with the next
-        // response after switching. The item-less segment's own numeral is the
-        // lifted figure describing the lifted view it serves, so it stays.
+        // While an item-less selection is in play on either side (captured
+        // envelope or live URL), the item-bearing numerals cannot be paired
+        // honestly with what a click delivers — see suppressLiftedNumerals
+        // above. No numeral beats a wrong one: All and the typed item-bearing
+        // controls all go count-less in that state, and the counts return
+        // with the next response after switching. The item-less segment's own
+        // numeral is the lifted figure describing the lifted view it serves,
+        // so it stays.
         // Per-segment counts otherwise go out exactly as served: every filter
         // but contract_type is applied to them. That stays true of an
         // item-less segment under an item-level filter — the served zero is

--- a/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
+++ b/app/frontend/web/src/features/contracts/components/SegmentTabs.tsx
@@ -84,20 +84,34 @@ function segmentPatch(
 
 export function SegmentTabs({
   search,
+  countsSearch,
   counts,
   onSelect,
 }: {
   search: ContractSearch
+  /**
+   * The search `counts` was served under, captured at fetch time (WEB-1).
+   * keepPreviousData holds an envelope on screen for the whole of the next
+   * request, so numeral interpretation MUST read the captured search — the
+   * live one describes counts that have not arrived yet. Clicks and pressed
+   * states stay on the live search: they are about where the reader goes,
+   * not about what the numbers mean.
+   */
+  countsSearch: ContractSearch
   /** The envelope's per-type counts, keyed by every type the server enumerates. */
   counts: Record<string, number>
   onSelect: (patch: Partial<ContractSearch>) => void
 }) {
   const leavingItemLess = isItemLessSelection(search)
+  // The counts' ships-lift state is a property of the request that produced
+  // them, not of the URL: while an item-less selection's envelope is on
+  // screen, the item-bearing figures in it are ships-lifted.
+  const countsFromItemLess = isItemLessSelection(countsSearch)
   const selected = activeSegment(search)
   // What All would land on decides what All may claim: every route into it from
   // an item-less segment restores ships-only, so only a view the reader has
   // already widened counts the item-less types in.
-  const allCountsEveryType = !leavingItemLess && !search.ships_only
+  const allCountsEveryType = !countsFromItemLess && !countsSearch.ships_only
 
   return (
     <fieldset className="flex flex-wrap items-center gap-1.5">
@@ -105,22 +119,26 @@ export function SegmentTabs({
       {SEGMENTS.map((segment) => {
         const active =
           segment.type === undefined ? search.contract_type === undefined : segment.type === selected
-        // While an item-less segment is active the request carried no ships-only
-        // filter, so the envelope's item-bearing counts are lifted — but All's
-        // destination RESTORES ships-only, a population those counts cannot
-        // describe. No numeral beats a wrong one; the count returns with the
-        // next response after switching.
-        // Per-segment counts go out exactly as served: every filter but
-        // contract_type is applied to them, so the number a segment shows is
-        // the number selecting it delivers. That stays true of an item-less
-        // segment under an item-level filter — the served zero is honest, and
-        // the empty state it leads to explains itself.
+        // While an item-less selection's envelope is on screen, its request
+        // carried no ships-only filter, so the item-bearing counts in it are
+        // lifted — but clicking All OR a typed item-bearing segment RESTORES
+        // ships-only, a population those counts cannot describe. No numeral
+        // beats a wrong one: All and the typed item-bearing controls all go
+        // count-less in that state, and the counts return with the next
+        // response after switching. The item-less segment's own numeral is the
+        // lifted figure describing the lifted view it serves, so it stays.
+        // Per-segment counts otherwise go out exactly as served: every filter
+        // but contract_type is applied to them. That stays true of an
+        // item-less segment under an item-level filter — the served zero is
+        // honest, and the empty state it leads to explains itself.
         const count =
           segment.type === undefined
-            ? leavingItemLess
+            ? countsFromItemLess
               ? undefined
               : sumCounts(counts, allCountsEveryType ? CONTRACT_TYPES : ITEM_BEARING_TYPES)
-            : (counts[segment.type] ?? 0)
+            : countsFromItemLess && ITEM_BEARING_TYPES.includes(segment.type)
+              ? undefined
+              : (counts[segment.type] ?? 0)
         return (
           <button
             key={segment.type ?? 'all'}

--- a/app/frontend/web/src/features/contracts/components/pages.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/pages.test.tsx
@@ -845,6 +845,44 @@ describe('contract-type segments', () => {
     )
   })
 
+  it('drops the numerals the moment an item-less segment is clicked from a widened view', async () => {
+    // The reverse transition: the widened envelope's numerals are still on
+    // screen when Courier is clicked, but the live URL is already the
+    // item-less selection — so clicking All or a typed control from here
+    // RESTORES ships-only, a population the widened figures do not describe.
+    // Either context being item-less poisons the numeral's meaning: the
+    // captured one says what the figures are, the live one says what a click
+    // delivers, and the numeral must be honest about both.
+    let releaseCourier!: (page: Response) => void
+    const courierInFlight = new Promise<Response>((resolve) => {
+      releaseCourier = resolve
+    })
+    const calls = stubFetch(
+      anonymousMe((url) =>
+        url.includes('contract_type=courier') ? courierInFlight : segmentedPage(url),
+      ),
+    )
+
+    renderApp('/contracts?ships_only=false')
+    await screen.findByText('Tristan')
+    expect(screen.getByRole('button', { name: /^Item exchange 1,240$/ })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /^Courier 115$/ }))
+    await waitFor(() =>
+      expect(calls.some((url) => url.includes('contract_type=courier'))).toBe(true),
+    )
+
+    expect(screen.getByRole('button', { name: /^Courier/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /^Item exchange$/ }).textContent).toBe('Item exchange')
+    expect(screen.getByRole('button', { name: /^All$/ }).textContent).toBe('All')
+
+    releaseCourier(jsonResponse(listPage([COURIER_ROW], { segment_counts: SEGMENT_COUNTS })))
+    // Settled on courier, the item-less control's own (honest) numeral is back.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^Courier 115$/ })).toBeInTheDocument(),
+    )
+  })
+
   it('keeps a sort both segments can express', async () => {
     // Price is sortable in All and in Auction alike — resetting it would throw
     // away the user's choice for no disclosure gain.

--- a/app/frontend/web/src/features/contracts/components/pages.test.tsx
+++ b/app/frontend/web/src/features/contracts/components/pages.test.tsx
@@ -789,6 +789,62 @@ describe('contract-type segments', () => {
     expect(all.textContent).toBe('All')
   })
 
+  it('shows the typed item-bearing controls without counts while an item-less segment is active', async () => {
+    // The same rule as the All control one test up: this envelope's
+    // item-exchange/auction counts were served ships-lifted, but clicking
+    // either button RESTORES ships-only (Criterion 1.9), so the numeral would
+    // advertise a population the click cannot deliver. Courier's own numeral
+    // is honest in this state — its count is the lifted figure and its page is
+    // the lifted view — so it stays.
+    stubFetch(anonymousMe(segmentedPage))
+
+    renderApp('/contracts?contract_type=courier&ships_only=false')
+    await screen.findByText('Jita to Amarr rush')
+
+    expect(screen.getByRole('button', { name: /^Item exchange$/ }).textContent).toBe('Item exchange')
+    expect(screen.getByRole('button', { name: /^Auction$/ }).textContent).toBe('Auction')
+    expect(screen.getByRole('button', { name: /^Courier 115$/ })).toBeInTheDocument()
+  })
+
+  it('keeps the typed numerals off until the new segment response lands', async () => {
+    // keepPreviousData holds the courier envelope on screen while the
+    // item-exchange response loads, and the numerals' meaning comes off that
+    // captured envelope, not the live URL (WEB-1): read from the URL, the
+    // lifted numbers would resurrect for exactly the window the old rows are
+    // still up.
+    let releaseExchange!: (page: Response) => void
+    const exchangeInFlight = new Promise<Response>((resolve) => {
+      releaseExchange = resolve
+    })
+    const calls = stubFetch(
+      anonymousMe((url) =>
+        url.includes('contract_type=item_exchange') ? exchangeInFlight : segmentedPage(url),
+      ),
+    )
+
+    renderApp('/contracts?contract_type=courier&ships_only=false')
+    await screen.findByText('Jita to Amarr rush')
+
+    await userEvent.click(screen.getByRole('button', { name: /^Item exchange$/ }))
+    await waitFor(() =>
+      expect(calls.some((url) => url.includes('contract_type=item_exchange'))).toBe(true),
+    )
+
+    // The pressed state follows the live URL...
+    expect(screen.getByRole('button', { name: /^Item exchange$/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    // ...but the counts on screen are still the lifted envelope's, so the
+    // numerals stay off until the response for this segment arrives.
+    expect(screen.getByRole('button', { name: /^Item exchange$/ }).textContent).toBe('Item exchange')
+
+    releaseExchange(jsonResponse(listPage([ROW], { segment_counts: SEGMENT_COUNTS })))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^Item exchange 1,240$/ })).toBeInTheDocument(),
+    )
+  })
+
   it('keeps a sort both segments can express', async () => {
     // Price is sortable in All and in Auction alike — resetting it would throw
     // away the user's choice for no disclosure gain.

--- a/app/frontend/web/src/features/contracts/hooks/useContracts.ts
+++ b/app/frontend/web/src/features/contracts/hooks/useContracts.ts
@@ -54,6 +54,7 @@ export function useContracts(search: ContractSearch) {
       // columns over rows whose terms had not been written yet.
       return {
         ...data,
+        countsSearch: search,
         segment,
         regionIds: query.region_ids ?? [],
         enrichmentFiltered,

--- a/docs/bug-hunts/2026-08-08-f008-prerelease-consolidated.md
+++ b/docs/bug-hunts/2026-08-08-f008-prerelease-consolidated.md
@@ -37,8 +37,12 @@ on every item-less-segment visit under default settings.
 **Blast radius:** Frontend-only for the D11-precedent fix (hide typed numerals in that state, as All
 already does). The full fix (serve ships-respecting mirror counts) is a backend envelope change —
 recorded as design decision D-b below.
-**Fix approach:** Apply the D11 precedent now — typed item-bearing numerals hidden while
-`leavingItemLess`, pinned by tests; keep D-b as the recorded upgrade path.
+**Fix approach:** Applied (PR #155): typed item-bearing numerals hidden per the D11 precedent,
+with interpretation reading a fetch-time-captured search (WEB-1) OR'd with the live one so both
+transition directions are covered. Accepted residuals from the review's state enumeration — the
+ships-only ↔ widened toggle's one-request stale window (generic keepPreviousData semantics) and
+one over-suppressed honest numeral in the ships-only → item-less transition — are documented at
+the predicate; D-b (mirror counts) remains the recorded complete answer.
 
 ### B2. A spec-conformant contract without `price` poisons the entire aggregation run, recurring every tick
 **Consensus:** ALL FOUR hunters; verified by consolidation.

--- a/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
+++ b/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
@@ -63,13 +63,13 @@ notes and commit messages.
 
 ## Execution Status
 
-**Overall:** 1/4 phases shipped.
+**Overall:** 2/4 phases shipped.
 
 | Phase | Status | Ship SHA(s) | Notes |
 |---|---|---|---|
 | 1 — parser gaps (B3/B5/B7) | ✅ Shipped | `82dd8ef` | PR #153 merged 2026-08-08 at `251e951` |
-| 2 — format fixes (B4/B6) | 🚧 In progress | — | on branch `fix/composition-format` |
-| 3 — segment numerals (B1) | ⬜ Not started | — | — |
+| 2 — format fixes (B4/B6) | ✅ Shipped | `f585dc5` | PR #154 merged 2026-08-08 at `195af01` |
+| 3 — segment numerals (B1) | 🚧 In progress | — | on branch `fix/segment-count-numerals` |
 | 4 — price nullable (B2) | ⬜ Not started | — | PR to be LEFT OPEN for Sam (`Review — database schema`) |
 
 ## Global constraints (every phase)
@@ -166,7 +166,7 @@ notes and commit messages.
 
 ## Phase 2 — Format fixes (B4, B6) — branch `fix/composition-format`
 
-**Execution Status:** 🚧 IN PROGRESS — claimed 2026-08-08T21:20Z (branch `fix/composition-format`)
+**Execution Status:** ✅ SHIPPED at `f585dc5` on 2026-08-08 (PR #154 merged at `195af01`)
 
 **Files:** `src/features/contracts/format.ts`, `src/features/contracts/format.test.ts`.
 
@@ -197,7 +197,7 @@ Routine; codex skipped as trivial, recorded); merge on green.
 
 ## Phase 3 — Segment numerals in the item-less state (B1) — branch `fix/segment-count-numerals`
 
-**Execution Status:** ⬜ NOT STARTED
+**Execution Status:** 🚧 IN PROGRESS — claimed 2026-08-08T21:50Z (branch `fix/segment-count-numerals`)
 
 **Files:** `src/features/contracts/components/SegmentTabs.tsx`, its tests (in `pages.test.tsx` or
 a colocated file — follow where D11's All-numeral tests live).

--- a/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
+++ b/docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md
@@ -72,6 +72,17 @@ notes and commit messages.
 | 3 — segment numerals (B1) | 🚧 In progress | — | on branch `fix/segment-count-numerals` |
 | 4 — price nullable (B2) | ⬜ Not started | — | PR to be LEFT OPEN for Sam (`Review — database schema`) |
 
+### Discoveries
+
+- **Phase 3 accepted residuals (codex round 2's state enumeration, 2026-08-08):** the
+  suppression predicate (`countsFromItemLess || leavingItemLess`) leaves the ships-only ↔ widened
+  toggle showing the held envelope's figures for its one-request window — the same
+  keepPreviousData semantics as every number on the page, coherent with the held rows, and not
+  worth a flicker on the most-used checkbox — and over-suppresses one honest numeral during the
+  ships-only → item-less transition (hidden-though-right for one request; hidden beats wrong).
+  Both are documented at the predicate in `SegmentTabs.tsx`; the complete per-request answer is
+  design decision D-b (mirror counts), Sam's call.
+
 ## Global constraints (every phase)
 
 1. **TDD is mandatory.** BEFORE starting any task: invoke `superpowers:test-driven-development` and


### PR DESCRIPTION
## Summary

Remediation plan Phase 3 (bug B1 of `docs/bug-hunts/2026-08-08-f008-prerelease-consolidated.md`; found independently by three of four hunters):

Standing on Courier, the Item exchange / Auction buttons showed ships-lifted counts, but clicking them restores `ships_only` — advertised ~33,800, delivered ~411 at spec magnitudes. This is Criterion 1.8's "silent-no-op wearing a numeral" in mirror direction; D11 fixed it for the All control only.

Fix follows the D11 precedent ("no numeral beats a wrong one") **plus** the WEB-1 capture discipline: `useContracts`' queryFn now captures the search the envelope was served under (`countsSearch`, joining the existing fetch-time captures), and SegmentTabs interprets counts exclusively from it — so the numerals also stay off through the whole `keepPreviousData` transition window instead of resurrecting from the stale envelope the moment the URL flips. Pressed states and click patches stay on the live search. The Courier control's own numeral (honest in that state) stays.

The full alternative — serving ships-respecting mirror counts — remains design decision D-b for Sam (recorded in D11 and the consolidated report).

## Test evidence

- TDD: two page-level tests watched RED (buttons carried the lifted numerals), then GREEN — including the WEB-1 discriminator using the established deferred-response pattern: pressed state follows the click while numerals stay off until the new response lands.
- New e2e in `segments.spec.ts`: on Courier, item-bearing buttons expose no count; Courier keeps its own.
- All five lanes: eslint ✓, tsc ✓, vitest 318×2 ✓, e2e 140 ✓.

## Merge classification

Routine

Frontend-only; no API change. Codex adversarial review run before merge per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)