### PR TITLE
fix(api): index the location filter columns and widen issuer ids to int64

### DIFF
--- a/app/backend/src/alembic/versions/a7c44d19e582_location_indexes_issuer_int64.py
+++ b/app/backend/src/alembic/versions/a7c44d19e582_location_indexes_issuer_int64.py
@@ -43,13 +43,12 @@ def upgrade() -> None:
         'ix_contracts_start_location_id', 'contracts',
         ['start_location_id'], unique=False,
     )
-    op.alter_column(
-        'contracts', 'issuer_id',
-        existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False,
-    )
-    op.alter_column(
-        'contracts', 'issuer_corporation_id',
-        existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False,
+    # One statement for both columns: a width change rewrites the table, and
+    # separate ALTERs would do that twice under the same exclusive lock.
+    op.execute(
+        "ALTER TABLE contracts "
+        "ALTER COLUMN issuer_id TYPE BIGINT, "
+        "ALTER COLUMN issuer_corporation_id TYPE BIGINT"
     )
 
 
@@ -77,13 +76,11 @@ def downgrade() -> None:
         $$
         """
     )
-    op.alter_column(
-        'contracts', 'issuer_corporation_id',
-        existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False,
-    )
-    op.alter_column(
-        'contracts', 'issuer_id',
-        existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False,
+    # Single statement, single table rewrite — mirror of the upgrade.
+    op.execute(
+        "ALTER TABLE contracts "
+        "ALTER COLUMN issuer_corporation_id TYPE INTEGER, "
+        "ALTER COLUMN issuer_id TYPE INTEGER"
     )
     op.drop_index('ix_contracts_start_location_id', table_name='contracts')
     op.drop_index('ix_contracts_start_location_system_id', table_name='contracts')

--- a/app/backend/src/alembic/versions/a7c44d19e582_location_indexes_issuer_int64.py
+++ b/app/backend/src/alembic/versions/a7c44d19e582_location_indexes_issuer_int64.py
@@ -1,0 +1,89 @@
+"""location filter indexes + issuer columns to int64
+
+Two remainders from the 2026-08-08 perf disposition and bug hunt:
+
+- ix_contracts_start_location_system_id / ix_contracts_start_location_id —
+  the system/station filter columns were the last unindexed IN-list predicates
+  on the browse path (the 2026-08-02 audit used start_location_id's missing
+  index as its scan-cost control), and start_location_system_id is scanned
+  IS NULL by the unknown-system residual count on every system-filtered
+  request.
+- issuer_id / issuer_corporation_id widen to BigInteger: ESI publishes both
+  as int64, and a CCP id above 2^31 would poison ingestion the same way a
+  price-less contract did before f2a91c3b7e04.
+
+Revision ID: a7c44d19e582
+Revises: f2a91c3b7e04
+Create Date: 2026-08-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7c44d19e582'
+down_revision: Union[str, None] = 'f2a91c3b7e04'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Pre-deploy command on a live database; fail fast rather than queue behind
+    # the outgoing instance's ingestion transaction.
+    op.execute("SET lock_timeout = '30s'")
+    op.create_index(
+        'ix_contracts_start_location_system_id', 'contracts',
+        ['start_location_system_id'], unique=False,
+    )
+    op.create_index(
+        'ix_contracts_start_location_id', 'contracts',
+        ['start_location_id'], unique=False,
+    )
+    op.alter_column(
+        'contracts', 'issuer_id',
+        existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False,
+    )
+    op.alter_column(
+        'contracts', 'issuer_corporation_id',
+        existing_type=sa.Integer(), type_=sa.BigInteger(), existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Narrowing back to Integer is impossible once an id above 2^31-1 is stored;
+    the guard turns the incidental out-of-range error into a stated refusal,
+    emitted as SQL under an exclusive lock so it renders offline and cannot
+    race a writer (the f2a91c3b7e04 pattern).
+    """
+    op.execute("SET lock_timeout = '30s'")
+    op.execute("LOCK TABLE contracts IN ACCESS EXCLUSIVE MODE")
+    op.execute(
+        """
+        DO $$
+        DECLARE oversized bigint;
+        BEGIN
+            SELECT COUNT(*) INTO oversized FROM contracts
+            WHERE issuer_id > 2147483647 OR issuer_corporation_id > 2147483647;
+            IF oversized > 0 THEN
+                RAISE EXCEPTION 'cannot narrow issuer columns to int32: % stored contract(s) carry an id above 2147483647. CCP has allocated beyond int32; deleting those rows is a data decision this migration refuses to make.', oversized;
+            END IF;
+        END
+        $$
+        """
+    )
+    op.alter_column(
+        'contracts', 'issuer_corporation_id',
+        existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False,
+    )
+    op.alter_column(
+        'contracts', 'issuer_id',
+        existing_type=sa.BigInteger(), type_=sa.Integer(), existing_nullable=False,
+    )
+    op.drop_index('ix_contracts_start_location_id', table_name='contracts')
+    op.drop_index('ix_contracts_start_location_system_id', table_name='contracts')

--- a/app/backend/src/fastapi_app/models/contracts.py
+++ b/app/backend/src/fastapi_app/models/contracts.py
@@ -70,8 +70,11 @@ class Contract(Base):
     # populates returns an empty page that reads as "no matches" (ESI-3).
     status: Mapped[str] = mapped_column(String, nullable=False)
     type: Mapped[str] = mapped_column(String, nullable=False)
-    issuer_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    issuer_corporation_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    # BigInteger because ESI publishes both as int64: CCP allocating an id above
+    # 2^31 would otherwise poison ingestion the same way a price-less contract
+    # did before f2a91c3b7e04 made price nullable.
+    issuer_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    issuer_corporation_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     start_location_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
     start_location_system_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     # NULL where the destination is a player structure (no tokenless resolution
@@ -130,6 +133,12 @@ class Contract(Base):
         Index('ix_contracts_date_expired', 'date_expired'),
         # Serves the per-region watermark lookup (max(last_seen_at) grouped by region).
         Index('ix_contracts_region_last_seen', 'start_location_region_id', 'last_seen_at'),
+        # The system/station filter columns. start_location_id was the 2026-08-02
+        # perf audit's own control experiment for unindexed scan cost, and
+        # start_location_system_id is additionally scanned IS NULL by
+        # _count_unknown_system_excluded on every system-filtered request.
+        Index('ix_contracts_start_location_system_id', 'start_location_system_id'),
+        Index('ix_contracts_start_location_id', 'start_location_id'),
         Index('ix_contracts_collateral', 'collateral'),
         Index('ix_contracts_volume', 'volume'),
         Index('ix_contracts_buyout', 'buyout'),

--- a/app/backend/src/fastapi_app/tests/test_migrations.py
+++ b/app/backend/src/fastapi_app/tests/test_migrations.py
@@ -71,15 +71,22 @@ def test_downgrade_refuses_while_priceless_contracts_exist(blank_migrated_sync_c
                   r"contract\(s\) have no price.*data decision this migration "
                   r"refuses to make",
         ):
-            command.downgrade(cfg, "-1")
+            # Explicit target, never "-1": a relative step silently re-targets
+            # itself the moment a newer migration lands above this one. The
+            # preceding migrations' downgrades run first on the walk; the
+            # refusal aborts the one caller-managed transaction, so the
+            # rollback below restores every step.
+            command.downgrade(cfg, "685dab7d6df5")
     finally:
         # The fixture is SESSION-scoped (TEST-23): one database and one
         # connection shared by every consumer. Leave both exactly as found
         # WHATEVER this test's outcome — clear any open/aborted transaction,
-        # then remove the row this test committed, or the sibling
-        # clean-downgrade test meets a corpus with a price-less contract.
+        # remove the row this test committed, and restore head (the first
+        # single-step downgrade above committed).
         conn.rollback()
         conn.execute(text("DELETE FROM contracts WHERE contract_id = 990001"))
+        conn.commit()
+        command.upgrade(cfg, "head")
         conn.commit()
 
 
@@ -95,7 +102,9 @@ def test_clean_downgrade_restores_not_null_on_price(blank_migrated_sync_connecti
     conn = blank_migrated_sync_connection
     cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
     cfg.attributes["connection"] = conn
-    command.downgrade(cfg, "-1")
+    # Explicit targets, never "-1" — a relative step silently re-targets
+    # itself the moment a newer migration lands above this one.
+    command.downgrade(cfg, "685dab7d6df5")
     conn.commit()
 
     try:
@@ -140,3 +149,72 @@ def test_offline_downgrade_renders_a_transaction_wrapped_locked_guard():
     alter = rendered.index("ALTER COLUMN price SET NOT NULL")
     commit = rendered.index("COMMIT")
     assert begin < lock < guard < alter < commit
+
+
+def test_downgrade_refuses_while_an_issuer_id_exceeds_int32(blank_migrated_sync_connection):
+    """The issuer-narrowing downgrade must fail with a stated reason once CCP has
+    allocated beyond int32 — not with an incidental out-of-range error. Same
+    emitted-SQL guard shape as the price migration; same SESSION-scoped fixture
+    discipline (TEST-23): every mutation restored in finally."""
+    from pathlib import Path
+
+    import pytest
+    from alembic import command
+    from alembic.config import Config
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError
+
+    conn = blank_migrated_sync_connection
+    conn.execute(
+        text(
+            """
+            INSERT INTO contracts
+                (contract_id, collateral, status, type, issuer_id,
+                 issuer_corporation_id, for_corporation, date_issued, date_expired,
+                 item_processing_status, is_ship_contract)
+            VALUES
+                (990002, 0, 'outstanding', 'item_exchange', 3000000000, 1, FALSE,
+                 '2026-07-01T00:00:00Z', '2026-12-31T00:00:00Z', 'PENDING_ITEMS',
+                 FALSE)
+            """
+        )
+    )
+    conn.commit()
+
+    cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
+    cfg.attributes["connection"] = conn
+    try:
+        with pytest.raises(DBAPIError, match="cannot narrow issuer columns to int32"):
+            command.downgrade(cfg, "f2a91c3b7e04")
+    finally:
+        conn.rollback()
+        conn.execute(text("DELETE FROM contracts WHERE contract_id = 990002"))
+        conn.commit()
+
+
+def test_clean_downgrade_restores_int32_issuer_columns(blank_migrated_sync_connection):
+    """With no oversized ids the downgrade must actually narrow — the guard test
+    alone stays green if the alteration is dropped. Head restored in finally."""
+    from pathlib import Path
+
+    from alembic import command
+    from alembic.config import Config
+    from sqlalchemy import text
+
+    conn = blank_migrated_sync_connection
+    cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
+    cfg.attributes["connection"] = conn
+    command.downgrade(cfg, "f2a91c3b7e04")
+    conn.commit()
+
+    try:
+        data_type = conn.execute(
+            text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_name = 'contracts' AND column_name = 'issuer_id'"
+            )
+        ).scalar_one()
+        assert data_type == "integer"
+    finally:
+        command.upgrade(cfg, "head")
+        conn.commit()

--- a/app/backend/src/fastapi_app/tests/test_migrations.py
+++ b/app/backend/src/fastapi_app/tests/test_migrations.py
@@ -153,9 +153,11 @@ def test_offline_downgrade_renders_a_transaction_wrapped_locked_guard():
 
 def test_downgrade_refuses_while_an_issuer_id_exceeds_int32(blank_migrated_sync_connection):
     """The issuer-narrowing downgrade must fail with a stated reason once CCP has
-    allocated beyond int32 — not with an incidental out-of-range error. Same
-    emitted-SQL guard shape as the price migration; same SESSION-scoped fixture
-    discipline (TEST-23): every mutation restored in finally."""
+    allocated beyond int32 — not with an incidental out-of-range error, and for
+    EITHER column (dropping one arm of the guard must fail one variant). Same
+    emitted-SQL guard shape as the price migration; TEST-23: arrangement,
+    assertion, and restoration all inside one cleanup scope, so a regression in
+    the tested code still leaves the session fixture exactly as found."""
     from pathlib import Path
 
     import pytest
@@ -165,31 +167,36 @@ def test_downgrade_refuses_while_an_issuer_id_exceeds_int32(blank_migrated_sync_
     from sqlalchemy.exc import DBAPIError
 
     conn = blank_migrated_sync_connection
-    conn.execute(
-        text(
-            """
-            INSERT INTO contracts
-                (contract_id, collateral, status, type, issuer_id,
-                 issuer_corporation_id, for_corporation, date_issued, date_expired,
-                 item_processing_status, is_ship_contract)
-            VALUES
-                (990002, 0, 'outstanding', 'item_exchange', 3000000000, 1, FALSE,
-                 '2026-07-01T00:00:00Z', '2026-12-31T00:00:00Z', 'PENDING_ITEMS',
-                 FALSE)
-            """
-        )
-    )
-    conn.commit()
-
     cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
     cfg.attributes["connection"] = conn
-    try:
-        with pytest.raises(DBAPIError, match="cannot narrow issuer columns to int32"):
-            command.downgrade(cfg, "f2a91c3b7e04")
-    finally:
-        conn.rollback()
-        conn.execute(text("DELETE FROM contracts WHERE contract_id = 990002"))
-        conn.commit()
+
+    for column in ("issuer_id", "issuer_corporation_id"):
+        try:
+            conn.execute(
+                text(
+                    f"""
+                    INSERT INTO contracts
+                        (contract_id, collateral, status, type, issuer_id,
+                         issuer_corporation_id, for_corporation, date_issued,
+                         date_expired, item_processing_status, is_ship_contract)
+                    VALUES
+                        (990002, 0, 'outstanding', 'item_exchange',
+                         {'3000000000' if column == 'issuer_id' else '1'},
+                         {'3000000000' if column == 'issuer_corporation_id' else '1'},
+                         FALSE, '2026-07-01T00:00:00Z', '2026-12-31T00:00:00Z',
+                         'PENDING_ITEMS', FALSE)
+                    """
+                )
+            )
+            conn.commit()
+            with pytest.raises(DBAPIError, match="cannot narrow issuer columns to int32"):
+                command.downgrade(cfg, "f2a91c3b7e04")
+        finally:
+            conn.rollback()
+            conn.execute(text("DELETE FROM contracts WHERE contract_id = 990002"))
+            conn.commit()
+            command.upgrade(cfg, "head")
+            conn.commit()
 
 
 def test_clean_downgrade_restores_int32_issuer_columns(blank_migrated_sync_connection):
@@ -208,13 +215,16 @@ def test_clean_downgrade_restores_int32_issuer_columns(blank_migrated_sync_conne
     conn.commit()
 
     try:
-        data_type = conn.execute(
-            text(
-                "SELECT data_type FROM information_schema.columns "
-                "WHERE table_name = 'contracts' AND column_name = 'issuer_id'"
-            )
-        ).scalar_one()
-        assert data_type == "integer"
+        types = dict(
+            conn.execute(
+                text(
+                    "SELECT column_name, data_type FROM information_schema.columns "
+                    "WHERE table_name = 'contracts' "
+                    "AND column_name IN ('issuer_id', 'issuer_corporation_id')"
+                )
+            ).all()
+        )
+        assert types == {"issuer_id": "integer", "issuer_corporation_id": "integer"}
     finally:
         command.upgrade(cfg, "head")
         conn.commit()


### PR DESCRIPTION
## Summary

**Held for Sam — schema migration** (`a7c44d19e582`, anchored on #156's `f2a91c3b7e04`; single head verified). Two remainders now that #156 settled the head:

1. **Indexes on `start_location_system_id` and `start_location_id`** — perf disposition item 5: the last unindexed IN-list filter columns on the browse path (`start_location_id` was the 2026-08-02 audit's own scan-cost control), plus the `IS NULL` scan `_count_unknown_system_excluded` performs per system-filtered request.
2. **`issuer_id` / `issuer_corporation_id` → BigInteger** — bug-hunt design item D-g, folded into this wave per its recorded recommendation: ESI publishes both as int64; a CCP id above 2^31 is the price-outage shape all over again. **If you'd rather take the indexes alone, say so and I'll strip the widening** — they're separable ALTERs.

Downgrade narrows back behind the #156-pattern guard (emitted SQL, `ACCESS EXCLUSIVE` lock, stated refusal when oversized ids exist), renderable offline via the env.py wrapper #156 fixed.

## Test evidence

- Migration-equivalence test drove the model change RED → GREEN.
- New refusal + clean-downgrade tests (footprint-free on the session-scoped fixture, TEST-23).
- **Every downgrade test now names its target revision** — the price tests' relative `"-1"` silently re-targeted onto this migration the moment it existed (caught tonight when they broke; a second instance was self-inflicted by an unapplied edit and briefly misread as an alembic anomaly — it wasn't, and the debugging trail is in the session log).
- Full backend suite **688 passed**, lint clean.

## Merge classification

Review — database schema

**Do not merge without Sam.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)