### PR TITLE
perf(api): raise the item upsert batch from 50 to 500

### DIFF
--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -581,7 +581,10 @@ class ContractAggregationService:
 
         if all_items:
             logger.info(f"Preparing to upsert {len(all_items)} contract items in batches.")
-            BATCH_SIZE = 50  # Number of items to process in each batch
+            # Sized against asyncpg's 32,767 bind-parameter ceiling: item rows
+            # carry ~17 supplied columns, so 500 rows binds ~8,500 parameters.
+            # The contract upsert above uses the same figure.
+            BATCH_SIZE = 500
             for i in range(0, len(all_items), BATCH_SIZE):
                 batch_items = all_items[i:i + BATCH_SIZE]
                 logger.info(f"Upserting batch of {len(batch_items)} contract items (items {i + 1}-{i + len(batch_items)} of {len(all_items)}).")


### PR DESCRIPTION
## Summary

Perf disposition item 3 (`docs/perf-audits/2026-08-08-remediation-status.md`, finding SP7 — "the single highest value-per-character change in this document"): the item upsert still batched at 50 while the contract upsert beside it uses 500. ~10× fewer statements and per-batch log lines per enrichment run. Bind-param ceiling documented at the constant (~8,500 of 32,767 used).

## Test evidence

Ingestion + upsert suites green (65 passed), lint clean. No behavior change — batch size only; TDD not applicable (perf constant, not a feature or bugfix; upsert correctness is covered by the existing suites).

## Merge classification

Routine

One constant; no schema, no API, no semantics change. Codex review skipped as below the meaningful-PR bar (recorded per the OD5 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)