### PR TITLE
chore(api): adopt redis aclose() and the plain sqlalchemy select import

### DIFF
--- a/app/backend/src/fastapi_app/core/cache.py
+++ b/app/backend/src/fastapi_app/core/cache.py
@@ -54,7 +54,7 @@ class CacheManager:
     async def close(self):
         """Closes the Redis connection pool if it has been initialized."""
         if self.redis_client:
-            await self.redis_client.close()
+            await self.redis_client.aclose()
             self.redis_client = None
             logger.info("Redis connection closed.")
 

--- a/app/backend/src/fastapi_app/core/esi_client_class.py
+++ b/app/backend/src/fastapi_app/core/esi_client_class.py
@@ -187,7 +187,7 @@ class ESIClient:
         if self._managed_http_client:
             await self._managed_http_client.aclose()
         if self._managed_redis_client:
-            await self._managed_redis_client.close()
+            await self._managed_redis_client.aclose()
 
     async def get_esi_data_with_etag_caching(
         self, path: str, all_pages: bool = False, ignore_404: bool = False

--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -359,7 +359,7 @@ class ContractAggregationService:
                         "Leaving the current holder's lock intact.",
                         lock_ttl,
                     )
-            await redis_client.close()  # Ensure redis client is closed
+            await redis_client.aclose()  # Ensure redis client is closed
 
     def _usable_region_ids(self) -> List[int] | None:
         """Validate the configured region list, or None when the run must be skipped.

--- a/app/backend/src/fastapi_app/services/contract_service.py
+++ b/app/backend/src/fastapi_app/services/contract_service.py
@@ -3,7 +3,7 @@ import time
 from sqlalchemy import and_, case, func, or_, text
 from sqlalchemy.exc import StatementError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
+from sqlalchemy import select
 from sqlalchemy.orm import aliased, selectinload
 
 from ..core.config import get_settings

--- a/app/backend/src/fastapi_app/services/watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/services/watchlist_matcher.py
@@ -106,7 +106,7 @@ class WatchlistMatcherService:
                         "expired mid-run and was reacquired by another runner. Leaving it intact.",
                         lock_ttl,
                     )
-            await redis_client.close()
+            await redis_client.aclose()
 
     async def run_matching(self) -> None:
         started = time.monotonic()

--- a/app/backend/src/fastapi_app/tests/lock_double.py
+++ b/app/backend/src/fastapi_app/tests/lock_double.py
@@ -28,5 +28,5 @@ class FakeLockRedis:
             return 1
         return 0
 
-    async def close(self):
+    async def aclose(self):
         pass

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -25,7 +25,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.exc import StatementError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
+from sqlalchemy import select
 
 from datetime import datetime, timedelta, timezone
 from fastapi_app.models.contracts import Contract, ContractItem


### PR DESCRIPTION
## Summary

Perf disposition item 14 (`docs/perf-audits/2026-08-08-remediation-status.md`, SP16 + P12): the four async redis `close()` calls move to `aclose()` (deprecated since redis-py 5.0.1; installed 6.2.0 verified to carry `aclose`), and `contract_service` drops the `sqlalchemy.future` import shim, matching `background_aggregation`. The lock test double renames with the client API it stands in for.

**SP14 deliberately not taken:** the "dead" `sorted()` in `resolve_ids_to_names` stays — chunk-order determinism gives reproducible request bodies (VCR-style matching and log stability), and sorting a few thousand ints is noise. Recorded so nobody re-opens it without that context.

## Test evidence

Full backend suite 679 passed (dev baseline), lint clean.

## Merge classification

Routine

Mechanical currency; no semantics change. Codex review skipped as below the meaningful-PR bar (recorded per the OD5 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)