### PR TITLE
docs(plan): record the perf quick-win wave (OD9)

### DIFF
--- a/docs/superpowers/handoffs/2026-08-08-overnight-campaign-handoff.md
+++ b/docs/superpowers/handoffs/2026-08-08-overnight-campaign-handoff.md
@@ -56,7 +56,9 @@ now). Its §1 release runbook pointer remains authoritative and is NOT restated:
 
 ## 3. The queued docket (next sessions)
 
-1. **Perf quick-wins** — ranked list in
+1. **Perf quick-wins** — PARTIALLY DONE since this handoff was written: PRs #158 (item batch
+   50→500), #159 (search debounce at the data layer), #160 (redis aclose + select import; SP14
+   deliberately kept) shipped; see decision-log OD9. Remaining: ranked list in
    [`docs/perf-audits/2026-08-08-remediation-status.md`](../../perf-audits/2026-08-08-remediation-status.md)
    §"Still open, worth doing". Local, no production access needed: item upsert batch 50→500
    (`background_aggregation.py:584` — one line), search debounce (`FilterRail.tsx` — the React

--- a/docs/superpowers/plans/2026-08-08-overnight-followups-decision-log.md
+++ b/docs/superpowers/plans/2026-08-08-overnight-followups-decision-log.md
@@ -245,3 +245,29 @@ sibling's committed row poisoned it. Recorded as pitfall TEST-23; both tests are
 footprint-free under `finally`.
 
 **Reversibility.** Three merged PRs are ordinary reverts; #156 awaits Sam by construction.
+
+---
+
+## OD9 — Perf quick-win wave: three shipped, one deliberately rejected, the rest sequenced
+
+**Background.** Continuing Sam's autonomy grant after the bug-hunt remediation, the local items
+from the perf disposition's ranked list.
+
+**Shipped.** PR #158 (item upsert batch 50→500 — disposition item 3), PR #159 (search debounced at
+the data layer, 300 ms, URL untouched — item 6; two codex rounds: round 1 caught the page-reset
+riding the effective search from page 2+, fixed by freezing the whole query while the text is
+mid-edit; the repo's react-hooks lint rejected both the ref form and setState-in-effect, forcing
+the documented render-adjust pattern with value comparison), PR #160 (redis `aclose()` + plain
+`select` import — item 14's live half).
+
+**Rejected, recorded so nobody reopens it bare:** SP14's "dead" `sorted()` in
+`resolve_ids_to_names` stays — chunk-order determinism feeds reproducible request bodies, and the
+sort is noise at real id counts.
+
+**Sequenced, not started:** the location indexes wait for PR #156 (a second migration PR now would
+fork the alembic head); the bundle-budget needs a warn-vs-fail choice and a baseline number;
+cache-aside, the ESI fan-out semaphore, QueueHandler logging, ingestion metrics, and streaming
+each carry enough design surface to deserve fresh-context sessions against the disposition's
+write-ups.
+
+**Reversibility.** All ordinary PR reverts.


### PR DESCRIPTION
## Summary

Decision-log OD9: PRs #158/#159/#160 shipped, SP14 deliberately rejected with its reasoning, the remaining perf items sequenced (indexes gated on PR #156's migration head; the mediums to fresh-context sessions). Campaign-handoff docket updated to match.

## Merge classification

Routine

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)