### PR TITLE
test(api): pin the endpoint guardrails and fix the vacuous secret-hygiene assertion

### DIFF
--- a/app/backend/src/fastapi_app/tests/api/test_contracts.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contracts.py
@@ -190,3 +190,51 @@ async def test_paginate_contracts(client: AsyncClient, db_session: AsyncSession)
     assert data["page"] == 2
     assert data["size"] == 3
     assert [c["contract_id"] for c in data["items"]] == [4, 5, 6]
+
+
+# --- Endpoint guardrails: the constraints standing between an anonymous caller and the corpus ---
+
+async def test_size_above_the_cap_is_rejected_before_it_reaches_the_corpus(client: AsyncClient):
+    """size<=100 is the only thing between a caller and corpus-per-request pages;
+    its removal must fail a test, not pass silently."""
+    over = await client.get("/contracts/?size=101")
+    assert over.status_code == 422
+
+    at_cap = await client.get("/contracts/?size=100")
+    assert at_cap.status_code == 200
+
+
+async def test_a_search_below_min_length_is_rejected_at_the_wire(client: AsyncClient):
+    """The schema's min_length=3 guard, pinned at the HTTP surface — toApiQuery
+    gates short searches client-side, but the wire contract must hold for any
+    caller."""
+    response = await client.get("/contracts/?search=ab")
+    assert response.status_code == 422
+
+
+async def test_a_read_path_failure_serves_the_fixed_body_with_no_internals(
+    test_app, monkeypatch
+):
+    """The generic 500 handler's body is a fixed sentence. A failure whose
+    exception text carries statement internals (the SQLA-4 shape — an ILIKE
+    bind with the user's own search text) must not surface any of it on the
+    wire an anonymous caller sees; the scrub is pinned at the log layer
+    elsewhere, and this pins the HTTP layer. Starlette's Exception handler
+    builds the response AND re-raises, so this client must not re-raise app
+    exceptions the way the shared fixture's transport does — the response is
+    the subject here."""
+    from httpx import ASGITransport
+
+    from fastapi_app.api import contracts as contracts_api
+
+    async def raiser(*args, **kwargs):
+        raise RuntimeError("params: {'search_pattern': '%SECRET-BIND-TEXT%'}")
+
+    monkeypatch.setattr(contracts_api, "get_contracts", raiser)
+
+    transport = ASGITransport(app=test_app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as quiet_client:
+        response = await quiet_client.get("/contracts/?search=widget")
+    assert response.status_code == 500
+    assert response.json() == {"detail": "An unexpected server error occurred."}
+    assert "SECRET-BIND-TEXT" not in response.text

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -1325,7 +1325,13 @@ async def test_run_aggregation_reuses_app_session_factory_and_never_logs_databas
     for rec in caplog.records:
         msg = rec.getMessage()
         assert "Creating database engine" not in msg
-        assert service.settings.DATABASE_URL[:16] not in msg
+        # The SENSITIVE parts, each on its own: the old [:16] slice only covered
+        # "postgresql+async" — the dialect prefix every URL shares — so a line
+        # leaking just the credentials or host sailed past the guard. The
+        # fixture plants distinctive values precisely so these can be asserted.
+        assert "secret_user" not in msg
+        assert "secret_pw" not in msg
+        assert "db.internal" not in msg
 
 
 # --- ingestion-freshness recording (M4 Task 3.3) ---

--- a/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
+++ b/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
@@ -1,0 +1,357 @@
+<!-- ABOUTME: Consolidated test-coverage review of the F008 surface + the 2026-08-08/09 remediation work. -->
+<!-- ABOUTME: Four subagent reviews (read, write, frontend logic, frontend components/e2e); 130 gap rows by severity. -->
+
+# F008 + remediation test-coverage review — consolidated (2026-08-09)
+
+**Method:** four parallel systematic reviews (per-function path maps, every GAP row severity-tagged,
+no "covered indirectly" allowed). Full per-function tables are in the four subagent reports beside
+this file — they are the evidence; this file is the severity-organized view.
+
+## Totals
+
+| Severity | Count |
+|---|---|
+| Security-critical | **4** |
+| Correctness | **62** |
+| Nice-to-have | **60** |
+| **Total** | **126** + 4 queued-input statuses |
+
+## Coverage summary (per review)
+
+| Review | Report | Sec | Corr | NTH |
+|---|---|---|---|---|
+| Backend read path (contract_service, api/contracts) | subagent-backend-read-findings.md | 3 | 13 | 10 |
+| Backend write path (ingestion, matcher, upsert, migrations) | subagent-backend-write-findings.md | 1 | 11 | 19 |
+| Frontend logic (filters, format, columns, hooks) | subagent-frontend-logic-findings.md | 0 | 28 | 13 |
+| Frontend components + e2e | subagent-frontend-components-findings.md | 0 | 10 | 18 |
+
+## Security-critical gaps (4)
+
+1. **The anonymous list endpoint's `size<=100` cap has zero 422 tests** — the only thing standing
+   between a caller and corpus-per-request pages, and its removal is test-invisible.
+   `schemas/contracts.py:456`, `api/contracts.py:33`.
+2. **`search` min-length 422 untested at the endpoint AND the field has no max_length** — unbounded
+   user text binds into a double-wildcard ILIKE over two columns on an anonymous endpoint (coverage
+   gap + code observation). `schemas/contracts.py:332-336`.
+3. **No API-level test asserts the wire-visible 500 body carries no internals** — the SQLA-4/D12
+   parameter scrub is pinned at engine/log layers, never at the HTTP surface an attacker sees.
+   `main.py:88-104`.
+4. **The secret-hygiene log test asserts `DATABASE_URL[:16]` — the shared dialect prefix — never
+   appears in logs**, so a line leaking only credentials or host passes the guard the test exists to
+   be. (Write-path review SEC-1.)
+
+## Queued-input statuses
+
+- **O1a (WirePage omits `unknown_system_excluded`)** — STILL OPEN.
+- **O1b (fixture tiebreak localeCompare vs Python ordinal)** — STILL OPEN.
+- **O2 (type-partition invariant)** — PARTIALLY ADDRESSED: frontend partition now pinned
+  (`filters.test.ts:70`); `background_aggregation.py:720` still hard-codes
+  `["item_exchange", "auction"]` with no test pinning it to the enum.
+- **PR #156 deferred e2e null-price pin** — STILL OPEN.
+
+## What is demonstrably strong
+
+- The F008-era backend surface: liveness branches parametrized over every delisting case, derived-total
+  equivalence matrices, three-way partition identities per range family, both directions + NULL
+  placement for all six nullable sorts, whole-record log-scrub assertions with vacuity guards.
+- The remediation-week additions all landed with discriminating tests (mutation-verified fixtures,
+  render-order pins, footprint-free migration tests).
+- a11y assertions are real (aria-sort, aria-pressed, alert roles asserted per state, axe on five pages).
+
+## Key cross-cutting observations
+
+- **The gaps concentrate on the PRE-F008 legacy surface** (detail 404/422, collateral & date_expired
+  sorts, min_collateral) and **endpoint-level input validation** (1 of ~20 constraint paths has a
+  wire 422 test) — the bug-hunt's "old code predating the new rules" risk shape, third sighting.
+- **This week's debounce/freeze machinery has behavior-level pins but no unit layer**
+  (useDebouncedValue: no test file; sameSearch branches unpinned; DEFAULT_DIRECTION asserted for 2
+  of 9 fields).
+- **Write-path observability seams are trusted, not tested**: last_seen_at stamping (the watermark's
+  sole input), recursive-CTE queries only ever run against one distinct value, lock-skip paths.
+- **Responsive column visibility is asserted at no layer** despite the mobile Playwright project
+  running every spec.
+
+## Appendix — per-review gap registers (verbatim)
+
+### Backend read path — gap register
+
+## 3. Gap register (summary with severities)
+
+### Security-critical (3)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| SC-1 | `size` (and implicitly the whole pagination cost cap) has zero 422 tests on the anonymous list endpoint; `le=100` is the only thing standing between a caller and corpus-per-request pages, and its removal is test-invisible. | `schemas/contracts.py:456`, `api/contracts.py:33` (row 152) |
+| SC-2 | `search` min_length 422 untested at the endpoint, and the field has NO max_length — unbounded user text binds into a double-wildcard ILIKE over two columns on an anonymous endpoint. Coverage gap + code observation. | `schemas/contracts.py:332–336` (row 153) |
+| SC-3 | No API-level test asserts the wire-visible 500 body on a read-path failure contains no internals; the SQLA-4/D12 scrub is pinned at the engine/log layers only, never at the HTTP surface an attacker sees. | `main.py:88–104`, `api/contracts.py` (row 158) |
+
+### Correctness (13)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| C-1 | `GET /contracts/{id}` 404 branch has zero tests anywhere. | `api/contracts.py:76–77` (row 163) |
+| C-2 | Non-integer `/contracts/{id}` 422 untested. | `api/contracts.py:60–63` (row 164) |
+| C-3 | int64-overflow contract id → currently a driver 500; behavior unpinned. | `api/contracts.py:60–74` (row 165) |
+| C-4 | `min_collateral` filter has zero assertions anywhere (only `max_collateral`, and only in combination). | `contract_service.py:286–287` (row 30) |
+| C-5 | `sort_by=date_expired` ("Time left") — both directions untested; the silent-no-op-sort defect class F008 §6.2 names. | `contract_service.py:43`, SORT_MAP (row 86) |
+| C-6 | `sort_by=collateral` — both directions untested. | `contract_service.py:45` (row 87) |
+| C-7 | `sort_by=date_issued&sort_direction=asc` untested (desc pinned only via the fallback test). | row 85 |
+| C-8 | `still_listed_by_esi` case-`else_` correlated fallback under a NON-empty config (config-drift path) has no row-level regression test; verified once manually per the 2026-08-02 perf audit. | `contract_service.py:159–168` (row 11) |
+| C-9 | `_primary_label` ship-priority branch not distinguishably tested — no fixture where the offered ship has a higher record_id than a named non-ship item; `named[0]` alone passes every test. | `contract_service.py:710–714` (row 96) |
+| C-10 | Expiry criterion of `_live_item_bearing_contracts` (readiness denominator) untested — delisted sibling pinned, expired one not. | `contract_service.py:867` (row 120) |
+| C-11 | `page=0` / negative page 422 untested (constraint removal → negative OFFSET → 500). | `schemas/contracts.py:455` (row 154) |
+| C-12 | Negative-bound 422s untested across all six numeric range families at the endpoint. | `schemas/contracts.py:338–398` (row 155) |
+| C-13 | Malformed value types (non-int id-list members, non-bool `is_bpc`) and unknown `sort_by`/`sort_direction` 422s untested at the endpoint. | rows 156–157 |
+
+### Nice-to-have (10)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| N-1 | Out-of-range page (beyond last) with total > 0 — empty-`IN` joined branch and simple branch both unpinned. | row 77 |
+| N-2 | Joined-path `nulls_last` exercised for only 2 of 6 NULLABLE sorts (shared branch, low residual risk). | rows 71–72 |
+| N-3 | `_composition.total_volume is None` branch unasserted. | row 108 |
+| N-4 | `_primary_label` "Courier" (no destination) and `Contract {id}` fallbacks execute in fixtures but are never read. | rows 101–102 |
+| N-5 | Blank-string title (`"  "`) treated as absent — untested despite the comment calling it the common ESI shape. | row 99 |
+| N-6 | Detail item array record_id ORDER unasserted (set-only assertion). | row 116 |
+| N-7 | Taxonomy sort tie-break by id at equal names unasserted. | row 133 |
+| N-8 | `_taxonomy_coverage` short-circuit ordering (cost property) unasserted. | row 129 |
+| N-9 | `_error_without_bound_parameters` restore-after-render (`finally`) unasserted. | row 136 |
+| N-10 | Delisted-but-unexpired contract reachable via detail (asymmetry sibling of the pinned expired case) unasserted; also `min_runs=-1` boundary admission (`ge=-1` vs ESI-3 "never sends -1") unasserted. | rows 166, `schemas/contracts.py:351–366` |
+
+---
+
+## 4. What is demonstrably strong (for calibration)
+
+The F008-era surface is exceptionally well covered: both liveness branches parametrized over every delisting case; the derived-total equivalence matrix (13 filter shapes × 2 watermark branches, vacuity-guarded); three-way partition identities for every range family; both directions asserted for all six nullable sorts with NULL placement; log scrubbing pinned at four sites with whole-record assertions and a vacuity guard; the empty-page short-circuit discriminated by log-payload shape rather than response shape. The gaps concentrate in (a) the pre-F008 legacy surface (detail 404, collateral/date sorts, min_collateral) and (b) endpoint-level input validation, where exactly one of ~20 constraint paths (contract_type) has a wire-level 422 test.
+
+
+### Backend write path — severity sections
+
+## 1. Security-critical
+
+### SEC-1 — The secret-hygiene assertion checks the URL *scheme*, not the credentials
+`test_run_aggregation_reuses_app_session_factory_and_never_logs_database_url`
+(test_background_aggregation.py:1291-1328) sets
+`DATABASE_URL = "postgresql+asyncpg://secret_user:secret_pw@db.internal:5432/hb"` and asserts
+`service.settings.DATABASE_URL[:16] not in msg`. `DATABASE_URL[:16]` is `"postgresql+async"` — the
+dialect prefix every URL shares. The test catches a log line carrying the *full* URL, but a log line
+that renders only the credentials or netloc (`secret_user`, `secret_pw`, `db.internal`) — which is how
+sanitizers typically fail, by stripping the scheme and leaking the rest — passes. The docstring claims
+"no log line may carry any fragment of DATABASE_URL"; the assertion enforces one fragment, the least
+secret one. **Fix:** assert `"secret_pw" not in msg` and `"secret_user" not in msg` explicitly.
+Severity: security-critical (the test exists precisely as the secret-leak guard, and it is near-vacuous
+for the leak shapes that matter).
+
+---
+
+## 2. Correctness
+
+### C-1 — `_resolve_esi_objects` non-dict payload shape guard has no test
+background_aggregation.py:139-144. The guard exists because of a *documented live incident* ("this
+happened live when the list-shaped ETag helper flattened object payloads into keys"), yet no test ever
+returns a non-dict from `get_universe_type` / `get_universe_group` / `get_universe_station` /
+`get_universe_category`. All failure-path tests raise exceptions (the 131-134 branch). If the
+`isinstance(payload, dict)` check regressed, a list payload would flow into `.get()` calls and kill the
+run — the exact incident the guard repaired. GAP: feed a list/str payload, assert the one id degrades
+(warning logged, entry absent) and the run completes.
+
+### C-2 — The recursive-CTE observed-ids queries are only ever executed against ONE distinct value
+`_OBSERVED_CATEGORY_IDS_SQL` (156-165) and `_OBSERVED_GROUP_IDS_SQL` (170-179) are hand-written loose
+index scans whose `UNION ALL` recursion step only produces output when ≥2 distinct ids exist. Every
+repair test (`test_a_failed_category_name_fetch_is_repaired_from_observed_items`,
+`test_a_nameless_group_payload_is_repaired_from_observed_items`) stores items of exactly one category
+(6) and one group (25). A broken recursion returning only `min(category_id)` passes the entire suite,
+and the self-healing cache would silently repair only the lowest-numbered category/group forever. GAP:
+a repair test with two distinct missing categories (and groups), asserting both cache rows land.
+
+### C-3 — `last_seen_at` stamping is never asserted on the write path
+`_build_contract_rows` (263) stamps every row with one shared `seen_at`, and re-sighting restamps via
+the upsert's copy-on-conflict — this is the sole input to the `still_listed_by_esi()` watermark that
+decides site-wide visibility AND watchlist alerting. No aggregation test asserts (a) that a persisted
+row carries a fresh `last_seen_at`, (b) that all rows of one batch carry the SAME stamp (the
+"one run writes one value" invariant the docstring declares), or (c) that a re-sighted contract's stamp
+advances. The matcher tests hand-write `last_seen_at` on fixtures (legitimate for the reader side, but
+per TEST-18 that is exactly the seam where the writer can silently stop writing: if
+`last_seen_at` were dropped from the row dict, or added to `preserve_on_null`, every re-sighted
+contract would read as delisted one run later and no current test goes red). GAP: ingest, capture
+stamp; re-ingest, assert the stamp advanced and equals its batch-mates'.
+
+### C-4 — `run_aggregation`'s held-lock skip path is untested (matcher has it; aggregation does not)
+background_aggregation.py:473-476 (`except ConcurrencyLockError: log + return`) and the acquire-failure
+raise at 334-340. `grep ConcurrencyLockError test_background_aggregation.py` → no matches. The
+watchlist suite pins both (`test_run_matching_skips_when_lock_held`,
+`test_concurrency_lock_raises_when_held`); the aggregation suite pins release/TTL/mismatch but never a
+pre-held lock. A regression that let `run_aggregation` proceed (or crash the scheduler) on a held lock
+— the concurrent-run scenario the whole mechanism exists for — is invisible. GAP: pre-seed the store
+with a foreign token, run `run_aggregation`, assert no fetch/session activity and clean return.
+
+### C-5 — All-regions-failed outcome ("failure" via counters, not forced) is untested
+`_record_run_outcome` (499): `outcome = "failure"` when `ok == 0` without `forced_failure`. Tests cover
+success, all-304 success, partial, and forced failure (commit raise). The natural path — every region's
+fetch raises, `all_contracts_data` empty, no exception propagates, outcome derives from `(0, N)` — has
+no test asserting `outcome == "failure"`, gauge unmoved, and `last_success_at` preserved from the prior
+record. This is the readiness signal for a total ESI outage.
+
+### C-6 — The freshness-writer's own failure swallow is untested
+`_record_run_outcome` 495-523: "A failure of the outcome WRITE itself is logged and swallowed —
+freshness recording must never turn a successful ingest into a failed job." No test makes
+`redis_client.get`/`set` raise inside the recorder and asserts the run still completes as a success
+(and the warning is logged). If the try/except were narrowed or removed, a cache blip after a healthy
+commit would mark the whole job failed.
+
+### C-7 — `run_matching`'s job-boundary exception swallow is untested
+watchlist_matcher.py:127-133: a generic exception must be caught, logged via `log_key_event(...,
+success=False)`, and NOT propagate to the scheduler. No test raises from `_match_and_notify`/`_prune`/
+commit and asserts run_matching returns quietly with the failure event recorded. A regression here
+crash-loops the APScheduler job.
+
+### C-8 — No write-path test ingests an issuer id above 2^31 (the a7c migration's motivating bug)
+Migration a7c44d19e582 exists because "a CCP id above 2^31 would poison ingestion the same way a
+price-less contract did before f2a91c3b7e04". The price half got its TEST-22 write-path test
+(`test_a_spec_minimal_contract_persists_with_absent_optionals_null_or_defended` asserts `price is
+None` persists); the issuer half got only schema tests (model↔migration equivalence, downgrade
+guards). No test feeds `_process_contracts` a contract with `issuer_id=3_000_000_000` and asserts the
+row persists. The schema-equivalence test pins the column type, but the end-to-end "spec-extreme value
+survives the writer" test — the TEST-22 mirror this migration's own docstring invokes — is absent.
+
+### C-9 — The a7c downgrade's offline (`--sql`) rendering is unpinned
+`test_offline_downgrade_renders_a_transaction_wrapped_locked_guard` pins BEGIN < LOCK < guard < ALTER <
+COMMIT for **f2a91c3b7e04 only**. a7c44d19e582's downgrade uses the same emitted-SQL guard shape
+(docstring: "the f2a91c3b7e04 pattern") plus an additional ordering property of its own — index drops
+BEFORE the narrowing rewrite (a7c:81-85) — and neither the transaction wrapping nor the drop-before-
+rewrite order is asserted for it. Deleting a7c's `LOCK TABLE` line or reordering the drops regresses
+silently. (Escalated per instruction: the guard-atomicity property is what makes the refusal safe
+against a concurrent writer.)
+
+### C-10 — The matcher's contract-type gate is tested through one arm only
+watchlist_matcher.py:159-161 `Contract.type.in_((item_exchange, auction))`. Every matcher fixture is
+`ctype="auction"` (the `_contract` default); no test creates a matching **item_exchange** contract
+(positive arm — also leaves `_SHIP_TYPE_LABELS`' "an item exchange" rendering unasserted, see N-11) and
+no test creates a courier/other-type contract carrying an included watched item and asserts exclusion
+(negative arm). Dropping `item_exchange` from the tuple, or the tuple membership entirely, passes the
+suite.
+
+### C-11 — Mocked-behavior hazards beyond the known D-c (flag per CLAUDE.md testing rules)
+- **`test_plain_upsert_still_merges_on_dialects_without_conflict_support`** (test_db_upsert.py:125-141)
+  asserts against a hand-rolled `_RecordingSession` whose `merge` just appends to a list — it verifies
+  `db.merge` is *called*, not that merge-based upsert semantics work. The real fallback path (db_upsert
+  .py:77-79) never executes against any real non-PG database in the suite.
+- **The sqlite branch of `bulk_upsert`** (db_upsert.py:62-67), including preserve_on_null-on-sqlite,
+  never executes at all — the suite runs PostgreSQL only. The docstring's "compatible with both
+  PostgreSQL and SQLite" and "Supported on PostgreSQL and SQLite" claims are unverified; the branch is
+  effectively dead code carrying a compatibility promise no test backs.
+- **`FakeLockRedis.eval`** (tests/lock_double.py:24-29) reimplements the compare-and-delete Lua script
+  in Python. The double's semantics match today, but the Lua source itself (`_RELEASE_LOCK_LUA`) is
+  never executed by any test — a typo in the Lua (e.g. `KEYS[1]`/`ARGV[1]` swap) passes every lock test.
+  Lower priority than the first two (the script is 2 lines and shared), but it is the same hazard class.
+- *(Known, referenced, not re-counted: D-c — the `ESINotModifiedError` handlers in
+  `_fetch_regions`/`_fetch_item_rows` are dead against the real client, and the tests that exercise
+  them (`test_fetch_regions_counts_a_304_region_as_ok`,
+  `test_reingestion_with_unmodified_items_keeps_ship_flag`, the all-304 freshness test) mock a raise
+  the client never performs. D-d — Valkey-evicted page body truncating a region walk — likewise known.)*
+
+---
+
+## 3. Nice-to-have
+
+### N-1 — `_parse_esi_datetime` edge paths
+The `None → None` path (83-89) runs constantly via `date_completed` but no test asserts
+`row.date_completed is None` (spec-minimal asserts eight other optionals, not this one), and no test
+ever supplies a *populated* `date_completed`. A malformed date string raising `ValueError` inside
+`_build_contract_rows` kills the whole batch — behavior neither pinned nor decided.
+
+### N-2 — Per-field mapping assertions missing in `_build_contract_rows` (240-282)
+Fields whose *populated* value is never asserted on a persisted row: `status` (both the `"unknown"`
+default and a supplied value), `title`, `for_corporation=True`, `collateral` (non-zero), `reward`,
+`volume`. A `reward`↔`volume` mapping swap is undetectable by the current suite. `date_issued`/
+`date_expired` values are also never directly asserted post-persist (a swap is only accidentally caught
+by the expiry filter in the is_bpc HTTP test).
+
+### N-3 — Item-payload absence paths partially unasserted
+`is_blueprint_copy` absent → NULL is never asserted (ESI sends the flag true-or-absent per TEST-18;
+`test_item_level_columns...` asserts runs/ME/TE/item_id None for record 8212 but not the BPC flag), and
+`is_singleton`'s `.get(..., False)` default is never asserted.
+
+### N-4 — `_apply_dev_limit` with a configured limit and an under-limit batch
+Paths tested: limit>len (truncate), 0, None. The `limit and limit>0` but `len(contracts) <= limit`
+pass-through-without-warning path (421) has no test.
+
+### N-5 — `_record_run_outcome`'s invalid-JSON prior branch
+The `except (ValueError, TypeError)` at 510-511 (prior record is *unparseable* JSON, e.g. `"not json"`)
+is distinct from the tested valid-JSON-non-object branch (`"[]"`); it has no test.
+
+### N-6 — Lock release on body exception and client close are unasserted
+When the locked body raises (e.g. the commit-failure freshness test), the finally-release runs but no
+test asserts the lock key was removed from the store afterward; `aclose()` on all paths (including the
+acquire-failure path) is a no-op in the double and never asserted.
+
+### N-7 — `_select_known_station_systems` chunk boundary and mixed batches
+The read-back loop chunks via `UPDATE_ID_CHUNK_SIZE` (667) — monkeypatchable, but no test forces >1
+chunk here (the two existing chunk-boundary tests cover the status UPDATEs and the skip SELECT). Also
+no test mixes one already-known station with one needing a fresh fetch in a single batch (the partial
+fall-through at 632-644).
+
+### N-8 — The contract/item upsert 500-row batch loops are untestable as written
+`batch_size = 500` (544) and `BATCH_SIZE = 500` (587) are function-local literals — unlike
+`UPDATE_ID_CHUNK_SIZE` they cannot be monkeypatched, so crossing their boundary requires 500+ row
+fixtures nobody writes. Testability defect: hoist to module level so a boundary test becomes possible.
+
+### N-9 — Chunk crossing unforced for the incomplete-status and non-ship-clear UPDATE loops
+`test_id_list_updates_batch_across_the_chunk_boundary` crosses the boundary for the COMPLETED-set and
+ship-flag loops; the `incomplete_contract_ids` loop (818-823) and the `non_ship_completed` clear loop
+(812-817) are separate loops that could each independently stop after chunk one.
+
+### N-10 — No test asserts a courier contract triggers zero `get_contract_items` calls
+The `contract["type"] not in ["item_exchange", "auction"]` skip (720-721) is relied on by a dozen
+courier fixtures but never asserted (`get_contract_items.assert_not_awaited()` on a courier-only run).
+
+### N-11 — `_render_message` branch coverage
+`location=None → "an unknown location"` (57) never tested; the `"an item exchange"` label never
+rendered (see C-10); the `"a contract"` fallback label is unreachable given the query's type gate —
+either test it as defense-in-depth or note it as such.
+
+### N-12 — Matcher `distinct()` and fan-out shapes
+No test with two included items of the same watched type in one contract (pins `.distinct()`, 179 —
+without it `matched` double-counts even while `created` stays right); no multi-user test (two enabled
+users watching the same type both get notifications); no one-user-two-watches-one-contract test (two
+rows differing in `watch_type_id` both insert past the unique index).
+
+### N-13 — `_prune` sub-branches of "outstanding"
+The delete-when-gone test uses an *absent* contract row; the expired-but-present row, the
+completed-but-present row, and the `created_at == cutoff` strict-`<` boundary (231) each lack a test.
+
+### N-14 — `run_matching` happy path never runs end-to-end
+The only `run_matching` tests stub `_match_and_notify`/`_prune` (session-factory test) or hold the
+lock. No test drives a real match through `run_matching` asserting the commit lands (notifications
+visible post-commit) and the success `log_key_event` carries `matches/created/pruned`.
+
+### N-15 — `bulk_upsert([])` early return (db_upsert.py:32-33) untested
+A regression reordering it below `values[0]` access crashes on the aggregation's no-op paths.
+
+### N-16 — Non-NULL overwrite pinned for only one preserved column
+`preserve_on_null` NULL-keeps is asserted for all four name columns end-to-end
+(`test_resolved_names_survive_a_degraded_name_resolution_run`), but the "non-NULL still overwrites"
+direction is asserted only for `issuer_corporation_name` (rename test) — the other three columns'
+overwrite arm of the COALESCE rides on it. Also untested: one statement carrying mixed rows (one NULL,
+one non-NULL in the same preserved column) exercising per-row COALESCE.
+
+### N-17 — a7c clean downgrade never asserts the two indexes were dropped
+`test_clean_downgrade_restores_int32_issuer_columns` asserts column types only; index absence is caught
+only accidentally (a retained index would crash the `finally` re-upgrade on duplicate name). Assert
+`pg_indexes` directly.
+
+### N-18 — Failure before the region fetch records `failure` with 0/0 counters
+If `esi_client.__aenter__` or the session factory raises (before `_fetch_regions`), the forced-failure
+record carries the initial `regions_ok=0, regions_failed=0` (437-438) — reasonable, but unpinned.
+
+### N-19 — Spec-minimal contract does not assert the resolver/station calls are skipped
+`test_a_spec_minimal_contract_persists...` asserts NULLs persist but not that
+`get_universe_station` was never awaited for a contract with no locations (the `is not None` guard in
+`_npc_station_ids`, 208).
+
+---
+
+
+### Frontend logic and components
+
+Full registers in their reports (60+ rows): `subagent-frontend-logic-findings.md` (28 correctness / 13 nice-to-have; summary at its §Summary counts) and `subagent-frontend-components-findings.md` (10 / 18; queued-input statuses at its §1).

--- a/docs/test-coverage-reports/subagent-backend-read-findings.md
+++ b/docs/test-coverage-reports/subagent-backend-read-findings.md
@@ -1,0 +1,397 @@
+# ABOUTME: Systematic test-coverage review of the backend READ path (contract_service.py + api/contracts.py).
+# ABOUTME: Per-function path maps with coverage verdicts; every GAP carries a severity. Research-only artifact.
+
+# Backend READ path — test coverage review (2026-08-08)
+
+**Sources reviewed:**
+- `app/backend/src/fastapi_app/services/contract_service.py` (1185 lines)
+- `app/backend/src/fastapi_app/api/contracts.py` (81 lines)
+
+**Test files reviewed:**
+- `app/backend/src/fastapi_app/tests/api/test_contract_filters.py` (2525 lines)
+- `app/backend/src/fastapi_app/tests/api/test_contracts.py` (192 lines)
+- `app/backend/src/fastapi_app/tests/services/test_contract_service.py` (1324 lines)
+- Supporting: `tests/conftest.py` (setup_contracts fixture), `tests/test_db_engine.py` (SQLA-4 engine scrub)
+
+**Intent sources consulted:** `design/features/F008-Type-Aware-Contract-Browsing.md` (via decision logs), `docs/pitfalls/testing-pitfalls.md`, `docs/pitfalls/implementation-pitfalls.md` (SQLA-4), `docs/superpowers/plans/2026-08-06-f008-decision-log.md` (D12), `docs/superpowers/plans/2026-08-08-overnight-followups-decision-log.md` (OD3, OD4).
+
+**Rules applied:** no "covered indirectly" — a path with no dedicated assertion is a GAP. API-level tests that directly assert on a path count as Covered (integration). Enum/operator siblings are separate rows. Severity when in doubt: escalated.
+
+**Depth check:** contract_service.py at 1185 lines requires ≥ 48 mapped paths (1 per 25 lines). This review maps **90+ paths** across the two files. Depth check passes.
+
+---
+
+## 1. `contract_service.py`
+
+### 1.1 `_needs_item_join` (lines 78–88)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 1 | `filters.search` truthy → True (84) | `test_expired_exclusion_also_applies_on_the_item_joined_path`, `test_pagination_with_search_returns_full_distinct_pages`, equivalence case `search-joins-items` | Covered |
+| 2 | `filters.type_ids` truthy → True (85) | `test_filter_by_type_id`, equivalence case `type-ids-joins-items` | Covered |
+| 3 | `sort_by == ship_name` → True (87) | `test_pagination_sorted_by_ship_name_no_duplicates`, `test_ship_name_sorts_both_ways_and_leaves_item_less_contracts_last` | Covered |
+| 4 | none → False (unjoined path) | Every default-filters test; equivalence case `unfiltered` uses `_needs_item_join` itself as the reference discriminator | Covered |
+| 5 | is_bpc / ranges / taxonomy deliberately do NOT set the join (comment 89–93) | `test_pagination_with_is_bpc_returns_full_distinct_pages` (proves is_bpc works without row multiplication); taxonomy/range tests pass through the EXISTS path | Covered |
+
+### 1.2 `still_listed_by_esi` (96–168) + `_newest_in` (171–183)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 6 | Empty `AGGREGATION_REGION_IDS` → correlated-only predicate (147–148) | `liveness_branch` param `region-not-configured` across `test_contracts_missing_from_the_latest_run_are_excluded`, `test_a_region_whose_run_failed_keeps_all_its_contracts`, `test_never_stamped_contracts_stay_visible`, plus all 13 derived-total equivalence cases | Covered |
+| 7 | Configured region, row at its region's watermark → visible (150–158, fast/uncorrelated branch) | Same three tests under `liveness_branch` param `region-configured` | Covered |
+| 8 | Configured region, row below watermark → hidden (fast branch) | `test_contracts_missing_from_the_latest_run_are_excluded` (`region-configured`), `segment_corpus` 962007 | Covered |
+| 9 | `last_seen_at IS NULL` → visible, under both config states (143, 160) | `test_never_stamped_contracts_stay_visible` (both params) | Covered |
+| 10 | Per-region isolation: a stalled region keeps its own watermark (both branches) | `test_a_region_whose_run_failed_keeps_all_its_contracts` (both params) | Covered |
+| 11 | **`case` else_ fallback with a NON-empty config** (166): row whose region is absent from a non-empty `AGGREGATION_REGION_IDS` is judged by the correlated subquery | No test seeds a row in a region outside a non-empty configured set and asserts its visibility both at and below its own region's watermark. `liveness_branch` flips config between `[A,B]` (rows all inside) and `[]` (branch 6). The docstring claims a both-way EXCEPT verification against production under a deliberately-wrong config (perf audit 2026-08-02), but that is a one-time manual check, not a regression test. Config drift is the exact scenario the comment calls out. | **GAP — correctness** |
+
+### 1.3 `_has_blueprint_copy_item` (186–214)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 12 | EXISTS true branch (is_bpc=true) | `test_filter_by_is_bpc` (service + API), `test_is_bpc_is_a_contract_level_predicate_on_a_mixed_bundle` | Covered |
+| 13 | Negated branch (is_bpc=false), exact complement | `test_is_bpc_is_a_contract_level_predicate_on_a_mixed_bundle` (totals sum to unfiltered), `test_is_bpc_false_matches_items_esi_left_unmarked` | Covered |
+| 14 | NULL `is_blueprint_copy` reads as "not a copy" (ESI-3, 208–210) | `test_is_bpc_false_matches_items_esi_left_unmarked` | Covered |
+| 15 | Offered-only (`is_included IS TRUE`, 208): want-to-buy copy does not match | `test_is_bpc_is_a_contract_level_predicate_on_a_mixed_bundle` (954003) | Covered |
+
+### 1.4 `_offered_item_range_exists` (217–248)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 16 | runs: min only / max only / both-bounds-on-one-item (242–245) | `test_runs_filter_is_a_contract_level_predicate_with_a_three_way_identity` (low, high, [10,12] window) | Covered |
+| 17 | ME: min only / max only / window | `test_me_filter_..._three_way_identity` | Covered |
+| 18 | TE: min only / max only / window | `test_te_filter_..._three_way_identity` | Covered |
+| 19 | NULL column satisfies neither direction (BPO with runs=None) | runs identity test (963003 in neither branch) | Covered |
+| 20 | Offered-only: requested-side item never matches | all three identity tests (963004 / 964004 / 964104) | Covered |
+| 21 | Families are independent EXISTS (different items satisfy different families) | `test_range_families_are_independent_of_each_other` | Covered |
+
+### 1.5 `_apply_contract_filters` (251–320)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 22 | Expiry predicate on count + simple fetch (263) | `test_expired_contracts_are_excluded_from_the_list` (asserts total AND page) | Covered |
+| 23 | Expiry predicate on joined fetch | `test_expired_exclusion_also_applies_on_the_item_joined_path` | Covered |
+| 24 | Expiry predicate across page boundaries (TEST-4) | `test_expired_exclusion_holds_across_page_boundaries` | Covered |
+| 25 | Delisting predicate (268) | §1.2 rows above | Covered |
+| 26 | search: title ILIKE branch (276) | `test_filter_contracts_by_search` ("Special") | Covered |
+| 27 | search: item type_name ILIKE branch (277) | `test_filter_contracts_by_search` ("Beta") | Covered |
+| 28 | min_price (282–283) | `test_filter_by_min_price`, API `test_filter_contracts_by_price` | Covered |
+| 29 | max_price (284–285) | `test_filter_by_max_price`, API `test_filter_contracts_by_price` (incl. both-bounds) | Covered |
+| 30 | **min_collateral (286–287)** | No test anywhere sets `min_collateral`. Grep confirms the only collateral filter use is `max_collateral` (combined with `min_price` in `test_filter_by_price_and_collateral`). An inverted operator (`<=` for `>=`) or a copy-paste against the wrong column would ship undetected. | **GAP — correctness** |
+| 31 | max_collateral (288–289) | `test_filter_by_price_and_collateral` (only in combination — but it has its own assertion discriminating on collateral 1M vs 100M) | Covered |
+| 32 | is_ship_contract true / false / absent (292–293) | `test_filter_by_is_ship_contract` (all three) | Covered |
+| 33 | contract_type: single, multiple (297–299) | `test_filter_by_contract_type` | Covered |
+| 34 | contract_type includes `unknown` → `not_in(known)` folding (300–307) | `test_a_contract_type_outside_the_enum_stays_counted_and_reachable` (selected total==2, both rows returned) | Covered |
+| 35 | is_bpc true / false / absent (313–315) | §1.3 rows | Covered |
+
+### 1.6 `_apply_location_filters` (323–339)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 36 | region_ids single / multiple (332–333) | `test_filter_by_region_ids_repeated_query_params`, `test_filter_by_multiple_region_ids` | Covered |
+| 37 | system_ids single / multiple (334–335) | `test_filter_by_system_ids_repeated_query_params`, `test_filter_by_multiple_system_ids` | Covered |
+| 38 | station_ids single / multiple (336–337) | `test_filter_by_station_ids_repeated_query_params`, `test_filter_by_multiple_station_ids` | Covered |
+
+### 1.7 `_apply_item_filters` (342–390)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 39 | type_ids IN (344–345) | `test_filter_by_type_id`, API repeated-param test | Covered |
+| 40 | runs / ME / TE family gating (`min is not None or max is not None`, 349/355/361) | three-way identity tests | Covered |
+| 41 | taxonomy: category only (379–380) | `test_category_filter_is_a_contract_level_predicate_on_a_mixed_bundle`, repeated categories in `test_group_filter_stands_alone_and_repeats` | Covered |
+| 42 | taxonomy: group only, single + repeated (381–382) | `test_group_filter_stands_alone_and_repeats` | Covered |
+| 43 | taxonomy: category AND group must land on the SAME offered item (374–388) | `test_category_and_group_must_be_satisfied_by_the_same_offered_item` (0-match pairing + 1-match pairing) | Covered |
+| 44 | taxonomy offered-only | `taxonomy_corpus` 965003 asserted absent | Covered |
+| 45 | Unrepresented category → empty page, not error | `test_a_category_absent_from_the_corpus_returns_an_empty_page` | Covered |
+
+### 1.8 `_count_distinct_contracts` (393–403)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 46 | DISTINCT contract count over duplicated joined rows | `test_the_residual_holds_on_the_item_joined_path` (3-item contract counts once); used as the reference oracle in the 13 derived-total equivalence cases | Covered |
+
+### 1.9 `_count_under_ships_filter` (429–441)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 47 | `is_ship_contract is None` → all (437–438) | unfiltered segment tests | Covered |
+| 48 | True → ships aggregate (439–440) | `test_an_item_less_segment_reports_its_true_count_under_ships_only` | Covered |
+| 49 | False → complement (441) | `test_an_item_bearing_segment_reports_the_complement_under_ships_excluded` | Covered |
+
+### 1.10 `_segment_counts_and_total` (444–534)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 50 | contract_type + is_ship_contract lifted for counts (470–471) | `test_segment_counts_read_every_type_with_the_type_filter_lifted` | Covered |
+| 51 | Item-less segments read ships flag lifted; item-bearing respect it (507–514, Criterion 1.8) | the two Criterion-1.8 tests (both flag values). Non-lifting of offered-item filters ratified as designed — OD4 (2026-08-08 overnight decision log): no code change; served zero is honest. NOT flagged as a gap. | Covered |
+| 52 | Other filters still narrow counts (§6.2) | `test_segment_counts_respect_the_other_filters` | Covered |
+| 53 | DISTINCT aggregate iff joined (482–486) | `test_segment_counts_count_contracts_not_joined_item_rows` (joined); unjoined via every default test + equivalence `unfiltered` | Covered |
+| 54 | Out-of-enum stored type folds into `unknown` (497–505) | `test_a_contract_type_outside_the_enum_stays_counted_and_reachable`, `test_a_stored_type_outside_the_enum_is_counted_under_unknown` | Covered |
+| 55 | Zero-fill over every enum type (495) | `test_segment_counts_are_zero_filled_over_every_contract_type` | Covered |
+| 56 | total: selected=None sums everything (520–532) | `sum(segment_counts.values()) == total` assertion; equivalence `unfiltered` | Covered |
+| 57 | total: membership judged on FOLDED segment (528–531) | unknown-selection test (total==2 with one folded row) | Covered |
+| 58 | total under each ships-flag value / combined with contract_type | equivalence cases `ships-only`, `ships-excluded`, `contract-type-with-ships-only` | Covered |
+| 59 | Whole-function equivalence vs flat count, both liveness branches | `test_the_derived_total_equals_the_flat_count_for_the_same_filters` × 13 cases × 2 branches, vacuity-guarded | Covered |
+
+### 1.11 `_observed_coverage` + `_OBSERVED_REGIONS_SQL` (541–572)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 60 | Multi-region walk, ascending ids, as_of = newest across all (569–572) | `test_coverage_reports_every_region_the_corpus_holds` | Covered |
+| 61 | Empty corpus → `[]` + `as_of=None` (571 default) | `test_coverage_on_an_empty_corpus_is_empty_rather_than_absent` | Covered |
+| 62 | Region with only NULL stamps stays listed, contributes no as_of candidate | `test_a_region_whose_rows_are_all_unstamped_still_counts_as_covered` | Covered |
+| 63 | Observed-not-configured semantics | `test_a_configured_but_uningested_region_is_absent_from_coverage` | Covered |
+| 64 | Coverage carried onto the empty page | `test_coverage_is_carried_onto_an_empty_page` | Covered |
+
+### 1.12 `_count_unknown_system_excluded` (575–596)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 65 | Residual = same query minus system predicate plus IS NULL | `test_system_ids_matches_resolved_contracts_and_reports_the_residual` | Covered |
+| 66 | Absent (None, not 0) when system_ids unset | `test_the_residual_is_absent_when_system_ids_is_not_applied`, wire test | Covered |
+| 67 | Counts only rows the OTHER filters kept | `test_the_residual_counts_only_rows_the_other_filters_kept` | Covered |
+| 68 | Reported on the empty page (measured before short-circuit) | `test_the_residual_is_still_reported_when_nothing_matched` | Covered |
+| 69 | DISTINCT on joined path | `test_the_residual_holds_on_the_item_joined_path` | Covered |
+
+### 1.13 `_fetch_page_joined` (599–638)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 70 | min aggregate asc / max aggregate desc as the direction-appropriate representative (614) | `volume_and_ship_name_sort_contracts` 972013 ("Bantam"/"Zealot" straddle "Merlin") — both directions asserted | Covered |
+| 71 | nulls_last on joined path for NULLABLE sort (616–617) | ship_name (both directions), reward_per_volume desc (`test_a_new_sort_survives_the_grouped_joined_pagination_path`) | Covered for those two |
+| 72 | **nulls_last on joined path for the other four NULLABLE sorts** (buyout, days_to_complete, volume, price under a join) | Simple path covers all six; joined path exercises only ship_name + reward_per_volume. Mechanism is one shared branch, exercised twice with order assertions, so residual risk is low. | GAP — nice-to-have |
+| 73 | Non-nullable sort on joined path (price asc + search) | `test_pagination_with_search_returns_full_distinct_pages` (exact order) | Covered |
+| 74 | Pagination over grouped ids, no dup/skip across boundaries (618–624) | search, ship_name, and is_bpc pagination tests (SQLA-1/TEST-4) | Covered |
+| 75 | contract_id ASC tiebreaker at equal aggregate keys (621) | `test_joined_pagination_tiebreaks_equal_sort_keys_by_contract_id` (service; scope limit candidly documented) + `test_pagination_sorted_by_ship_name_no_duplicates` (plan-level) | Covered |
+| 76 | Python-side reorder to id_query order (636–637) | Exact-order assertions on joined-path tests fail without it | Covered (integration) |
+| 77 | **Page beyond the last page on the joined path** (page_ids == [] → `IN ()` data query → empty items with total > 0) | No test requests a page past the end while total > 0 on the joined path (nor on the simple path). Response shape for an out-of-range page is unpinned. | GAP — nice-to-have |
+
+### 1.14 `_fetch_page_simple` (641–658) + sort matrix
+
+Per instruction 7, each `SortableContractFields` value × direction is a separate path. NULLABLE_SORTS membership (68–75): buyout, days_to_complete, reward_per_volume, volume, ship_name, price.
+
+| # | Sort × direction | Coverage | Verdict |
+|---|---|---|---|
+| 78 | price asc / desc + nulls_last both ways | `test_price_sorts_both_ways_and_leaves_unpriced_contracts_last`, `test_sort_by_price_asc`, `test_sorting_by_price_asc` | Covered |
+| 79 | buyout asc / desc + nulls_last | `test_buyout_sorts_both_ways_and_leaves_auctions_without_one_last` | Covered |
+| 80 | days_to_complete asc / desc + nulls_last | `test_days_to_complete_sorts_both_ways_and_leaves_non_couriers_last` | Covered |
+| 81 | reward_per_volume asc / desc + nulls_last; SQL expression ordered differently from both operand columns; zero-volume NULL | `test_reward_per_volume_sorts_both_ways...`, `test_a_zero_volume_courier_sorts_as_unpriced...` | Covered |
+| 82 | volume asc / desc + nulls_last | `test_volume_sorts_both_ways_and_leaves_contracts_without_one_last` (OD3 fix evidence) | Covered |
+| 83 | ship_name asc / desc + nulls_last (joined) | `test_ship_name_sorts_both_ways_and_leaves_item_less_contracts_last`, API `test_sort_contracts` desc | Covered |
+| 84 | date_issued desc (default) | `test_unmapped_sort_falls_back_to_date_issued` asserts exact desc order + tiebreak (via the fallback, which maps to the same column/direction) | Covered |
+| 85 | **date_issued asc (explicit)** | No test sends `sort_by=date_issued&sort_direction=asc` and asserts order. | **GAP — correctness** |
+| 86 | **date_expired asc / desc** | Zero tests sort by date_expired. This is the "Time left" sort the liveness comment (257–259) names as the default-ascending UI sort — the sort whose interaction with expired rows motivated the expiry predicate. A silent no-op here is exactly the defect class §6.2 acceptance evidence exists for; the newer sorts each got both-direction evidence, this pre-existing one has none. | **GAP — correctness** |
+| 87 | **collateral asc / desc** | Zero tests sort by collateral (non-null column, simple order). A courier browser sorting by collateral is a primary use case per `test_contract_response_exposes_collateral`'s own docstring ("filterable and sortable"), yet the sort itself is unasserted. | **GAP — correctness** |
+| 88 | Non-NULLABLE sort skips nulls_last (649–650 false branch) | date_issued fallback test (order asserted on non-null column) | Covered |
+| 89 | Pagination offset/limit on simple path (652–654) | `test_paginate_contracts` (page 2, size 3, exact ids), `test_pagination` (service) | Covered |
+
+### 1.15 `_category_names` (661–674)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 90 | kind=="category" name map; consumed by list AND detail | `derived_field_contracts` composition name assertions; `test_detail_response_carries_every_item_and_its_blueprint_terms` ("Blueprint" name on detail) | Covered |
+
+### 1.16 `_offered_items` (677–687)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 91 | is_included filter (offered only) | requested-item exclusion asserted in composition (961001: 2 rows not 3) and blueprint tests (954003) | Covered |
+| 92 | record_id ordering ("first item" determinism) | Consumed by `_primary_label` named[0]; see row 96 — the ordering itself is only observable when record insertion order differs from record_id order, which no fixture arranges | GAP folded into row 96 |
+
+### 1.17 `_reward_per_volume` (690–698)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 93 | reward None → None; volume 0 → None; volume None → None (696–697) | `test_reward_per_volume_is_null_when_the_division_is_undefined` (all three) | Covered |
+| 94 | Normal division (698) | courier row asserts 80_000.0 | Covered |
+
+### 1.18 `_primary_label` (701–724)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 95 | Offered ship headline (711–714) | 961001 asserts "Rokh" — **but** the Rokh is also the lowest-record_id named item, so the ship branch and the named[0] fallback give identical answers there | Weak — see row 96 |
+| 96 | **Ship OUTRANKS an earlier-record non-ship item** — the reason the branch exists ("an offered ship outranks whatever module happens to come first") | No fixture places a named non-ship item at a lower record_id than the offered ship (`category=="ship"`). Deleting the `ship = next(...)` line and always taking `named[0]` passes every current test. | **GAP — correctness** |
+| 97 | named[0] fallback when no item carries `category=="ship"` (713) | `test_complex_filter_api` asserts "Tristan" on an item without category | Covered |
+| 98 | Title fallback when nothing named offered (716–717) | 954003 asserts "Wanted: Caracal Blueprint Copy" | Covered |
+| 99 | **Blank-string title counts as absent** (`title.strip()`, 716) | Comment says real ESI titles are frequently `""`; no fixture has `title="   "` or `""` falling through to the courier/contract-id branches. | GAP — nice-to-have |
+| 100 | Courier with end_location_name (719–721) | 961003 asserts "Courier to Amarr VIII..." | Covered |
+| 101 | **Courier without end_location_name → "Courier"** (722) | Executes in `test_reward_per_volume_is_null...` (961101/961102 are title-less couriers with no end name) but no assertion reads their `primary_label`. | GAP — nice-to-have |
+| 102 | **Final fallback `f"Contract {id}"`** (724) | 961103 (title=None, item_exchange, no items) exercises it; no assertion reads it. | GAP — nice-to-have |
+
+### 1.19 `_composition` (727–770)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 103 | < 2 offered rows → None (737–738) | single-item, courier, requested-only tests | Covered |
+| 104 | Row counts (not quantities), per category incl. None bucket | 961005 / 962401 | Covered |
+| 105 | Unnamed known category serves NULL name (749) | 961005 category 42 | Covered |
+| 106 | Ordering: count desc for EVERY entry incl. NULL bucket; name asc at ties; unnamed after named (758–764) | `test_composition_orders_every_entry_by_share_then_name`, `test_a_dominant_uncategorized_bucket_leads_the_composition` | Covered |
+| 107 | total_volume from contract (769) | 961001 asserts 1500.0 | Covered |
+| 108 | **total_volume None branch** (769, volume is None) | 961005 has no volume; test asserts categories + total_item_rows but never `total_volume is None` | GAP — nice-to-have |
+
+### 1.20 `_blueprint_summary` (773–792)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 109 | No copies → None (781–782) | single-item + requested-only tests | Covered |
+| 110 | >1 copies → count only (783–784) | `test_auction_row_carries_its_buyout_and_counts_its_copies` (exact null terms + count 2) | Covered |
+| 111 | Single copy → full terms (786–792) | 961001 assertion; `test_filter_by_bpc_runs` | Covered |
+
+### 1.21 `_contract_fields` / `_list_item` / `_detail_item` (795–853)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 112 | is_blueprint_copy_contract offered-only derivation (827–829) | mixed-bundle + want-to-buy tests | Covered |
+| 113 | Field allowlist: authenticated-route fields never serialize (status, date_completed, is_singleton, raw_quantity) | the three omits-fields tests, swept across all fixture items | Covered |
+| 114 | List rows carry no item array | `test_list_rows_carry_no_item_array` | Covered |
+| 115 | Detail = row + full item array incl. requested items | `test_detail_response_carries_every_item_and_its_blueprint_terms` | Covered |
+| 116 | **Detail items sorted by record_id** (850–852) | Test builds a dict keyed by record_id and asserts the SET; wire order is unasserted ("renders identically on every request" is the stated contract) | GAP — nice-to-have |
+| 117 | last_seen_at on the wire | derived-fields test asserts round-trip equality | Covered |
+
+### 1.22 `_live_item_bearing_contracts` (856–870)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 118 | Delisted rows out of readiness population | `test_a_delisted_contract_does_not_drag_the_readiness_ratio` | Covered |
+| 119 | Item-less types (courier/loan) out; auction in | `test_only_item_bearing_contract_types_count_in_the_denominator` (both directions — auction degradation asserted) | Covered |
+| 120 | **Expired rows out of readiness population** (`date_expired > func.now()`, 867) | No taxonomy-readiness test seeds an EXPIRED stale-version contract and asserts it does not drag the ratio. The delisted sibling is tested; the expiry criterion of the same tuple is not. | **GAP — correctness** |
+
+### 1.23 `_enrichment_is_current` (873–897)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 121 | Ratio threshold, both sides of 0.99 (897) | parametrized `0.995-clears` / `0.95-does-not` | Covered |
+| 122 | Denominator includes PENDING and ENRICHMENT_INCOMPLETE rows | `test_contracts_still_awaiting_or_failing_enrichment_stay_in_the_denominator` | Covered |
+| 123 | Numerator requires status AND version (889–891) | same test (failed rows deliberately keep the current version) | Covered |
+| 124 | Empty corpus → not ready (`live > 0`) | `test_taxonomy_on_a_cold_cache_...` (partial on empty) | Covered (integration) |
+
+### 1.24 `_live_category_ids` (900–917) / `_taxonomy_coverage` (920–939)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 125 | Ratio not current → partial (935–936) | ratio tests | Covered |
+| 126 | Live category missing from name cache → partial; fixed → complete (937–938) | `test_a_category_the_name_cache_is_missing_holds_the_signal_at_partial` (both states) | Covered |
+| 127 | Category on delisted rows only does not hold the signal | `test_a_category_seen_only_on_delisted_rows_does_not_hold_the_signal` | Covered |
+| 128 | NULL category_id excluded from sweep (914) | Implicit in fixtures without taxonomy ids alongside `complete` verdicts (e.g. ratio tests use item-less enriched contracts and still reach `complete`) | Covered |
+| 129 | **Short-circuit order: ratio settles before the category sweep runs** (932–934) | Behavioral outcome covered; the cost-motivated ordering itself has no call-order assertion. Reordering is invisible to tests (and harmless to correctness). | GAP — nice-to-have |
+
+### 1.25 `get_taxonomy` (942–982)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 130 | kind split; flat groups each naming their category; name-sorted (reverse-seeded per TEST-12) | `test_taxonomy_serves_name_sorted_flat_lists_...` | Covered |
+| 131 | Cold cache → empty lists + partial, no error; route matched ahead of /{contract_id} | `test_taxonomy_on_a_cold_cache_...` | Covered |
+| 132 | Coverage measured against the SERVED category list (979–981) | missing-name test asserts `categories == [6]` alongside `partial` | Covered |
+| 133 | **Sort tie-break by id at equal names** (959, 971) | No fixture seeds two categories or groups with identical names | GAP — nice-to-have |
+
+### 1.26 `_error_without_bound_parameters` (985–1005)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 134 | Non-StatementError → plain str (998–999) | `test_db_error_logs_failure_and_reraises` (RuntimeError message asserted) | Covered |
+| 135 | StatementError → scrubbed render, diagnosis retained (1000–1004) | `test_a_failing_statement_does_not_log_its_bound_search_text` — vacuity-guarded, whole-record assertion (SQLA-4/D12 discipline followed exactly as the pitfall prescribes) | Covered |
+| 136 | **`finally` restores prior `hide_parameters`** (1004–1005) | No assertion that `exc.hide_parameters` returns to its prior value after logging (matters if the exception is re-rendered downstream expecting original behavior). | GAP — nice-to-have |
+
+### 1.27 `get_contracts` (1008–1185)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 137 | Start log emits length-only search dimension (1024–1041) | `test_no_search_log_site_echoes_the_raw_query_text` (all four sites, whole-record repr scan) | Covered |
+| 138 | Full-dimension payload carries type + taxonomy ids (1026–1040 / 1145–1159) | `test_full_dimension_logs_carry_the_type_and_taxonomy_filters` (exact key sets) | Covered |
+| 139 | join vs no-join query construction (1047–1052) | §1.1 | Covered |
+| 140 | unknown_system_excluded computed iff system_ids, BEFORE short-circuit (1069–1073) | §1.12 rows 66, 68 | Covered |
+| 141 | Coverage computed once per request (1077) | §1.11 | Covered |
+| 142 | total==0 short-circuit: distinct branch pinned by 4-key vs 11-key log payload (1079–1107) | `test_zero_results_returns_empty_page` — the strongest branch-discrimination test in the suite | Covered |
+| 143 | Empty page carries segment_counts + coverage | `test_the_empty_page_still_carries_the_full_segment_counts`, `test_coverage_is_carried_onto_an_empty_page` | Covered |
+| 144 | SORT_MAP fallback to date_issued on unmapped key (1111–1114) | `test_unmapped_sort_falls_back_to_date_issued` (model_construct bypass; defensive branch, exact order asserted) | Covered |
+| 145 | descending = (sort_direction == desc) (1116) | every both-direction sort test | Covered |
+| 146 | joined vs simple fetch dispatch (1118–1121) | §1.13/§1.14 | Covered |
+| 147 | Success log key event (1139–1160) | log tests (site 3 of 4) | Covered |
+| 148 | Exception path: failure event, scrubbed error, bare re-raise of the ORIGINAL object (1164–1185) | `test_db_error_logs_failure_and_reraises` (`excinfo.value is boom_error`), StatementError scrub test | Covered |
+
+---
+
+## 2. `api/contracts.py`
+
+### 2.1 `list_public_contracts` (33–44)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 149 | `Annotated[ContractFilters, Query()]` binding: id lists as repeated query params, never body (FASTAPI-1) | repeated-param tests for region/system/station/type/group/category + `test_id_list_filters_are_query_params_in_openapi_schema` | Covered |
+| 150 | Delegation to service | every API test | Covered (integration) |
+| 151 | 422: unknown `contract_type` value (closed enum, §17.8) | `test_filter_by_contract_type` (`barter` → 422) | Covered |
+| 152 | **422: `size` bounds (`ge=1, le=100`) — size=0, size=101, size=-1** | No test. This is the ONLY resource cap on an anonymous, corpus-scale query endpoint; if the `le=100` constraint were dropped, `size=100000` would page the whole corpus per request and no test would notice. Note the saved-searches 422 tests validate a DIFFERENT model (SavedSearch payload), not this endpoint's Query binding. | **GAP — security-critical** |
+| 153 | **422: `search` min_length=3 — and no max_length exists at all** | No endpoint test sends `search=ab`. Worse (code observation surfaced by the coverage sweep): `ContractFilters.search` declares `min_length=3` but NO `max_length`, so an anonymous caller can bind an arbitrarily long string into the un-indexed double-wildcard ILIKE (`%...%`) across title AND item name — a query-cost lever with no cap and no test that would catch one being added/removed. The short-search 422 is also the only guard against 1-char full-corpus ILIKE scans. | **GAP — security-critical** |
+| 154 | **422: `page` `ge=1` — page=0, page=-1** | No test. If the constraint were removed, page=0 produces a negative OFFSET → database error → 500 on trivially malformed anonymous input. | **GAP — correctness** |
+| 155 | **422: negative numeric bounds across the six range families** (min/max_price `ge=0`, min/max_collateral `ge=0`, min/max_me `ge=0`, min/max_te `ge=0`, min/max_runs `ge=-1`) | No endpoint tests. (saved-searches covers `min_price=-1` and `min_me=-1` on its own model only.) | **GAP — correctness** |
+| 156 | **422: malformed value types — non-integer id-list members (`region_ids=abc`), non-boolean `is_bpc=maybe`, non-numeric prices** | No endpoint tests pin the fail-closed 422 for type-mismatched query values. | **GAP — correctness** |
+| 157 | **422: unknown `sort_by` / `sort_direction` values** | No test sends `sort_by=issuer_id` or `sort_direction=sideways`. The enum 422 is the FIRST layer of the arbitrary-column-sort defense; SORT_MAP + fallback (the second layer) IS tested, which is why this is correctness rather than security-critical — but the layer the wire actually exercises is the untested one. | **GAP — correctness** |
+| 158 | **Wire-visible error body on an induced read-path 500** | `main.py`'s `generic_exception_handler` returns a constant `{"detail": "An unexpected server error occurred."}` and logs `str(exc)` (scrubbed only because the engine sets `hide_parameters=True` — pinned by `test_db_engine.py` at the RENDER layer). No API-level test drives a failure through `/contracts/` and asserts the response body carries no internals (statement text, bind values, traceback). The repo's parameter-scrubbing rule (SQLA-4/D12) is tested at the log layer; the HTTP surface — the one an anonymous attacker actually sees — has no assertion. | **GAP — security-critical** |
+
+### 2.2 `list_contract_taxonomy` (49–57)
+
+| # | Path | Coverage | Verdict |
+|---|---|---|---|
+| 159 | Route order ahead of /{contract_id} (would 422 otherwise) | `test_taxonomy_on_a_cold_cache_...` (docstring names this as the proof; a 422 would fail the 200 assertion) | Covered |
+| 160 | Delegation + response shape | all taxonomy tests | Covered |
+
+### 2.3 `get_contract` (60–81)
+
+| # | Path (lines) | Coverage | Verdict |
+|---|---|---|---|
+| 161 | Found → `_detail_item` with category names (79–81) | detail tests (fields, items, derived names) | Covered |
+| 162 | Expired contract still served (list/detail asymmetry pinned) | `test_detail_still_serves_an_expired_contract` | Covered |
+| 163 | **Not found → 404** (76–77) | **Zero tests.** Grep across the entire test tree finds no request for a nonexistent contract id and no 404 assertion on `/contracts/{id}`. The only user-visible error branch in this file is completely unexercised — the `scalar_one_or_none` / `HTTPException(404)` pair could regress to `scalar_one` (→ 500) or to serving a null body and nothing would fail. | **GAP — correctness** |
+| 164 | **Non-integer path param → 422** (`/contracts/abc`) | No test. The taxonomy test's docstring reasons about this behavior but nothing sends a non-integer id. | **GAP — correctness** |
+| 165 | **int64-overflow id** (`/contracts/99999999999999999999` — passes Python int parsing, overflows PG BIGINT → DBAPIError → 500) | No test pins whether this returns 404, 422, or a 500; currently it is a driver-error 500 on malformed anonymous input. Fail-closed behavior unpinned. | **GAP — correctness** |
+| 166 | Delisted-but-unexpired contract still served by detail (list hides via watermark; detail applies neither predicate) | No dedicated test (the expired sibling is pinned; the delisted asymmetry — same design rationale — is not). | GAP — nice-to-have |
+
+---
+
+## 3. Gap register (summary with severities)
+
+### Security-critical (3)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| SC-1 | `size` (and implicitly the whole pagination cost cap) has zero 422 tests on the anonymous list endpoint; `le=100` is the only thing standing between a caller and corpus-per-request pages, and its removal is test-invisible. | `schemas/contracts.py:456`, `api/contracts.py:33` (row 152) |
+| SC-2 | `search` min_length 422 untested at the endpoint, and the field has NO max_length — unbounded user text binds into a double-wildcard ILIKE over two columns on an anonymous endpoint. Coverage gap + code observation. | `schemas/contracts.py:332–336` (row 153) |
+| SC-3 | No API-level test asserts the wire-visible 500 body on a read-path failure contains no internals; the SQLA-4/D12 scrub is pinned at the engine/log layers only, never at the HTTP surface an attacker sees. | `main.py:88–104`, `api/contracts.py` (row 158) |
+
+### Correctness (13)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| C-1 | `GET /contracts/{id}` 404 branch has zero tests anywhere. | `api/contracts.py:76–77` (row 163) |
+| C-2 | Non-integer `/contracts/{id}` 422 untested. | `api/contracts.py:60–63` (row 164) |
+| C-3 | int64-overflow contract id → currently a driver 500; behavior unpinned. | `api/contracts.py:60–74` (row 165) |
+| C-4 | `min_collateral` filter has zero assertions anywhere (only `max_collateral`, and only in combination). | `contract_service.py:286–287` (row 30) |
+| C-5 | `sort_by=date_expired` ("Time left") — both directions untested; the silent-no-op-sort defect class F008 §6.2 names. | `contract_service.py:43`, SORT_MAP (row 86) |
+| C-6 | `sort_by=collateral` — both directions untested. | `contract_service.py:45` (row 87) |
+| C-7 | `sort_by=date_issued&sort_direction=asc` untested (desc pinned only via the fallback test). | row 85 |
+| C-8 | `still_listed_by_esi` case-`else_` correlated fallback under a NON-empty config (config-drift path) has no row-level regression test; verified once manually per the 2026-08-02 perf audit. | `contract_service.py:159–168` (row 11) |
+| C-9 | `_primary_label` ship-priority branch not distinguishably tested — no fixture where the offered ship has a higher record_id than a named non-ship item; `named[0]` alone passes every test. | `contract_service.py:710–714` (row 96) |
+| C-10 | Expiry criterion of `_live_item_bearing_contracts` (readiness denominator) untested — delisted sibling pinned, expired one not. | `contract_service.py:867` (row 120) |
+| C-11 | `page=0` / negative page 422 untested (constraint removal → negative OFFSET → 500). | `schemas/contracts.py:455` (row 154) |
+| C-12 | Negative-bound 422s untested across all six numeric range families at the endpoint. | `schemas/contracts.py:338–398` (row 155) |
+| C-13 | Malformed value types (non-int id-list members, non-bool `is_bpc`) and unknown `sort_by`/`sort_direction` 422s untested at the endpoint. | rows 156–157 |
+
+### Nice-to-have (10)
+
+| ID | Gap | Where |
+|----|-----|-------|
+| N-1 | Out-of-range page (beyond last) with total > 0 — empty-`IN` joined branch and simple branch both unpinned. | row 77 |
+| N-2 | Joined-path `nulls_last` exercised for only 2 of 6 NULLABLE sorts (shared branch, low residual risk). | rows 71–72 |
+| N-3 | `_composition.total_volume is None` branch unasserted. | row 108 |
+| N-4 | `_primary_label` "Courier" (no destination) and `Contract {id}` fallbacks execute in fixtures but are never read. | rows 101–102 |
+| N-5 | Blank-string title (`"  "`) treated as absent — untested despite the comment calling it the common ESI shape. | row 99 |
+| N-6 | Detail item array record_id ORDER unasserted (set-only assertion). | row 116 |
+| N-7 | Taxonomy sort tie-break by id at equal names unasserted. | row 133 |
+| N-8 | `_taxonomy_coverage` short-circuit ordering (cost property) unasserted. | row 129 |
+| N-9 | `_error_without_bound_parameters` restore-after-render (`finally`) unasserted. | row 136 |
+| N-10 | Delisted-but-unexpired contract reachable via detail (asymmetry sibling of the pinned expired case) unasserted; also `min_runs=-1` boundary admission (`ge=-1` vs ESI-3 "never sends -1") unasserted. | rows 166, `schemas/contracts.py:351–366` |
+
+---
+
+## 4. What is demonstrably strong (for calibration)
+
+The F008-era surface is exceptionally well covered: both liveness branches parametrized over every delisting case; the derived-total equivalence matrix (13 filter shapes × 2 watermark branches, vacuity-guarded); three-way partition identities for every range family; both directions asserted for all six nullable sorts with NULL placement; log scrubbing pinned at four sites with whole-record assertions and a vacuity guard; the empty-page short-circuit discriminated by log-payload shape rather than response shape. The gaps concentrate in (a) the pre-F008 legacy surface (detail 404, collateral/date sorts, min_collateral) and (b) endpoint-level input validation, where exactly one of ~20 constraint paths (contract_type) has a wire-level 422 test.

--- a/docs/test-coverage-reports/subagent-backend-write-findings.md
+++ b/docs/test-coverage-reports/subagent-backend-write-findings.md
@@ -1,0 +1,308 @@
+# ABOUTME: Systematic test-coverage review of the backend WRITE/ingestion path (background_aggregation,
+# ABOUTME: watchlist_matcher, db_upsert, price-nullable + issuer-int64 migrations) — path map, GAP rows, severities.
+
+# Backend write-path test coverage review — 2026-08-08
+
+**Scope:** `app/backend/src/fastapi_app/services/background_aggregation.py`, `watchlist_matcher.py`,
+`db_upsert.py`, migrations `f2a91c3b7e04_contracts_price_nullable.py` +
+`a7c44d19e582_location_indexes_issuer_int64.py`, against their test files
+(`tests/services/test_background_aggregation.py` [2074 lines], `tests/services/test_watchlist_matcher.py`,
+`tests/services/test_db_upsert.py`, `tests/test_migrations.py`).
+
+**Method:** every function path-mapped with line numbers; a path counts as covered only when a test
+exercises it with its own assertion (no "covered indirectly"). Intent sources consulted: F008 spec §7,
+testing-pitfalls TEST-18/TEST-22/TEST-23, the 2026-08-08 overnight-followups decision log, and the
+consolidated bug-hunt report (design concerns D-c and D-d are KNOWN and referenced, not re-found).
+
+**Totals: 1 security-critical, 11 correctness, 19 nice-to-have.**
+
+The suite is unusually strong — the enrichment-status state machine, preserve_on_null semantics,
+watermark/delisting predicate, price-NULL matcher branches, and migration guard/clean/offline paths are
+all pinned with mechanism-level assertions. The gaps below are what path-by-path mapping still surfaces.
+
+---
+
+## 1. Security-critical
+
+### SEC-1 — The secret-hygiene assertion checks the URL *scheme*, not the credentials
+`test_run_aggregation_reuses_app_session_factory_and_never_logs_database_url`
+(test_background_aggregation.py:1291-1328) sets
+`DATABASE_URL = "postgresql+asyncpg://secret_user:secret_pw@db.internal:5432/hb"` and asserts
+`service.settings.DATABASE_URL[:16] not in msg`. `DATABASE_URL[:16]` is `"postgresql+async"` — the
+dialect prefix every URL shares. The test catches a log line carrying the *full* URL, but a log line
+that renders only the credentials or netloc (`secret_user`, `secret_pw`, `db.internal`) — which is how
+sanitizers typically fail, by stripping the scheme and leaking the rest — passes. The docstring claims
+"no log line may carry any fragment of DATABASE_URL"; the assertion enforces one fragment, the least
+secret one. **Fix:** assert `"secret_pw" not in msg` and `"secret_user" not in msg` explicitly.
+Severity: security-critical (the test exists precisely as the secret-leak guard, and it is near-vacuous
+for the leak shapes that matter).
+
+---
+
+## 2. Correctness
+
+### C-1 — `_resolve_esi_objects` non-dict payload shape guard has no test
+background_aggregation.py:139-144. The guard exists because of a *documented live incident* ("this
+happened live when the list-shaped ETag helper flattened object payloads into keys"), yet no test ever
+returns a non-dict from `get_universe_type` / `get_universe_group` / `get_universe_station` /
+`get_universe_category`. All failure-path tests raise exceptions (the 131-134 branch). If the
+`isinstance(payload, dict)` check regressed, a list payload would flow into `.get()` calls and kill the
+run — the exact incident the guard repaired. GAP: feed a list/str payload, assert the one id degrades
+(warning logged, entry absent) and the run completes.
+
+### C-2 — The recursive-CTE observed-ids queries are only ever executed against ONE distinct value
+`_OBSERVED_CATEGORY_IDS_SQL` (156-165) and `_OBSERVED_GROUP_IDS_SQL` (170-179) are hand-written loose
+index scans whose `UNION ALL` recursion step only produces output when ≥2 distinct ids exist. Every
+repair test (`test_a_failed_category_name_fetch_is_repaired_from_observed_items`,
+`test_a_nameless_group_payload_is_repaired_from_observed_items`) stores items of exactly one category
+(6) and one group (25). A broken recursion returning only `min(category_id)` passes the entire suite,
+and the self-healing cache would silently repair only the lowest-numbered category/group forever. GAP:
+a repair test with two distinct missing categories (and groups), asserting both cache rows land.
+
+### C-3 — `last_seen_at` stamping is never asserted on the write path
+`_build_contract_rows` (263) stamps every row with one shared `seen_at`, and re-sighting restamps via
+the upsert's copy-on-conflict — this is the sole input to the `still_listed_by_esi()` watermark that
+decides site-wide visibility AND watchlist alerting. No aggregation test asserts (a) that a persisted
+row carries a fresh `last_seen_at`, (b) that all rows of one batch carry the SAME stamp (the
+"one run writes one value" invariant the docstring declares), or (c) that a re-sighted contract's stamp
+advances. The matcher tests hand-write `last_seen_at` on fixtures (legitimate for the reader side, but
+per TEST-18 that is exactly the seam where the writer can silently stop writing: if
+`last_seen_at` were dropped from the row dict, or added to `preserve_on_null`, every re-sighted
+contract would read as delisted one run later and no current test goes red). GAP: ingest, capture
+stamp; re-ingest, assert the stamp advanced and equals its batch-mates'.
+
+### C-4 — `run_aggregation`'s held-lock skip path is untested (matcher has it; aggregation does not)
+background_aggregation.py:473-476 (`except ConcurrencyLockError: log + return`) and the acquire-failure
+raise at 334-340. `grep ConcurrencyLockError test_background_aggregation.py` → no matches. The
+watchlist suite pins both (`test_run_matching_skips_when_lock_held`,
+`test_concurrency_lock_raises_when_held`); the aggregation suite pins release/TTL/mismatch but never a
+pre-held lock. A regression that let `run_aggregation` proceed (or crash the scheduler) on a held lock
+— the concurrent-run scenario the whole mechanism exists for — is invisible. GAP: pre-seed the store
+with a foreign token, run `run_aggregation`, assert no fetch/session activity and clean return.
+
+### C-5 — All-regions-failed outcome ("failure" via counters, not forced) is untested
+`_record_run_outcome` (499): `outcome = "failure"` when `ok == 0` without `forced_failure`. Tests cover
+success, all-304 success, partial, and forced failure (commit raise). The natural path — every region's
+fetch raises, `all_contracts_data` empty, no exception propagates, outcome derives from `(0, N)` — has
+no test asserting `outcome == "failure"`, gauge unmoved, and `last_success_at` preserved from the prior
+record. This is the readiness signal for a total ESI outage.
+
+### C-6 — The freshness-writer's own failure swallow is untested
+`_record_run_outcome` 495-523: "A failure of the outcome WRITE itself is logged and swallowed —
+freshness recording must never turn a successful ingest into a failed job." No test makes
+`redis_client.get`/`set` raise inside the recorder and asserts the run still completes as a success
+(and the warning is logged). If the try/except were narrowed or removed, a cache blip after a healthy
+commit would mark the whole job failed.
+
+### C-7 — `run_matching`'s job-boundary exception swallow is untested
+watchlist_matcher.py:127-133: a generic exception must be caught, logged via `log_key_event(...,
+success=False)`, and NOT propagate to the scheduler. No test raises from `_match_and_notify`/`_prune`/
+commit and asserts run_matching returns quietly with the failure event recorded. A regression here
+crash-loops the APScheduler job.
+
+### C-8 — No write-path test ingests an issuer id above 2^31 (the a7c migration's motivating bug)
+Migration a7c44d19e582 exists because "a CCP id above 2^31 would poison ingestion the same way a
+price-less contract did before f2a91c3b7e04". The price half got its TEST-22 write-path test
+(`test_a_spec_minimal_contract_persists_with_absent_optionals_null_or_defended` asserts `price is
+None` persists); the issuer half got only schema tests (model↔migration equivalence, downgrade
+guards). No test feeds `_process_contracts` a contract with `issuer_id=3_000_000_000` and asserts the
+row persists. The schema-equivalence test pins the column type, but the end-to-end "spec-extreme value
+survives the writer" test — the TEST-22 mirror this migration's own docstring invokes — is absent.
+
+### C-9 — The a7c downgrade's offline (`--sql`) rendering is unpinned
+`test_offline_downgrade_renders_a_transaction_wrapped_locked_guard` pins BEGIN < LOCK < guard < ALTER <
+COMMIT for **f2a91c3b7e04 only**. a7c44d19e582's downgrade uses the same emitted-SQL guard shape
+(docstring: "the f2a91c3b7e04 pattern") plus an additional ordering property of its own — index drops
+BEFORE the narrowing rewrite (a7c:81-85) — and neither the transaction wrapping nor the drop-before-
+rewrite order is asserted for it. Deleting a7c's `LOCK TABLE` line or reordering the drops regresses
+silently. (Escalated per instruction: the guard-atomicity property is what makes the refusal safe
+against a concurrent writer.)
+
+### C-10 — The matcher's contract-type gate is tested through one arm only
+watchlist_matcher.py:159-161 `Contract.type.in_((item_exchange, auction))`. Every matcher fixture is
+`ctype="auction"` (the `_contract` default); no test creates a matching **item_exchange** contract
+(positive arm — also leaves `_SHIP_TYPE_LABELS`' "an item exchange" rendering unasserted, see N-11) and
+no test creates a courier/other-type contract carrying an included watched item and asserts exclusion
+(negative arm). Dropping `item_exchange` from the tuple, or the tuple membership entirely, passes the
+suite.
+
+### C-11 — Mocked-behavior hazards beyond the known D-c (flag per CLAUDE.md testing rules)
+- **`test_plain_upsert_still_merges_on_dialects_without_conflict_support`** (test_db_upsert.py:125-141)
+  asserts against a hand-rolled `_RecordingSession` whose `merge` just appends to a list — it verifies
+  `db.merge` is *called*, not that merge-based upsert semantics work. The real fallback path (db_upsert
+  .py:77-79) never executes against any real non-PG database in the suite.
+- **The sqlite branch of `bulk_upsert`** (db_upsert.py:62-67), including preserve_on_null-on-sqlite,
+  never executes at all — the suite runs PostgreSQL only. The docstring's "compatible with both
+  PostgreSQL and SQLite" and "Supported on PostgreSQL and SQLite" claims are unverified; the branch is
+  effectively dead code carrying a compatibility promise no test backs.
+- **`FakeLockRedis.eval`** (tests/lock_double.py:24-29) reimplements the compare-and-delete Lua script
+  in Python. The double's semantics match today, but the Lua source itself (`_RELEASE_LOCK_LUA`) is
+  never executed by any test — a typo in the Lua (e.g. `KEYS[1]`/`ARGV[1]` swap) passes every lock test.
+  Lower priority than the first two (the script is 2 lines and shared), but it is the same hazard class.
+- *(Known, referenced, not re-counted: D-c — the `ESINotModifiedError` handlers in
+  `_fetch_regions`/`_fetch_item_rows` are dead against the real client, and the tests that exercise
+  them (`test_fetch_regions_counts_a_304_region_as_ok`,
+  `test_reingestion_with_unmodified_items_keeps_ship_flag`, the all-304 freshness test) mock a raise
+  the client never performs. D-d — Valkey-evicted page body truncating a region walk — likewise known.)*
+
+---
+
+## 3. Nice-to-have
+
+### N-1 — `_parse_esi_datetime` edge paths
+The `None → None` path (83-89) runs constantly via `date_completed` but no test asserts
+`row.date_completed is None` (spec-minimal asserts eight other optionals, not this one), and no test
+ever supplies a *populated* `date_completed`. A malformed date string raising `ValueError` inside
+`_build_contract_rows` kills the whole batch — behavior neither pinned nor decided.
+
+### N-2 — Per-field mapping assertions missing in `_build_contract_rows` (240-282)
+Fields whose *populated* value is never asserted on a persisted row: `status` (both the `"unknown"`
+default and a supplied value), `title`, `for_corporation=True`, `collateral` (non-zero), `reward`,
+`volume`. A `reward`↔`volume` mapping swap is undetectable by the current suite. `date_issued`/
+`date_expired` values are also never directly asserted post-persist (a swap is only accidentally caught
+by the expiry filter in the is_bpc HTTP test).
+
+### N-3 — Item-payload absence paths partially unasserted
+`is_blueprint_copy` absent → NULL is never asserted (ESI sends the flag true-or-absent per TEST-18;
+`test_item_level_columns...` asserts runs/ME/TE/item_id None for record 8212 but not the BPC flag), and
+`is_singleton`'s `.get(..., False)` default is never asserted.
+
+### N-4 — `_apply_dev_limit` with a configured limit and an under-limit batch
+Paths tested: limit>len (truncate), 0, None. The `limit and limit>0` but `len(contracts) <= limit`
+pass-through-without-warning path (421) has no test.
+
+### N-5 — `_record_run_outcome`'s invalid-JSON prior branch
+The `except (ValueError, TypeError)` at 510-511 (prior record is *unparseable* JSON, e.g. `"not json"`)
+is distinct from the tested valid-JSON-non-object branch (`"[]"`); it has no test.
+
+### N-6 — Lock release on body exception and client close are unasserted
+When the locked body raises (e.g. the commit-failure freshness test), the finally-release runs but no
+test asserts the lock key was removed from the store afterward; `aclose()` on all paths (including the
+acquire-failure path) is a no-op in the double and never asserted.
+
+### N-7 — `_select_known_station_systems` chunk boundary and mixed batches
+The read-back loop chunks via `UPDATE_ID_CHUNK_SIZE` (667) — monkeypatchable, but no test forces >1
+chunk here (the two existing chunk-boundary tests cover the status UPDATEs and the skip SELECT). Also
+no test mixes one already-known station with one needing a fresh fetch in a single batch (the partial
+fall-through at 632-644).
+
+### N-8 — The contract/item upsert 500-row batch loops are untestable as written
+`batch_size = 500` (544) and `BATCH_SIZE = 500` (587) are function-local literals — unlike
+`UPDATE_ID_CHUNK_SIZE` they cannot be monkeypatched, so crossing their boundary requires 500+ row
+fixtures nobody writes. Testability defect: hoist to module level so a boundary test becomes possible.
+
+### N-9 — Chunk crossing unforced for the incomplete-status and non-ship-clear UPDATE loops
+`test_id_list_updates_batch_across_the_chunk_boundary` crosses the boundary for the COMPLETED-set and
+ship-flag loops; the `incomplete_contract_ids` loop (818-823) and the `non_ship_completed` clear loop
+(812-817) are separate loops that could each independently stop after chunk one.
+
+### N-10 — No test asserts a courier contract triggers zero `get_contract_items` calls
+The `contract["type"] not in ["item_exchange", "auction"]` skip (720-721) is relied on by a dozen
+courier fixtures but never asserted (`get_contract_items.assert_not_awaited()` on a courier-only run).
+
+### N-11 — `_render_message` branch coverage
+`location=None → "an unknown location"` (57) never tested; the `"an item exchange"` label never
+rendered (see C-10); the `"a contract"` fallback label is unreachable given the query's type gate —
+either test it as defense-in-depth or note it as such.
+
+### N-12 — Matcher `distinct()` and fan-out shapes
+No test with two included items of the same watched type in one contract (pins `.distinct()`, 179 —
+without it `matched` double-counts even while `created` stays right); no multi-user test (two enabled
+users watching the same type both get notifications); no one-user-two-watches-one-contract test (two
+rows differing in `watch_type_id` both insert past the unique index).
+
+### N-13 — `_prune` sub-branches of "outstanding"
+The delete-when-gone test uses an *absent* contract row; the expired-but-present row, the
+completed-but-present row, and the `created_at == cutoff` strict-`<` boundary (231) each lack a test.
+
+### N-14 — `run_matching` happy path never runs end-to-end
+The only `run_matching` tests stub `_match_and_notify`/`_prune` (session-factory test) or hold the
+lock. No test drives a real match through `run_matching` asserting the commit lands (notifications
+visible post-commit) and the success `log_key_event` carries `matches/created/pruned`.
+
+### N-15 — `bulk_upsert([])` early return (db_upsert.py:32-33) untested
+A regression reordering it below `values[0]` access crashes on the aggregation's no-op paths.
+
+### N-16 — Non-NULL overwrite pinned for only one preserved column
+`preserve_on_null` NULL-keeps is asserted for all four name columns end-to-end
+(`test_resolved_names_survive_a_degraded_name_resolution_run`), but the "non-NULL still overwrites"
+direction is asserted only for `issuer_corporation_name` (rename test) — the other three columns'
+overwrite arm of the COALESCE rides on it. Also untested: one statement carrying mixed rows (one NULL,
+one non-NULL in the same preserved column) exercising per-row COALESCE.
+
+### N-17 — a7c clean downgrade never asserts the two indexes were dropped
+`test_clean_downgrade_restores_int32_issuer_columns` asserts column types only; index absence is caught
+only accidentally (a retained index would crash the `finally` re-upgrade on duplicate name). Assert
+`pg_indexes` directly.
+
+### N-18 — Failure before the region fetch records `failure` with 0/0 counters
+If `esi_client.__aenter__` or the session factory raises (before `_fetch_regions`), the forced-failure
+record carries the initial `regions_ok=0, regions_failed=0` (437-438) — reasonable, but unpinned.
+
+### N-19 — Spec-minimal contract does not assert the resolver/station calls are skipped
+`test_a_spec_minimal_contract_persists...` asserts NULLs persist but not that
+`get_universe_station` was never awaited for a contract with no locations (the `is not None` guard in
+`_npc_station_ids`, 208).
+
+---
+
+## 4. Path-map summary (evidence of coverage, per function)
+
+Depth check: every function exceeding the 25-line rule was path-mapped individually
+(`run_aggregation`, `_process_contracts`, `_update_item_processing_status`, `_upsert_taxonomy_names`,
+`_enrich_items_and_find_ships`, `_resolve_station_systems`, `_fetch_item_rows`, `_record_run_outcome`,
+`_concurrency_lock`, `_match_and_notify`, `_prune`, `bulk_upsert`, both migration downgrades).
+
+**background_aggregation.py — covered with own assertions:**
+region-id guards (non-list / list-with-str / empty, each with exact log-level assertions); per-region
+fetch isolation + 304-counts-ok + per-region stamping (with the anti-vacuity `-1` stamp overwrite);
+dev-limit truncate/0/None; freshness success/all-304/partial/forced-failure/non-object-prior + gauge
+both directions; lock happy release / TTL>interval (two intervals) / token-mismatch-leaves-intact;
+region-id persistence + NULL; structure-id 1e11 boundary both sides (with name-everything-passed
+anti-vacuity resolver); all four denormalized names populated + preserved-on-degraded + rename-updates;
+NPC station range both edges ×2 roles, structure never-requested ×2 roles, known-pair outage survival
+×2 roles, payload-missing-system_id, lookup-failure-degrades; type-specific fields (buyout/days/
+end name) present + absent; item columns (runs/ME/TE/item_id/BPC true/taxonomy ids) present + absent;
+spec-minimal TEST-22 payload; ship flag set / excluded-item not / clear-on-version-bump /
+degraded-never-clears; status machine COMPLETED / ENRICHMENT_INCOMPLETE (type, category, requested-
+side, category-less-group) / PENDING_ITEMS (fetch fail, zero items) with per-contract isolation;
+skip predicate both arms (status demotion, version bump) + chunk-crossing on skip-SELECT and
+flag/status UPDATEs; 304 re-ingestion keeps flag + old stamp; multipage item walk over a real
+ESIClient; taxonomy cache write / cache-first skip / category repair / nameless-group repair (both
+with fresh-service restart proof); session-factory reuse.
+
+**watchlist_matcher.py — covered:** happy match + exact message; idempotent second run; partial-index
+`index_where` binding; chunk crossing; bundle-price both sides; price ==/> boundary; expired /
+completed / delisted / at-watermark / per-region stalled watermark; requested-item excluded; disabled
+user excluded; NULL-price × {unbounded watch → dash message, bounded watch → excluded}; prune
+delete-gone / keep-outstanding / delete-delisted / keep-recent; lock held-skip / mismatch / raise /
+TTL×2; session-factory reuse.
+
+**db_upsert.py — covered:** preserve-NULL keeps + same-statement plain copy; non-NULL overwrites;
+unpreserved NULL overwrites; fresh-insert NULL stays NULL; NotImplementedError on other dialects with
+preserve_on_null; merge fallback invoked without it (see C-11 for the hazard); omitted-column
+preservation via the aggregation 304 test.
+
+**Migrations — covered:** model↔migration equivalence with `compare_server_default`; env.py
+import-safety; price downgrade refusal (message-matched) + clean restore + offline BEGIN<LOCK<guard<
+ALTER<COMMIT ordering; issuer downgrade refusal for EITHER column (loop over both arms) + clean narrow
+of both; TEST-23 restoration discipline present in every mutating migration test (finally-scoped
+rollback + row delete + upgrade-to-head).
+
+**Concurrency/TOCTOU review (instruction 6):** acquisition is a single atomic `SET NX EX` and release a
+single atomic Lua CAD — no check-then-act window exists inside either lock at the Redis level; the only
+residual window is TTL-expiry-mid-run, which is exactly what the TTL-derivation tests and the
+token-mismatch tests pin. The aggregation and matcher locks use distinct keys (constants; divergence is
+a code-review property, not testable behavior). Cross-job TOCTOU (matcher reading mid-aggregation) is
+closed by the aggregation's single-transaction commit; matcher-vs-delist between its SELECT and INSERT
+is an accepted design race (alert for a just-delisted contract), consistent with the still_listed
+tradeoff notes. Untested residuals are C-4 (held-lock skip, aggregation side) and N-6 (release-on-
+exception assertion).
+
+**ON CONFLICT semantics (instruction 5):** update set = supplied columns minus PK; omitted columns
+(is_ship_contract, item_processing_status, enrichment_version, and every model default) preserved —
+pinned by the 304-reingestion test; `preserve_on_null` = {start_location_name, end_location_name,
+issuer_name, issuer_corporation_name} — NULL-keeps pinned per column end-to-end, non-NULL-overwrites
+pinned for one of four (N-16). `last_seen_at` is a *supplied* column and therefore restamps on
+conflict — load-bearing and unasserted (C-3). Notification insert uses ON CONFLICT DO NOTHING against
+the partial unique index with a literal `index_where` — binding and idempotency both pinned.

--- a/docs/test-coverage-reports/subagent-frontend-components-findings.md
+++ b/docs/test-coverage-reports/subagent-frontend-components-findings.md
@@ -1,0 +1,304 @@
+# Frontend components + e2e — test coverage review
+
+ABOUTME: Systematic path-level coverage review of the contracts feature components
+ABOUTME: (ContractsPage family) and the Playwright e2e layer, incl. four queued prior-review inputs.
+
+Reviewed on branch `claude/pr-147-handoff-beaace` (2026-08-08). All paths are relative to
+`app/frontend/web/` unless prefixed. Intent sources: F008 spec §3/§8
+(`design/features/F008-Type-Aware-Contract-Browsing.md`), `docs/pitfalls/testing-pitfalls.md`
+(TEST-2/3/4/5/6/7/17), and the 2026-08-08 pre-release bug-hunt remediation plan
+(`docs/superpowers/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md`).
+
+Severity vocabulary per task: **security-critical / correctness / nice-to-have**.
+Verdict summary: **0 security-critical, 10 correctness, 18 nice-to-have.**
+
+---
+
+## 1. Queued inputs from prior reviews — current status
+
+### O1a — `WirePage` omits `unknown_system_excluded` — **STILL OPEN**
+
+- `e2e/fixtures/contracts.ts:153-160` — `WirePage` carries `total/page/size/items/segment_counts/coverage` and nothing else.
+- The real envelope always carries `unknown_system_excluded` (nullable): `src/lib/api/schema.d.ts:618`, pinned backend-side at `app/backend/src/fastapi_app/tests/test_export_openapi.py:36`.
+- The fixture file's own header (`e2e/fixtures/contracts.ts:1-8`) claims "feed the app exactly what the backend would send" — the claim is currently false by one field.
+- Impact today is latent (no component under `src/features/contracts/` reads the field), but the fixture lane cannot exercise any future consumer, and the drift is exactly what the wire-mirror discipline exists to prevent.
+- **Severity: correctness** (test-infrastructure drift, no user-visible bug yet).
+
+### O1b — fixture composition tiebreak `localeCompare` vs Python ordinal — **STILL OPEN**
+
+- Fixture: `e2e/fixtures/contracts.ts:293-298` — `(a.name ?? '').localeCompare(b.name ?? '')`.
+- Backend: `app/backend/src/fastapi_app/services/contract_service.py:758-764` — tuple key `(-item_row_count, name is None, name or "")`, i.e. Python code-point comparison.
+- `localeCompare` is ICU/locale-collation (case-insensitive-ish, `'a' < 'Z'`); Python ordinal is code-point (`'Z' < 'a'`). They agree only while names are same-case ASCII with distinct leading letters — true of today's `CATEGORY_NAMES` (`e2e/fixtures/contracts.ts:67-73`), so no assertion is currently wrong, but any future category set with mixed case or non-ASCII (EVE has none today in categories, but the map is hand-maintained) silently diverges the fixture's "derives the summaries the same way the service does" contract.
+- Cheap fix when taken: replace with the ordinal comparator `(a.name ?? '') < (b.name ?? '') ? -1 : …` or a code-point compare.
+- **Severity: correctness** (test-infrastructure; benign on current data by luck, not by construction).
+
+### O2 — item-less/item-bearing partition stated in four places — **PARTIALLY ADDRESSED**
+
+The four statements and their current pinning:
+
+| Location | Form | Pinned? |
+|---|---|---|
+| `src/features/contracts/filters.ts:58` (`ITEM_LESS_TYPES`) | literal | **Yes** — `src/features/contracts/filters.test.ts:66` |
+| `src/features/contracts/filters.ts:66` (`ITEM_BEARING_TYPES`) | literal | **Yes** — `filters.test.ts:67`, and **union = enum** at `filters.test.ts:70` (`[...ITEM_BEARING_TYPES, ...ITEM_LESS_TYPES].sort() === [...CONTRACT_TYPES].sort()`) |
+| `app/backend/src/fastapi_app/services/contract_service.py:409-420` | `_ITEMLESS_CONTRACT_TYPES` literal; `_ITEM_BEARING_CONTRACT_TYPES` **derived as the enum complement** | Partition holds **by construction** (complement), no test needed for the union |
+| `app/backend/src/fastapi_app/services/background_aggregation.py:720` | `if contract["type"] not in ["item_exchange", "auction"]: continue` — **hard-coded literal**, not `_ITEM_BEARING_CONTRACT_TYPES` | **NO** — no backend test references `_ITEMLESS_CONTRACT_TYPES`/`_ITEM_BEARING_CONTRACT_TYPES` (grep over `app/backend/src/fastapi_app/tests` finds none), and nothing pins the `_fetch_item_rows` literal against the enum |
+
+So: the TypeScript half of the queued gap is now closed (a sixth type fails the build via
+`UnmirroredContractTypes` at `filters.ts:49-51` and then fails `filters.test.ts:70` until
+classified). The Python half is half-closed: `contract_service` derives its complement, but
+**`_fetch_item_rows` still restates the item-bearing set as a literal with no pin** — a sixth
+item-bearing contract type would be counted, filtered and columned correctly everywhere else and
+*silently never have its items ingested*. Also note there is still no **cross-language** pin: the
+TS partition and the Python partition are each internally consistent but nothing compares them
+(e.g. an exported constant in the OpenAPI schema, or a wire-level test).
+
+- **Severity: correctness** (residual: `_fetch_item_rows` literal + no cross-language pin).
+
+### PR #156 deferred pin — no e2e fixture assigns `price: null` — **STILL OPEN**
+
+- `e2e/fixtures/contracts.ts:124` types `price: number | null`, but every builder and canned
+  dataset assigns a number (`makeContract` default `price: 250_000_000` at line 344; `SEVEN_SHIPS`,
+  `BPC_CONTRACTS`, `AUCTION_CONTRACTS`, `COURIER_CONTRACTS` all numeric; grep for `price: null`
+  under `e2e/` matches nothing — the only hit is the unrelated `max_price: null` in
+  `e2e/fixtures/account.ts:38`).
+- Reverting `WireContract.price` to `number` would still typecheck the entire e2e suite, so the
+  `number | null` widening is not regression-pinned at this layer.
+- The unit layer *does* pin the rendered branch (`pages.test.tsx:339-357`, detail-page bare dash,
+  no ISK unit in Economics) — but that test stubs raw JSON, so it would also survive the type
+  reversion; it pins the render, not the wire type.
+- Cheap fix when taken: one list-row + one detail e2e case built with `makeContract({ price: null })`
+  asserting the list cell dash and the detail dash-no-unit.
+- **Severity: correctness.**
+
+---
+
+## 2. Per-component branch map (unit/component layer: `pages.test.tsx`, `a11y.test.tsx`, `columns.test.ts`)
+
+Legend: ✔ = directly asserted; **GAP** = no direct assertion anywhere (per rules, "covered
+indirectly" is recorded as GAP).
+
+### 2.1 ContractsPage.tsx (`src/features/contracts/components/ContractsPage.tsx`)
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| EmptyResults: item-filtered item-less segment card (40-59) | ✔ | `pages.test.tsx:1805-1822`; negative case `is_bpc=false` `1824-1840`; e2e `taxonomy.spec.ts:170-174` |
+| EmptyResults: nothing-ingested + nothing-selected card (61-75) | ✔ | `pages.test.tsx:1293-1308` |
+| EmptyResults: uncovered-region heading, singular arm (79-94) | ✔ | `pages.test.tsx:1236-1250`; a11y `a11y.test.tsx:133-142`; e2e `states.spec.ts:118-137` |
+| EmptyResults: uncovered-region plural arm (85-92) | ✔ | `pages.test.tsx:1252-1264` |
+| EmptyResults: covered set empty inside uncovered card ("No region has been ingested yet") (85-87) | ✔ | `pages.test.tsx:1335-1352` |
+| EmptyResults: mixed covered+uncovered selection sentence (90-92) | ✔ | `pages.test.tsx:1323-1333` |
+| EmptyResults: ordinary covered-empty "Loosen a price bound" (95-103) | ✔ | `pages.test.tsx:1310-1321`; e2e `states.spec.ts:98-116` |
+| sr-only status: count, singular wording (197-199) | ✔ | `pages.test.tsx:164-176` ("1 contract matches", aria-live=polite) |
+| sr-only status: zero + no coverage suffix (203-204) | ✔ | `pages.test.tsx:1306-1307` |
+| sr-only status: zero + uncovered-selection suffix (205-207) | ✔ | `pages.test.tsx:1266-1279` |
+| "Data as of" shown / suppressed on null `as_of` (222-224) | ✔ | `pages.test.tsx:1209-1218` / `1220-1234`; e2e `states.spec.ts:139-149` |
+| SegmentTabs mounted only with data (231-233) | ✔ | every segment test waits on data; held-response tests keep tabs mounted (`pages.test.tsx:829-866`) |
+| enrichment-filtered incomplete notice (247-251), incl. WEB-1 held-response direction and drop-when-complete | ✔ | `pages.test.tsx:1478-1547` |
+| isPending skeleton (253-254) | ✔ | `pages.test.tsx:1758-1789`; e2e `states.spec.ts:65-96` |
+| isError alert + Retry (255-264) | ✔ | `pages.test.tsx:232-239`; a11y `165-176`; e2e retry-recovers `states.spec.ts:151-182` |
+| pageOutOfRange → redirect to last page (159-165) | ✔ | `pages.test.tsx:282-300`; e2e `pagination.spec.ts:124-144` |
+| pageOutOfRange → transient skeleton render (265-267) | **GAP** | never asserted (redirect end-state only). *nice-to-have* |
+| `data.size ?? DEFAULT_SIZE` fallback in pageCount (159) | **GAP** | every fixture envelope carries `size`. *nice-to-have* |
+| courier origin line shown on courier segment (276-280), incl. empty courier view | ✔ | `pages.test.tsx:1281-1291, 1385-1393`; negative outside courier `1395-1404`; e2e `segments.spec.ts:238-240` |
+| courier origin line suppressed when `ingested_region_ids` is empty (276) | **GAP** | the `.length > 0` guard's false arm never rendered. *nice-to-have* |
+| Filters disclosure button aria-expanded/aria-controls (172-183) | ✔ (e2e) | `responsive.spec.ts:32-101` (mobile project) — no unit assertion; the `+`/`−` glyph swap (180-182) asserted nowhere. *glyph: nice-to-have* |
+| text inputs navigate with `{ replace: true }` (122-128; also FilterRail/BlueprintFilter call sites) | **GAP** | no test anywhere asserts history-entry behavior (per-keystroke back-button walk would regress green). *nice-to-have* |
+| `resetFilters` preserves size/sort, drops the rest (132-141) | ✔ | e2e `filters.spec.ts:170-241` (exhaustive param sweep incl. sort-preservation); unit `pages.test.tsx:777-797` |
+| `handleSort` flip / DEFAULT_DIRECTION on new field (143-152) | ✔ | e2e `sorting.spec.ts:177-242` |
+
+### 2.2 SegmentTabs.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| `listTitle`: Ship/All fallback pair (41-45) | ✔ | `pages.test.tsx:123, 63-75` (e2e default-view) |
+| `listTitle`: typed titles — item_exchange/auction/courier/loan (28-34) | ✔ | courier `pages.test.tsx:671-672`; loan `971`; auction via `filters.spec` detour |
+| `listTitle`: `'Unknown Contracts'` (33) | **GAP** | the `unknown` segment is URL-reachable exactly like `loan`, but no test renders it (loan has a dedicated wire test at `pages.test.tsx:961-979`; unknown has none). *nice-to-have* |
+| `segmentPatch`: sort survives / resets by destination column set (75-76) | ✔ | `pages.test.tsx:707-757, 906-928` |
+| `segmentPatch`: item-less entry sets `ships_only:false` (77-79) | ✔ | `pages.test.tsx:649-679`; e2e `segments.spec.ts:100-137`; (the belt-and-braces half is documented mutation-unobservable at lines 60-63 — accepted) |
+| `segmentPatch`: leaving item-less REMOVES `ships_only` (80-82) | ✔ | `pages.test.tsx:681-705`; e2e `segments.spec.ts:139-168` |
+| Numeral suppression — settled item-less selection: All count-less + typed item-bearing count-less + item-less own numeral stays (149-156) | ✔ | `pages.test.tsx:799-810, 812-827`; e2e `segments.spec.ts:80-98, 151-153, 250-253` |
+| Numeral suppression — transition direction A (item-less → item-bearing, held response: numerals stay off until new envelope) (109-124) | ✔ (unit only) | `pages.test.tsx:829-866`. **E2E: absent** — no e2e spec holds a response across a segment click; the gate technique exists in `states.spec.ts:24-31` but is not applied here. *nice-to-have (unit pin is strong; e2e duplication low-value)* |
+| Numeral suppression — transition direction B (widened → item-less click, live-URL side poisons) (124, `leavingItemLess`) | ✔ (unit only) | `pages.test.tsx:868-904`. E2E absent — same note as above. *nice-to-have* |
+| Numeral suppression — ships-only → item-less click (the documented "hidden-though-honest" residual window, comment 110-123) | **GAP** | `pages.test.tsx:868` starts from `ships_only=false`; no test starts the transition from the ships-only default and asserts the in-flight suppression. The accepted residual is documented (D11 / 2026-08-08 bug-hunt) but not pinned, so a regression that *shows* numerals in that window (or breaks suppression generally from this start state) is untested. *nice-to-have* |
+| All sums ITEM_BEARING under ships-only / CONTRACT_TYPES when widened (129, 151-153) | ✔ | `pages.test.tsx:617-637, 639-647`; e2e `segments.spec.ts:59-78, 170-181` |
+| `counts[segment.type] ?? 0` missing-key fallback (156) | **GAP** | every fixture serves all five keys (deliberately, per `listPage` docs), so the `?? 0` arm never runs. *nice-to-have* |
+| aria-pressed active/inactive on plain buttons (162-164) | ✔ | `pages.test.tsx:625-627, 666-669, 974`; a11y `a11y.test.tsx:122-131`; e2e throughout |
+| loan/unknown get no control (20-25) | ✔ | `pages.test.tsx:635-636, 972`; e2e `segments.spec.ts:76-77` |
+
+### 2.3 ContractTable.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| aria-sort ascending/descending/absent, exactly one active (47-53) | ✔ | `pages.test.tsx:752-757, 771-775`; e2e `sorting.spec.ts:105, 127-130, 159-164, 230-234` |
+| Sortable header button + glyph (58-69) vs non-sortable span (70-71) | **GAP** (span arm) | sortable arm exercised by every sort click; no negative assertion that unsortable headers (Type, Route, Location…) expose no sort button. The ▲/▼ glyph direction itself is stripped by `headerNames()` (`pages.test.tsx:86-88`) and asserted nowhere (aria-sort carries the a11y contract, glyph is sighted-only). *nice-to-have* |
+| Column sets per segment (via `columnsFor`) | ✔ | header-name sweeps `pages.test.tsx:930-959, 1034-1104, 1133-1183`; e2e `segments.spec.ts:183-241`; set invariants `columns.test.ts:16-63` |
+| `hiddenClass` responsive column hiding — Location `max-lg:hidden` (columns.tsx:127), Issued `max-sm:hidden` (columns.tsx:151), courier Collateral/Volume `max-lg:hidden` (columns.tsx:280, 288) | **GAP** | asserted **nowhere at any layer**. JSDOM can't do it (fair), but the mobile Playwright project (Pixel 7, 412px) runs every spec and never asserts a hidden column `toBeHidden()` / a kept column `toBeVisible()` — `sorting.spec.ts:102-105` explicitly *works around* the hiding instead of pinning it. The two deliberate keeps ARE pinned: Deadline (`segments.spec.ts:218-223`, both projects) and the blueprint trio (`columns.test.ts:46-52` pins `hiddenClass === undefined`; `items.spec.ts:64-74` renders on both projects). But dropping `max-lg:hidden` from Location, or adding a hidden class to Price/Time-left, ships green. **correctness** |
+| `cellClass` function arm (5-8; Expired `text-warn` at columns.tsx:141-143, buyout-less faint at columns.tsx:243-244) | partial | buyout-less styling's *text* pinned (`pages.test.tsx:1058-1069`, e2e `segments.spec.ts:200`); the Expired `text-warn` arm never renders in any test (list rows are always future-dated per TEST-17; the keepPreviousData drift case that can show an expired row is unexercised). *nice-to-have* |
+| `isRefreshing` opacity dim (34-36) | **GAP** | never asserted. *nice-to-have* |
+| Sticky header intent guard (56) | ✔ | `pages.test.tsx:125-126` (className contains `sticky`) |
+| ContractTableSkeleton role/status/name (107-127) | ✔ | `states.spec.ts:76-95`; `pages.test.tsx:1781` |
+
+### 2.4 ContractDetailPage.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| notFound: non-integer id, no request leaves (124-131) | ✔ | `pages.test.tsx:414-429` |
+| notFound: `contractId <= 0` arm (126) | **GAP** | `/contracts/-5` or `/contracts/0` parses to a valid integer and takes a *different* guard arm than NaN; untested. *nice-to-have* |
+| notFound: 404 (127, 144) + title | ✔ | `pages.test.tsx:405-412`; e2e `detail.spec.ts:167-182` |
+| isPending skeleton (133-142) | ✔ | e2e `states.spec.ts:209-230` |
+| isError non-404 alert + Retry (143-157) | ✔ (render) | `states.spec.ts:232-244` asserts alert+button; the detail Retry is never *clicked* to recovery (list retry is, `states.spec.ts:170-181`). *nice-to-have* |
+| Price null → bare dash, no unit (189-191) | ✔ (unit) | `pages.test.tsx:339-357`. E2E: **absent** — see queued input 4. *correctness (counted there)* |
+| Reward row: rendered when `reward != null && reward > 0`, suppressed otherwise (193-195) | **GAP** | the courier detail test (`pages.test.tsx:548-558`) asserts Collateral only; no test asserts the Reward row renders (COURIER fixture has `reward: 80_000_000` but it is never read back), nor that an exchange contract (no reward key) suppresses the row. A courier's headline pay could disappear or render for `0` and every suite stays green. **correctness** |
+| Collateral row: `> 0` render (199-201) ✔ / `=== 0` suppression | ✔ / **GAP** | render `pages.test.tsx:555-557`; suppression (exchange CONTRACT has `collateral: 0`) never asserted. *nice-to-have* |
+| Volume row dash on null (202-204) | **GAP** | courier volume renders in the LIST; the detail Volume row (both arms) is never asserted. *nice-to-have* |
+| `for_corporation` Yes/No (205-207) | **GAP** | *nice-to-have* |
+| Issuer/corp name fallback to `Character ${id}` / `Corporation ${id}` (216-221) | **GAP** | `pages.test.tsx` ROW carries no `issuer_name`, so the fallback renders in every detail test yet is never asserted (and the named arm only via a11y fixture). *nice-to-have* |
+| Location label + null start location (222-224) | ✔ | `pages.test.tsx:560-570` |
+| Issued/Expires + expiry parenthetical / Expired badge, both arms (171-174, 225-231) | ✔ | `pages.test.tsx:383-403` |
+| Last seen shown / row omitted on null (237-239) | ✔ | `pages.test.tsx:463-486`; e2e positive `detail.spec.ts:106-110` |
+| Seller-title quoted subtitle: distinct title ✔ / blank ✔ / `title === primary_label` dedupe arm (178-180) | **GAP** (dedupe) | distinct `pages.test.tsx:330`; blank `359-381`; the third arm (courier fixtures hit it silently) never asserted. *nice-to-have* |
+| Empty items → "No item data recorded" Contents card (244-252) | **GAP** | the only render of this branch in any suite is incidental (COURIER detail, `items: []`) and never asserted; live-smoke asserts a `Contents` region exists (`live-smoke.spec.ts:63`) against arbitrary data. This is a real, common state (every courier/loan detail). **correctness** |
+| Offered/Requested split, each side conditional (77-79, 262-264) | ✔ | `pages.test.tsx:2071-2095`; a11y `105-120`; e2e `detail.spec.ts:93-101, 184-205` |
+| Item `Type ${id}` fallback (101) | ✔ | `pages.test.tsx:2097-2111` |
+| Ship badge / BPC badge / per-copy terms (103-105) | ✔ | e2e `detail.spec.ts:97-101`; terms `pages.test.tsx:2113-2131`, e2e `detail.spec.ts:207-229` |
+| WatchButton gate: `is_included && category === 'ship'` (106-110) | **GAP** | neither the positive render (offered ship shows a watch control) nor the negatives (requested ship / non-ship item shows none) is asserted in `pages.test.tsx`, `a11y.test.tsx`, `detail.spec.ts`, or `watchlist.spec.ts` (which covers the /watchlist page only, per its test list). If the watchlists feature's own unit tests cover the button in isolation, the *gate on this page* is still unpinned. **correctness** |
+| BackLink button (history) vs link (cold) (25-44) | ✔ | `pages.test.tsx:431-461, 488-498`; e2e `detail.spec.ts:118-165` incl. negative assertions on the other control's absence |
+
+### 2.5 FilterRail.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| Search input + MIN_SEARCH_LENGTH hint (60-73) | ✔ | debounce `pages.test.tsx:2134-2194`; gate e2e `filters.spec.ts:26-62` |
+| item-less: "Show" scope sentence + Ships-only disabled, is_bpc enabled (75-99) | ✔ | e2e `taxonomy.spec.ts:182-200`; unit sentence `pages.test.tsx:1791-1803` |
+| Price min/max set (102-141) | ✔ | e2e `filters.spec.ts:64-86` |
+| Price/blueprint bound cleared back to `''` → param removed (115, 133) | **GAP** | inputs are only ever filled, never cleared, in every suite (Clear-filters resets via navigation, not via the input path). *nice-to-have* |
+| Region count chip (146-150) | **GAP** | never asserted. *nice-to-have* |
+| Region type-ahead narrows (152-160) ✔ / "No region matches" empty message (166-167) | ✔ / **GAP** | e2e `filters.spec.ts:101-105`; empty-message arm untested. *nice-to-have* |
+| toggleRegion check→sorted ascending wire (51-56) ✔ / uncheck-to-last → param removed | ✔ / **GAP** | e2e `filters.spec.ts:107-121`; uncheck path untested. *nice-to-have* |
+| `hasActiveFilters` disjuncts (42-49) | partial | exercised for search+min_price+segment (e2e `filters.spec.ts:182-212`), `group_id` deep link (`pages.test.tsx:1876-1887`); the remaining disjuncts (`max_price`, `region_ids`, `!ships_only`, each blueprint bound) never individually gate the button. A dropped disjunct = deep-linked filter with no Clear button. *nice-to-have (boilable lake)* |
+| itemSurfaceReady gate open/closed + "still indexing" line (192-208) | ✔ | `pages.test.tsx:1430-1547, 1748-1789`; e2e `taxonomy.spec.ts:128-142`, `items.spec.ts:90-104` |
+| item-less sentence above the (open) item filters (199-203) | ✔ | `pages.test.tsx:1791-1803`; e2e `taxonomy.spec.ts:196-199` |
+
+### 2.6 TaxonomyFilter.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| Scoping: empty selection = whole taxonomy / scoped groups (70-76) | ✔ | `pages.test.tsx:1569-1587`; e2e `taxonomy.spec.ts:33-56` |
+| toggleCategory prune-in-one-navigation / widen-keeps-all (78-98) | ✔ | `pages.test.tsx:1622-1655`; e2e `taxonomy.spec.ts:102-126` |
+| toggleGroup add/remove (100-105) | ✔ | e2e `taxonomy.spec.ts:58-83` |
+| Group type-ahead + "No group matches “q”" (74-76, 153-156) | ✔ | `pages.test.tsx:1589-1605` |
+| "No group in the selected categories" (query-less empty arm, 155) | **GAP** | only the query arm of the ternary is asserted. *nice-to-have* |
+| "No category in the corpus yet" (111-112) | **GAP** | every ready-taxonomy fixture has categories. *nice-to-have* |
+| Null-`category_id` group: reachable only unscoped; dropped from `survivingGroups` on narrow (70-71, 92) | **GAP** | `WireTaxonomyGroup.category_id` is nullable (`e2e/fixtures/contracts.ts:167-171`) and the code comments call the case out, but no fixture serves one. *nice-to-have* |
+| Live-region scope description, both wordings + count + aria-live (126-141, IdFieldset 33-41) | ✔ | `pages.test.tsx:1657-1694`; a11y described-by resolution `a11y.test.tsx:144-163` |
+| Selected-count chips (27-31) | ✔ (via described-by tests' selected states) — chip numeral itself unasserted. *nice-to-have (folded into region chip row above)* |
+
+### 2.7 BlueprintFilter.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| ME min bound → URL + wire (35-64, family 2) | ✔ | e2e `filters.spec.ts:148-168`; deep-link `pages.test.tsx:1478-1532` |
+| **Runs min/max, ME max, TE min/max — the other five bounds** (FAMILIES 13-17) | **GAP** | no suite ever types into or deep-links `min_runs`/`max_runs`/`max_me`/`min_te`/`max_te` through the *controls* (the parser is covered in `filters.test.ts`, the wire in backend tests). `FAMILIES` is data: a swapped key (`max: 'max_me'` on the TE row) would produce a wrong wire param with everything green. The e2e Clear-filters sweep (`filters.spec.ts:237-240`) asserts their *absence* after reset only. **correctness** (five-case lake, minutes to boil) |
+| Empty string → `undefined` (bound removal, 30-31) | **GAP** | same fill-only pattern as price. *nice-to-have* |
+| sr-only Min/Max labels per family noun (40, 54) | partial | 'Minimum material efficiency' exercised; the other five labels unqueried. (folded into the row above) |
+
+### 2.8 Pagination.tsx
+
+| Branch (lines) | Status | Evidence / gap severity |
+|---|---|---|
+| Prev disabled on 1 / Next disabled on last (19, 25) | ✔ | e2e `pagination.spec.ts:81-97` |
+| Label "Page N of M · T contracts" (22-24) | ✔ | e2e `pagination.spec.ts:56, 139, 158`; boundary walk `29-79` (TEST-4) |
+| `Math.max(1, …)` clamp when `total === 0` (16) | **GAP** | unreachable from ContractsPage (EmptyResults replaces the table at `ContractsPage.tsx:281-287`), but the component is generic (`unitLabel` prop, line 8) and any other caller hits the clamp; never asserted. *nice-to-have* |
+| `unitLabel` non-default arm (8, 23) | **GAP** | *nice-to-have* |
+
+---
+
+## 3. Per-e2e-spec journey map (desktop + mobile projects unless noted)
+
+`playwright.config.ts:25-55`: `desktop` (1280×800) and `mobile` (Pixel 7, 412px) both run every
+spec except `live-smoke`, which runs desktop-shaped only (`live-smoke` + optional
+`live-smoke-prod`). Retries 0 throughout (TEST-2).
+
+| Spec | Journeys pinned | Journeys absent (rows) |
+|---|---|---|
+| `default-view.spec.ts` | root→/contracts redirect; ships-only default wire (`is_ship_contract=true`, PROXY-1 path, page/size/sort defaults); widen toggle drops the param | — |
+| `segments.spec.ts` | control set + honest counts; settled numeral suppression (item-bearing count-less while courier active); courier select clears ships-only + URL shape + reload-restores; All restore removes both params; widened All full sum; auction column split + "No buyout"; courier columns + unknown-structure + rate + Deadline + origin statement; shared courier URL | in-flight numeral suppression (both held-response directions — unit-only, `pages.test.tsx:829-904`); `loan`/`unknown` reachable-by-URL journey (unit-only, `pages.test.tsx:961-979`) — *nice-to-have each* |
+| `filters.spec.ts` | 3-char search gate incl. never-sent proof; price bounds; region type-ahead + 2-region repeated-key wire; is_bpc; min_me; Clear-filters exhaustive URL sweep + sort preservation; filter resets page to 1 | clearing an individual input back to empty (param removal) — *nice-to-have* |
+| `sorting.spec.ts` | default issued-desc; price sort + page reset + server-order render; direction flip; column-switch direction reset; deep-link sort; courier rate sort both directions + segment travels; courier sortless-entry reconcile to date_expired asc | **Deadline (`days_to_complete`) header click — untested in every suite** (only the parser accepts it, `filters.test.ts:189-190`, and the header renders; the header→wire→aria-sort journey for the one column comment-flagged "the server sorts on it so the header must disclose it", `columns.tsx:308-312`, is unpinned) — **correctness**. Buyout and Time-left header clicks e2e-absent (unit covers buyout `pages.test.tsx:1071-1084`; Time-left click covered nowhere as a click, only as reconcile target) — *nice-to-have* |
+| `pagination.spec.ts` | 3-page boundary walk, union/no-dup (TEST-4); disabled endpoints; scroll-to-top on page; out-of-range rewrite to last page; middle-page deep link without page-1 fetch | — |
+| `states.spec.ts` | held-response loading skeleton; empty card + zero announcement; uncovered-region card; freshness stamp; error alert + retry recovery (retry-exhaustion aware, TEST-7); live-region count update on filter; detail loading; detail error | "No data ingested yet" empty-corpus card (unit-only `pages.test.tsx:1293-1308`); mixed covered/uncovered selection (unit-only `1323-1333`); enrichment "results may be incomplete" notice (unit-only `1478-1547`) — *nice-to-have each* |
+| `taxonomy.spec.ts` | category scopes groups + wire; type-ahead + group beside category; shared two-param URL; prune-in-one-navigation; partial-coverage gate closed + message; filter survives item-less round trip + mismatch card; ships-only disabled on item-less | — |
+| `items.spec.ts` | three blueprint row states (values / "3 BPCs" link / nothing) on both viewports; gated columns absent under partial; mixed-lot composition line | composition unnamed-category "+N more" fallback (unit-only `pages.test.tsx:2032-2051`) — *nice-to-have* |
+| `detail.spec.ts` | row→detail full render (badges, regions, ISK unit, Last seen); history-back button restores filtered URL; cold deep link renders + link control + no stray requests; 404 + back; WTB two-sided split; per-copy terms; document title | **null-price detail (queued input 4)**; expired badge/countdown drop (unit-only `pages.test.tsx:383-403`); Last-seen-null omission (unit-only `476-486`); empty-items Contents card — *counted in §2.4* |
+| `responsive.spec.ts` | mobile: disclosure closed by default + hidden single-instance rail; open→filter end-to-end→close; filter survives collapse; desktop: no button + permanent rail; both: row→detail→browser-back | **responsive column visibility (Location/Issued/Collateral/Volume hides at 412px; Price/Time-left keeps)** — the one viewport-sensitive table behavior, unpinned anywhere — **correctness** (counted in §2.3) |
+| `live-smoke.spec.ts` | real-proxy 200 + PROXY-1 pathname; announced-total XOR structure; detail round trip + history back; real page-boundary no-dup (SQLA-1 guard) | mobile live-smoke project does not exist (config) — *nice-to-have*; no live structural probe of `segment_counts`/coverage block shape |
+| `auth.spec.ts` / `notifications.spec.ts` / `saved-searches.spec.ts` / `watchlist.spec.ts` | header identity (anon login link w/ next, authed portrait+logout, single logout POST, ?sso=denied notice); bell unread count, list + mark-all-read, anon prompt; save-search POST payload minus page, apply, header nav; watchlist anon prompt, add-by-name payload, two-step remove | outside this review's component scope; noted for the journey inventory. WatchButton-on-detail gate belongs to §2.4's GAP, not covered here either |
+
+---
+
+## 4. Findings ledger
+
+### Security-critical — 0
+
+None. The reviewed surface renders server-derived text through React (no `dangerouslySetInnerHTML`
+found in the components reviewed), and no auth/secret handling lives in this layer.
+
+### Correctness — 10
+
+| # | Finding | Where |
+|---|---|---|
+| C1 | O1a: `WirePage` still omits `unknown_system_excluded`; fixture lane's wire-mirror claim is false by one field | `e2e/fixtures/contracts.ts:153-160` vs `src/lib/api/schema.d.ts:618` |
+| C2 | O1b: fixture composition tiebreak `localeCompare` vs backend Python ordinal — agrees only over same-case ASCII | `e2e/fixtures/contracts.ts:297` vs `app/backend/src/fastapi_app/services/contract_service.py:758-764` |
+| C3 | O2 residual: `_fetch_item_rows` hard-codes `["item_exchange", "auction"]` with no test pinning it to the enum/partition; a sixth item-bearing type would silently never get items ingested. Frontend union now pinned (`filters.test.ts:70`); no cross-language pin exists | `app/backend/src/fastapi_app/services/background_aggregation.py:720` |
+| C4 | PR #156 deferral stands: no e2e fixture assigns `price: null`; reverting `WireContract.price` to `number` still typechecks; e2e list/detail null-price journey absent | `e2e/fixtures/contracts.ts:124` |
+| C5 | Responsive column visibility (`hiddenClass` — Location `max-lg:hidden`, Issued `max-sm:hidden`, courier Collateral/Volume `max-lg:hidden`) asserted at no layer, despite the mobile project running every spec; only the deliberate keeps (Deadline, blueprint trio) are pinned | `src/features/contracts/columns.tsx:127, 151, 280, 288`; workaround at `e2e/sorting.spec.ts:102-105` |
+| C6 | Detail Reward row (`reward != null && reward > 0`) — neither render (courier) nor suppression (zero/absent) is asserted anywhere | `src/features/contracts/components/ContractDetailPage.tsx:193-195` |
+| C7 | Detail empty-items "No item data recorded" Contents card never asserted — the standard courier/loan detail state | `ContractDetailPage.tsx:244-252` |
+| C8 | BlueprintFilter: five of six bounds (min/max runs, max ME, min/max TE) never exercised through the controls; a swapped key in the `FAMILIES` table ships green | `src/features/contracts/components/BlueprintFilter.tsx:13-17` |
+| C9 | Deadline (`days_to_complete`) header sort click untested in unit and e2e — the header discloses a server sort (per its own comment) whose click→wire→aria-sort journey is unpinned | `src/features/contracts/columns.tsx:303-316` |
+| C10 | WatchButton gate on detail items (`is_included && category === 'ship'`) — positive and negative arms unasserted in this layer | `ContractDetailPage.tsx:106-110` |
+
+### Nice-to-have — 18
+
+| # | Finding | Where |
+|---|---|---|
+| N1 | pageOutOfRange transient skeleton arm unasserted | `ContractsPage.tsx:265-267` |
+| N2 | `data.size ?? DEFAULT_SIZE` fallback unexercised | `ContractsPage.tsx:159` |
+| N3 | Courier origin line suppression when coverage is empty | `ContractsPage.tsx:276` |
+| N4 | Filters button `+`/`−` glyph swap unasserted (aria-expanded is pinned) | `ContractsPage.tsx:180-182` |
+| N5 | `{ replace: true }` history semantics for text inputs untested (per-keystroke history regression invisible) | `ContractsPage.tsx:122-128` |
+| N6 | `'Unknown Contracts'` title / unknown-segment-by-URL journey (loan has one; unknown doesn't) | `SegmentTabs.tsx:33` |
+| N7 | `counts[type] ?? 0` missing-key fallback | `SegmentTabs.tsx:156` |
+| N8 | ships-only → item-less in-flight suppression window (documented residual) unpinned; e2e has no in-flight numeral tests in either direction | `SegmentTabs.tsx:109-124` |
+| N9 | Non-sortable header span arm — no negative sort-button assertion; ▲/▼ glyph direction unasserted | `ContractTable.tsx:58-71` |
+| N10 | `isRefreshing` opacity dim | `ContractTable.tsx:34-36` |
+| N11 | Expired-row `text-warn` cellClass arm never rendered | `columns.tsx:141-143` |
+| N12 | Detail: negative/zero id guard arm; collateral-0 suppression; Volume row both arms; `for_corporation`; issuer/corp id fallbacks; title-dedupe arm; detail Retry never clicked to recovery | `ContractDetailPage.tsx:126, 199-207, 216-221, 178-180, 143-157` |
+| N13 | FilterRail: "No region matches" arm; region uncheck-to-removal; input clear-to-removal; remaining `hasActiveFilters` disjuncts; count chips | `FilterRail.tsx:42-49, 115, 133, 146-150, 166-167` |
+| N14 | TaxonomyFilter: "No category in the corpus yet"; "No group in the selected categories" (query-less arm); null-`category_id` group scoping | `TaxonomyFilter.tsx:70-71, 92, 111-112, 155` |
+| N15 | BlueprintFilter/price empty-string bound removal path | `BlueprintFilter.tsx:30-31`, `FilterRail.tsx:115, 133` |
+| N16 | Pagination `total===0` clamp arm and `unitLabel` arm | `Pagination.tsx:8, 16` |
+| N17 | E2E gaps that are unit-pinned: no-data-ingested card, mixed region selection, enrichment incomplete notice, unnamed-composition fallback, expired-badge detail, last-seen-null | see §3 states/items/detail rows |
+| N18 | No mobile live-smoke project | `playwright.config.ts:36-40` |
+
+---
+
+## 5. Review notes (method + uncertainties)
+
+- **Method.** Read all eight components plus `columns.tsx`/`filters.ts` end-to-end; mapped every
+  conditional against `pages.test.tsx` (2,195 lines), `a11y.test.tsx`, `columns.test.ts`,
+  `filters.test.ts` (targeted), all 16 e2e specs, both helpers, all three fixture files, and the
+  Playwright config. Backend files read only where a queued input required verification
+  (`contract_service.py`, `background_aggregation.py`, backend test greps).
+- **Boundary with the logic-layer reviewer.** `format.ts`/`filters.ts`/hooks internals
+  (`useContracts`, debounce) are the sibling subagent's scope; rows here reference them only where
+  a component-layer journey depends on them (e.g. Deadline sort).
+- **Uncertainty flagged rather than assumed.** C10 (WatchButton): the watchlists feature may carry
+  its own component tests for the button in isolation — I verified only that the *gate on the
+  detail page* is unasserted in the files in this review's scope plus `watchlist.spec.ts`.
+- **What I'd add with more time.** A pass over `src/features/watchlists`/`saved-searches`
+  component tests to close the C10 uncertainty, and a check of whether any Vitest test renders
+  `Pagination` outside ContractsPage (would retire N16's clamp row).
+- **Almost missed.** The frontend partition pin at `filters.test.ts:70` — the queued O2 wording
+  ("no test pinning … in either language") is now stale for TypeScript; only the Python
+  `_fetch_item_rows` literal remains unpinned. Report the residual, not the original claim.

--- a/docs/test-coverage-reports/subagent-frontend-logic-findings.md
+++ b/docs/test-coverage-reports/subagent-frontend-logic-findings.md
@@ -1,0 +1,372 @@
+# Frontend LOGIC layer — systematic test coverage review (2026-08-08)
+
+ABOUTME: Path-by-path coverage map for the contracts frontend logic layer (filters, format,
+ABOUTME: columns, regions, hooks, useDebouncedValue, api client) with per-row severity and gap calls.
+
+Reviewer rules applied: every path mapped with line numbers; a path without a dedicated
+assertion is **GAP** (component-level assertions in `pages.test.tsx` count as dedicated when
+they pin the exact branch, and the covering file:line is named); each parser field and enum
+variant is its own row; boundary values checked explicitly. Severity: **SEC** (input-handling
+path that could leak/corrupt requests or state), **CORR** (correctness), **NTH** (nice-to-have).
+
+Intent sources consulted: `docs/pitfalls/testing-pitfalls.md` (TEST-2 never weaken, TEST-17
+clock-anchored fixtures — the formatter tests correctly inject `now` and stay literal-vs-literal),
+`docs/plans/2026-08-08-f008-prerelease-bug-hunt-remediation-plan.md` (Phase 1: B3 integer
+guards, B5 per-field default sort direction, B7 dedupe; Phase 2: B4 pluralization, B6 label
+comment; Phase 3: B1 segment numerals), and the F008 criteria referenced inline in the source
+(1.1, 1.2, 1.7, 1.9, 2.2, 5.3, 6.1, 7.2, 7.3, §8). Note: the prompt named the plan at
+`docs/superpowers/plans/…`; in this worktree it lives at `docs/plans/…`.
+
+Files under review (all paths relative to `app/frontend/web/`):
+
+- `src/features/contracts/filters.ts` / `filters.test.ts`
+- `src/features/contracts/format.ts` / `format.test.ts`
+- `src/features/contracts/columns.tsx` / `columns.test.ts`
+- `src/features/contracts/regions.ts` / `regions.test.ts`
+- `src/features/contracts/hooks/useContracts.ts`, `useTaxonomy.ts`, `useContract.ts` / `hooks/hooks.test.tsx`
+- `src/lib/useDebouncedValue.ts` (no test file exists)
+- `src/lib/api/client.ts` / `client.test.ts`
+- Component-level pins cited from `src/features/contracts/components/pages.test.tsx`
+
+## Summary counts
+
+- **Security-critical gaps: 0.** Every input-handling path here either drops junk to
+  `undefined` (parser), gates it before the wire (`toApiQuery`), or is validated again
+  server-side. No path constructs a request or state from unvalidated input in a way that
+  could leak or corrupt — the failure mode of every gap below is a wrong display, a wrong
+  default, or a 422, not a leak. Escalation considered for the `page` upper bound
+  (`Number.MAX_SAFE_INTEGER` passes through to the API, filters.ts:284) and for the trimmed
+  search wire value; both are bounded by backend validation and classified CORR.
+- **Correctness gaps: 28**
+- **Nice-to-have gaps: 13**
+
+---
+
+## 1. `filters.ts` (343 lines) vs `filters.test.ts`
+
+### Constants / enums
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `SORT_FIELDS` membership (9 fields) | 6–16 | filters.test.ts:168–178 pins the exact list | Covered |
+| `CONTRACT_TYPES` mirrors server enum, all 5 variants | 30–36 | filters.test.ts:59–65 pins membership; `satisfies`/`Exhausted` close both directions at compile time | Covered |
+| `ITEM_LESS_TYPES` = courier, loan, unknown | 58 | filters.test.ts:66 | Covered |
+| `ITEM_BEARING_TYPES` = item_exchange, auction; partition property | 66 | filters.test.ts:67, 70 (partition of the enum) | Covered |
+| `MIN_SEARCH_LENGTH === 3` | 69 | filters.test.ts:286 | Covered |
+| `DEFAULT_PAGE`/`DEFAULT_SIZE`/`MAX_SIZE` values | 70–72 | Used as oracles throughout the test file; `MAX_SIZE=100` itself never observed at its boundary (see size rows) | Partial — see size boundary gap |
+
+### `DEFAULT_DIRECTION` per-field fallback (Phase 1 Task 1.2 / bug B5 — added this cycle)
+
+The parser reaches this map on line 289 whenever `sort_direction` is absent/junk. Each field
+is its own row per the review rules. Only two of nine are asserted.
+
+| Field → expected fallback | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `date_issued` → `desc` | 189 | filters.test.ts:36, 207, 266 | Covered |
+| `date_expired` → `asc` | 190 | filters.test.ts:259–261 (courier fallback) | Covered |
+| `price` → `asc` | 191 | none — no test parses `{sort_by:'price'}` without a direction | **GAP (CORR)** |
+| `collateral` → `asc` | 192 | none | **GAP (CORR)** |
+| `ship_name` → `asc` | 193 | none | **GAP (CORR)** |
+| `volume` → `desc` | 194 | none | **GAP (CORR)** |
+| `reward_per_volume` → `desc` | 197 | none (test :183 asserts the *field* is kept with courier, never the direction) | **GAP (CORR)** |
+| `days_to_complete` → `desc` | 198 | none (test :189 same — field only) | **GAP (CORR)** |
+| `buyout` → `asc` | 199 | none (test :185 same — field only) | **GAP (CORR)** |
+
+Mutation check (thought experiment, per TEST-12): flipping `volume: 'desc'` to `'asc'` in the
+map fails **zero** tests today. For a fix that exists *because* B5 was a flat-`desc` bug, seven
+of nine map entries being unpinned is the headline parser gap.
+
+### `activeSegment` (105–107)
+
+| Path | Coverage | Verdict |
+|---|---|---|
+| Exactly one selected type → that type | filters.test.ts:272 (via dedupe test); pages.test.tsx segment suites exercise it end-to-end | Covered |
+| `contract_type === undefined` → `undefined` | no assertion anywhere calls `activeSegment` on a no-selection search | **GAP (CORR)** |
+| Multi-type selection → `undefined` | no assertion (`?.length === 1` false branch) | **GAP (CORR)** |
+
+### Helper predicates (118–168)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `hasEnrichmentDependentFilters`: any of the 8 keys defined → true; all undefined → false | 129–131 | No unit test. Component pins: pages.test.tsx:1534 ("warns only when a filter that reads the new item columns is in play") asserts min_price does NOT trigger and a taxonomy filter does; :1478 the deep-link warning; :1525 drop-once-enriched | Covered (component-level, both branches pinned) |
+| `hasOfferedItemFilters` (adds `is_bpc` to the eight) | 139–143 | Grep finds no caller outside filters.ts and no test importing it. `requiresOfferedItem` does not call it — it uses `hasEnrichmentDependentFilters || is_bpc === true`. **This export appears entirely unused and untested** | **GAP (NTH)** — dead-export check; if a consumer exists it is untested, if none exists it is YAGNI |
+| `requiresOfferedItem`: enrichment-dependent branch | 156–158 | pages.test.tsx:1805 (empty item-less segment explained under an item filter) | Covered (component) |
+| `requiresOfferedItem`: `is_bpc === true` branch | 157 | pages.test.tsx:1791–1842 suite exercises item-filter-on-item-less explanations | Covered (component) |
+| `requiresOfferedItem`: `is_bpc === false` must NOT trigger | 157 | pages.test.tsx:1824 ("does not claim an item-less mismatch for is_bpc=false") — a dedicated assertion of exactly this split | Covered (component) |
+| `isItemLessSelection`: undefined → false; all-item-less → true; mixed → false | 165–168 | Composed behavior pinned via parser widening tests (filters.test.ts:85–97, 138–147) and pages.test.tsx:1791+; no direct unit call, but every branch has a behavioral assertion | Covered (composed) |
+| `isItemLessSelection` on an empty array → **vacuously true** (`[].every` ⇒ true) | 167 | Unreachable from the parser (`toContractTypes` returns `undefined`, never `[]`), but the function is exported and a future caller handing it a hand-built search hits the wrong answer silently. No test documents the contract | **GAP (NTH)** |
+
+### Parser fields — `parseContractSearch` (244–291)
+
+Each field: junk / valid / absent are separate paths.
+
+| Field & branch | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `search` valid non-empty string → kept | 268 | filters.test.ts:219, 228 | Covered |
+| `search` absent → undefined | 268 | filters.test.ts:17 (defaults) | Covered |
+| `search` **empty string** `''` → undefined (`length > 0` guard) | 268 | none — no test parses `{search: ''}` | **GAP (CORR)** |
+| `search` **non-string junk** (number/array) → undefined | 268 | none | **GAP (CORR)** |
+| `min_price` valid (int, decimal, numeric string, 0) | 269 | filters.test.ts:214–215, 250–252 | Covered |
+| `min_price` negative (number and string) → undefined | 269 | filters.test.ts:211, 213 | Covered |
+| `min_price`/`max_price` **non-numeric junk** (`'abc'`, `''`, `Infinity`) → undefined | 170–174, 202–205 | tested only through the blueprint-bounds path (:161); never through a price field | **GAP (NTH)** — shared helper, but per-field rule applies |
+| `max_price` negative → undefined; valid decimal kept | 270 | filters.test.ts:212, 215, 252 | Covered |
+| `region_ids` lone scalar → array; junk entries dropped (string-number kept, `'abc'`, −5 dropped); all-junk → undefined | 271, 220–226 | filters.test.ts:48–54 | Covered |
+| `region_ids` **empty array** `[]` → undefined | 221, 225 | none — the `value === undefined ? [] : [value]` vs `Array.isArray` distinction with a literal `[]` input is never exercised for this field | **GAP (CORR)** — boundary named in review scope |
+| `region_ids` non-integer (1.5) / zero → dropped | 224 | zero pinned only via `group_id` (:151); 1.5 nowhere | **GAP (NTH)** (folded into the shared-helper row below) |
+| `contract_type` valid single / valid array / mixed valid+junk / all junk → undefined | 272, 228–237 | filters.test.ts:73–83 | Covered |
+| `contract_type` duplicate values → deduped (Phase 1 Task 1.3 / B7) | 235 | filters.test.ts:269–273 incl. `activeSegment` identity | Covered |
+| `contract_type` **empty array** `[]` → undefined | 229, 236 | none | **GAP (CORR)** |
+| `category_id` valid scalar/array, junk dropped, all-junk → undefined | 273 | filters.test.ts:149–153 | Covered |
+| `category_id` **empty array** → undefined | 220–226 | none | **GAP (CORR)** |
+| `group_id` valid/junk incl. 0 dropped | 274 | filters.test.ts:151 | Covered |
+| `group_id` **empty array** → undefined | 220–226 | none | **GAP (CORR)** |
+| Six blueprint bounds (`min_runs`…`max_te`): negative → undefined, `'abc'` → undefined, 0 kept, `'10'` kept | 275–280 | filters.test.ts:155–165 loops all six | Covered |
+| Six blueprint bounds: **non-integer** (2.5, `'2.5'`) → undefined; `'0'` kept (Phase 1 Task 1.1 / B3) | 210–213 | filters.test.ts:239–247 loops all six | Covered |
+| `is_bpc` boolean true / false kept | 281 | filters.test.ts:116+127 (true), 130–136 (false) | Covered |
+| `is_bpc` absent → undefined | 281 | filters.test.ts:17 | Covered |
+| `is_bpc` **non-boolean junk** (`'true'`, 1) → undefined | 281 | none — the only parser field whose junk branch has no test at all | **GAP (CORR)** |
+| `ships_only` default true / explicit true / explicit false / string-junk `'false'` → true | 283 | filters.test.ts:40–46 | Covered |
+| `ships_only` item-less widening (single, explicit-true override, multi item-less) | 252–253, 283 | filters.test.ts:85–97 | Covered |
+| `ships_only` untouched for mixed / item-bearing / junk-only selection | 283 | filters.test.ts:138–147 | Covered |
+| Item-level filters preserved through an item-less selection (incl. `is_bpc=false`) | 254–265 | filters.test.ts:99–136 | Covered |
+| `page` junk (`'x'`) → DEFAULT_PAGE | 284 | filters.test.ts:198–204 | Covered |
+| `page` **bounds**: 0 → fallback, 1 kept (min boundary), negative, non-integer 1.5 → fallback | 215–218, 284 | none — only string junk tested; valid page 3 kept (:223, :232) | **GAP (CORR)** |
+| `size` out-of-range high (9999) → DEFAULT_SIZE | 285 | filters.test.ts:200, 205 | Covered |
+| `size` **bounds**: exactly `MAX_SIZE` (100) kept, 101 → fallback, 0 → fallback, 1 kept | 285 | none — the exact 100/101 edge is unpinned; a clamp-vs-fallback regression at the boundary is invisible | **GAP (CORR)** |
+| `sort_by` junk (`'DROP TABLE'`) → date_issued | 305–307 | filters.test.ts:201, 206 | Covered |
+| `reconcileSort`: valid + disclosed by segment → kept (reward_per_volume/courier, buyout/auction, days_to_complete/courier) | 301–312 | filters.test.ts:182–190 | Covered |
+| `reconcileSort`: valid but undisclosed, date_issued expressible → date_issued (buyout, no segment) | 311 | filters.test.ts:191 | Covered |
+| `reconcileSort`: valid but undisclosed, date_issued NOT expressible → date_expired (ship_name/courier) | 311 | filters.test.ts:192–194 | Covered |
+| `reconcileSort` **per multi-type selection**: `contractTypes.length !== 1` → segment undefined → default column set governs (e.g. `buyout` + `['auction','courier']` must reconcile to date_issued) | 308 | none — every reconcile test uses zero or one type | **GAP (CORR)** |
+| `sort_direction` valid kept (asc :226/235, explicit desc override :263–264) | 287–289 | Covered |
+| `sort_direction` junk → `DEFAULT_DIRECTION[sortBy]` | 289 | filters.test.ts:202, 207 (date_issued only) — per-field rows above | Covered for the branch; per-field gaps counted above |
+
+### `toApiQuery` (319–342)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| Search gate: 2 chars → undefined (below boundary) | 322 | filters.test.ts:288 | Covered |
+| Search gate: whitespace-padded 2 chars (`'  ab  '`) → undefined (trim before measuring) | 321–322 | filters.test.ts:289 | Covered |
+| Search gate: exactly 3 chars → sent (boundary) | 322 | filters.test.ts:290 | Covered |
+| Search **trimmed value is what's sent** (`'  abc  '` → `'abc'`, not the raw string) | 321–322 | none — every ≥3 test uses an already-trimmed string, so a regression to `s.search` (raw) passes the suite while sending padded text the backend matches differently | **GAP (CORR)** |
+| `ships_only: true` → `is_ship_contract: true`; false → undefined | 336 | filters.test.ts:302–305 | Covered |
+| Widened item-less selection → no `is_ship_contract` on the wire | 336 | filters.test.ts:307–314 | Covered |
+| Filter pass-throughs (type, taxonomy, blueprint bounds, prices, regions) + pagination/sort always present | 323–340 | filters.test.ts:277–300, 316–341 | Covered |
+| `is_bpc` pass-through | 335 | none — the pass-through test omits it | **GAP (NTH)** |
+| Junk-dropped field stays absent on the wire | — | filters.test.ts:277–283; client.test.ts:41–50 (undefined params omitted from the URL) | Covered |
+
+---
+
+## 2. `format.ts` (213 lines) vs `format.test.ts`
+
+TEST-17 compliance noted: `timeRemaining` tests inject `now` and assert literal-vs-literal —
+the sanctioned pattern; fixtures elsewhere use `daysFromNow()` helpers.
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `formatIsk` value → grouped; null → '—' | 30–32 | format.test.ts:91–92 | Covered |
+| `formatIsk(undefined)` → '—' | 31 | none (signature accepts it; couriers/auctions call it with possibly-absent fields, and Phase 4 makes `price` nullable) | **GAP (NTH)** |
+| `formatIsk(0)` → `'0'` (courier price is genuinely 0) | 31 | none directly (pages.test.tsx courier suites render price 0 rows but never assert the price cell text) | **GAP (NTH)** |
+| `formatVolume` null / undefined → '—' | 54 | format.test.ts:353–356 | Covered |
+| `formatVolume(0)` → `'0'` (measured zero keeps its numeral) | 55 | format.test.ts:349–350 | Covered |
+| `formatVolume` < 0.005 → `'<0.01'` | 55 | format.test.ts:348 | Covered |
+| `formatVolume` **exactly 0.005** (boundary: not `<`, so formatted) | 55 | none | **GAP (NTH)** |
+| `formatVolume` < 100 → two decimals; float-noise flattening | 56 | format.test.ts:330–331, 337–338 | Covered |
+| `formatVolume` **just below 100** (99.99 → `'99.99'`) — threshold's other side | 56 | none (:342 pins exactly 100 → `'100'`; the sub-threshold side is only pinned far away at 0.02–0.2) | **GAP (NTH)** |
+| `formatVolume` ≥ 100 → whole, grouped, rounded | 56–57 | format.test.ts:342–344 | Covered |
+| `formatRewardPerVolume` decimals kept / whole grouped / null / undefined | 61–63 | format.test.ts:131–136 | Covered |
+| `formatDeadline` value / 0 / null / undefined | 66–68 | format.test.ts:171–177 | Covered |
+| `formatDate` valid → UTC day; garbage → '—' | 70–73 | format.test.ts:101–102 | Covered |
+| `timeRemaining` NaN → '—' | 81 | format.test.ts:51 | Covered |
+| `timeRemaining` exact instant + past → 'Expired' (`<=` not `<`) | 82 | format.test.ts:54–59 | Covered |
+| `timeRemaining` sub-minute clamp to '1m' | 89 | format.test.ts:62–68 | Covered |
+| `timeRemaining` bucket boundaries (59m59s / 1h / 23h59m / 1d / 1d23h) + unit dropping | 83–88 | format.test.ts:71–86 | Covered |
+| `contractTypeLabel` all five enum variants (Phase 2 B6 pinned the courier label) | 95–112 | format.test.ts:108–117 — each variant its own assertion | Covered |
+| `contractTypeLabel` out-of-map → 'Unknown' | 111 | format.test.ts:119–123 | Covered |
+| `routeLabel` both named / null destination / null origin / both null, never the id | 120–131 | format.test.ts:141–166 | Covered |
+| `regionNames` 1/2/3-name prose; unknown id keeps `Region <id>`; empty list → `''` | 143–145 | format.test.ts:181–202 | Covered |
+| `pluralize` four shapes: count 1; already-plural `/s$/i`; consonant-y → -ies; default +s (Phase 2 Task 2.1 / B4) | 152–156 | format.test.ts:230–253 (Commodities, Accessories, SKINs, Decoys, singular) | Covered |
+| `formatComposition` two named + other bucket; row counts not quantities; unnamed → other; volume present; volume null omitted; sub-1 m³ | 171–184 | format.test.ts:215–320 | Covered |
+| `formatComposition` **`total_volume === 0`** → appends `'0 m³'` (`!= null` passes 0; formatVolume(0) → '0') | 182 | none — the zero-volume composition branch has no assertion, and the docstring at :180–181 makes a claim about it ("a measured zero is a real reading") that nothing pins | **GAP (CORR)** |
+| `formatComposition` **empty categories list** → `''` (or volume-only string) | 172–183 | none — guarded upstream by `total_item_rows > 1` (columns.tsx:69) but the function's own contract is unpinned | **GAP (NTH)** |
+| `formatBlueprintTerms` all three / runs-null+ME 0 / all null → '' / singular run | 194–200 | format.test.ts:360–382 | Covered |
+| `locationLabel` name / id fallback / both null | 207–212 | format.test.ts:385–392 | Covered |
+
+---
+
+## 3. `columns.tsx` (368 lines) vs `columns.test.ts` (+ pages.test.tsx pins)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| `columnsFor('courier')` → courier set (route/reward/collateral/volume/rate/deadline/expires) | 350 | pages.test.tsx:1086–1115 asserts the header list; :1174–1179 again | Covered (component) |
+| `columnsFor('auction')` → starting bid + buyout split | 351 | pages.test.tsx:1035–1056 | Covered (component) |
+| `columnsFor(undefined)` and `'item_exchange'` → default set | 351 | pages.test.tsx:930 | Covered (component) |
+| `columnsFor('loan'/'unknown')` → default set | 351 | columns.test.ts:34–44 pins keys equal closed set; pages.test.tsx:961 (loan by URL), :1995 (no blueprint columns) | Covered |
+| Blueprint columns inserted before Location, only when ready AND item-bearing | 352–353, 324–327 | columns.test.ts:29–44 (all 6 segments × both readiness states); pages.test.tsx:1967, 1978, 1995 | Covered |
+| Pinned invariant: gated columns add no `sortField` | 17–27 (test) | columns.test.ts:17–27 | Covered |
+| Pinned invariant: blueprint columns never breakpoint-hidden | 46–52 (test) | columns.test.ts:46–52 | Covered |
+| Pinned invariant: unique keys per set × readiness | 54–63 (test) | columns.test.ts:54–63 | Covered |
+| `sortableFieldsFor` **per-segment membership** | 363–367 | Only *consistency* with the closed set is asserted (columns.test.ts:17–27 — both sides derive from `columnsFor`, so deleting `sortField: 'days_to_complete'` from the Deadline column passes it). Membership is partially pinned from the outside: filters.test.ts:182–194 (courier has days_to_complete/reward_per_volume/date_expired, lacks ship_name and date_issued; auction has buyout; default lacks buyout) and pages.test.tsx:707–798, 1071, 1185–1201. Unpinned: default/loan/unknown full membership, courier's full set as a set | **GAP (NTH)** — a direct membership snapshot per segment would make the reconcile oracle mutation-proof |
+| `rowContext` computes expiry once + carries readiness | 55–57 | pages.test.tsx:136 (per-row countdowns across buckets) | Covered (component) |
+| `labelCell`: composition shown when ready; `+N more` fallback when not; nothing for single-row | 64–94 | pages.test.tsx:196–218 (`+2 more`), 2007–2030 (breakdown when ready, `+3 more` absent), 2032–2050 (fallback while unnamed) | Covered (component) |
+| `EXPIRES_COLUMN` cellClass: `text-warn` when the row's countdown reads Expired | 141–143 | none — the class fork has no assertion (list fixtures are clock-anchored live per TEST-17; the detail-page expired badge test :383 is a different code path) | **GAP (NTH)** |
+| Buyout cell: null → 'No buyout' + de-emphasized class; value → ISK | 243–245 | pages.test.tsx:1058–1069 (text pinned; class not) | Covered (text) |
+| `blueprintColumn`: no summary → blank | 186 | pages.test.tsx:1956 | Covered (component) |
+| `blueprintColumn`: single copy → runs/ME/TE values | 199–200 | pages.test.tsx:1930 | Covered (component) |
+| `blueprintColumn`: multi-copy → 'N BPCs' link in Runs, ME/TE blank | 187–197 | pages.test.tsx:1942–1953 (`['3 BPCs', '', '']`) | Covered (component) |
+| `blueprintColumn`: single copy with a **null figure** → that cell blank (`value == null`) | 199–200 | none at the list level (format.test.ts:366–375 pins the detail formatter, not this cell) | **GAP (NTH)** |
+
+---
+
+## 4. `regions.ts` vs `regions.test.ts`
+
+| Path | Coverage | Verdict |
+|---|---|---|
+| The Forge pinned to 10000002 | regions.test.ts:5–7 | Covered |
+| Sorted by name; k-space only (id < 11000000) | regions.test.ts:9–13 | Covered |
+| **Id uniqueness** (a duplicated id would silently shadow a map entry in format.ts:28) | none | **GAP (NTH)** |
+
+Generated file; deep content assertions are deliberately out of scope (regeneration script owns it).
+
+---
+
+## 5. Hooks — `useContracts.ts`, `useTaxonomy.ts`, `useContract.ts` vs `hooks.test.tsx` (+ pages.test.tsx)
+
+### The debounce + freeze machinery (added this week)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| Debounced search: one request per typed word, not per keystroke | useContracts.ts:49–65 | pages.test.tsx:2137–2154 | Covered (component) |
+| Whole-query freeze while unsettled: keystroke's page-1 reset does not fire under the OLD text | 62–64 | pages.test.tsx:2156–2182 (exactly one settled request, `search=raven&page=1`) | Covered (component) |
+| Cold-load initialization: deep-linked search rides request one, no debounce delay | useDebouncedValue.ts:6; useContracts.ts:49 | pages.test.tsx:2184–2193 | Covered (component) |
+| Settled → unsettled → settled transition updates `lastSettled` (adjust-state-during-render) | 62–64 | exercised implicitly by both debounce tests; no assertion observes `lastSettled` staleness directly | Covered (composed) |
+| **Non-keystroke control click mid-word folds into the settled request** (the comment's "a sort click mid-word … instead of doubling it", :57–61) | 62–64 | none — both freeze tests change params only via the keystroke's own navigation; an independent sort/segment/Clear click during the 300 ms window has no test | **GAP (CORR)** |
+| `sameSearch` scalar branch (Object.is equality/inequality) | 23–35 | never tested directly (module-private, not exported); only survives as "the page doesn't infinite-loop" | **GAP (CORR)** |
+| `sameSearch` **array branches**: length mismatch, elementwise mismatch, equal arrays | 28–29 | none — no test varies `region_ids`/`contract_type`/`category_id`/`group_id` mid-debounce; a regression to reference equality (the exact bug the value-comparison comment :53–56 warns about, → render loop) is caught by nothing dedicated | **GAP (CORR)** |
+| `sameSearch` **NaN branch** (`Object.is(NaN, NaN)` → true, unlike `===`) | 29, 31 | none — defensive today (the parser strips NaN) but the function's stated contract; one `Object.is` → `===` regression flips it to a permanent not-same → `setLastSettled` on every render | **GAP (CORR)** |
+| `sameSearch` array-vs-scalar / array-vs-undefined mixed types → not same | 28–31 | none | folded into the array-branches row above |
+| `toApiQuery`/`activeSegment`/predicates computed from **effectiveSearch** (not live search) | 65–71 | pages.test.tsx:2156–2182 pins `toApiQuery` reading the frozen search; the derived predicate values under freeze are untested but share the single `effectiveSearch` binding | Covered (composed) |
+| `useDebouncedValue` as a unit: trailing edge fires after delayMs; **timer reset on rapid change**; cleanup on unmount (no set-state-after-unmount); delayMs change | useDebouncedValue.ts:5–12 | **no test file exists for this new module** — coalescing is pinned once at integration level (pages.test.tsx:2137), reset/cleanup/delay-change never | **GAP (CORR)** (reset behavior) + **GAP (NTH)** (unmount cleanup, delayMs change) |
+
+### Readiness / capture machinery
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| Fetch page + expose data; taxonomy request precedes list (enabled-gate ordering) | 94–121 | hooks.test.tsx:68–80 | Covered |
+| Sub-3-char search never on the wire (hook level) | 65 | hooks.test.tsx:82–93 | Covered |
+| Server error → isError | 96–98 | hooks.test.tsx:95–101 | Covered |
+| Cold load costs ONE list request (readiness in key + enabled gate) | 95, 119 | hooks.test.tsx:165–185 | Covered |
+| Readiness flip → new list query, refetch | 95 | hooks.test.tsx:180–184 | Covered |
+| In-flight readiness change never lands under the stale value | 95–115 | hooks.test.tsx:187–211 | Covered |
+| `itemSurfaceReady` captured at fetch time | 114 | hooks.test.tsx:178, 183, 210; pages.test.tsx:1696 (no blueprint columns over pre-enrichment rows) | Covered |
+| `enrichmentFiltered` capture travels with rows (WEB-1) | 67, 112 | pages.test.tsx:1489–1523 ("keeps warning about the rows on screen while an unfiltered page loads over them") | Covered (component) |
+| `itemFilteredItemLessSegment` capture | 70–71, 113 | pages.test.tsx:1791–1854 suite incl. the is_bpc=false negative | Covered (component) |
+| `segment` capture | 66, 110 | pages.test.tsx:1133 (rows described with their own columns while next segment loads) | Covered (component) |
+| `regionIds` capture (`?? []`) | 111 | pages.test.tsx:1354 (result described while next region loads); the `?? []` default via :1293–1335 empty-coverage suites | Covered (component) |
+| `countsSearch` capture (Phase 3 / B1 numerals) | 109 | pages.test.tsx:799–905 (numerals held until the segment's own response lands, dropped when leaving item-less) | Covered (component) |
+| `keepPreviousData` placeholder behavior | 120 | pages.test.tsx:1133, 1354, 1489 | Covered (component) |
+| `enabled: readinessKnown` — error counts as an answer, list unblocks | 93, 119 | hooks.test.tsx:214–258; pages.test.tsx:1458, 1758 | Covered |
+
+### `useTaxonomy` (33–81)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| 5s abort on an unanswered probe; bound holds under production retry:1 client | 39–48 | hooks.test.tsx:214–258 (fake timers; also pins `retry: false` — a retry would break the 6 s bound) | Covered |
+| Error → ApiError on undefined data | 44 | hooks.test.tsx via the timeout path; pages.test.tsx:1458 (unreachable endpoint degrades to still-indexing, no retry control) | Covered |
+| **`refetchInterval: READINESS_POLL_MS` actually re-polls** — the mechanism behind D1's "degrades on its own" (docstring :7–17 says `staleTime` alone would NOT do it) | 54 | none — both readiness-flip tests drive `queryClient.refetchQueries` by hand, bypassing the interval. Deleting `refetchInterval` fails zero tests; the exact bug the docstring documents (a focused tab reporting `complete` for ~80 minutes across a resweep) comes back silently | **GAP (CORR)** |
+| `staleTime: READINESS_POLL_MS` | 53 | none (subsumed by the row above — the pair is the mechanism) | **GAP (NTH)** |
+| `useItemSurfaceReady`: complete → true; partial/error/loading → false | 79–81 | pages.test.tsx:1440–1458 (rail closed while enriching, open when complete, closed on unreachable endpoint) | Covered (component) |
+
+### `useContract` (4–18)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| Fetch by id, success | 10–16 | hooks.test.tsx:105–113 | Covered |
+| 404 → no retry (exactly one call) | 8–9 | hooks.test.tsx:115–122 | Covered |
+| **Non-404 error retried exactly once** (`failureCount < 1`) | 8–9 | none — no test issues a 500 and counts two calls; TEST-7 makes this policy load-bearing for every error-state test built on it | **GAP (CORR)** |
+| `enabled` gate: non-integer / non-positive id issues no request | 7 | pages.test.tsx:414–429 ("not-found for a non-numeric id without issuing a request") | Covered (component) |
+
+---
+
+## 6. `src/lib/api/client.ts` vs `client.test.ts` (+ hook suites)
+
+| Path | Lines | Coverage | Verdict |
+|---|---|---|---|
+| Repeated array param serialization | 68–71 | client.test.ts:21–30; pages.test.tsx:257 (end-to-end) | Covered |
+| Trailing-slash path under /api/v1 (PROXY-1) | 57–63 | client.test.ts:32–39 | Covered |
+| Undefined params omitted from URL | — | client.test.ts:41–50 | Covered |
+| `ApiError` status/message/detail/absent-detail | 19–32 | client.test.ts:53–71 | Covered |
+| `extractDetail` string / 422-array / missing / non-object | 37–43 | client.test.ts:73–84 | Covered |
+| `raiseApiError` throws with status + detail | 50–55 | client.test.ts:86–98 | Covered |
+| `raiseApiError` 401 → invalidates `['auth','me']` | 51–53 | useWatchlist.test.tsx:58, 91; parallel assertions in useSavedSearches/useNotifications/useLogout suites | Covered |
+| `raiseApiError` **non-401 leaves `['auth','me']` alone** (the negative) | 51–53 | client.test.ts:86–98 throws a 400 but never asserts the cache was untouched | **GAP (NTH)** |
+| `baseUrl` `location` fallback for non-DOM environments | 69 | untested; trivial ternary exercised implicitly by every jsdom test | Not counted |
+
+---
+
+## Gap register
+
+### Security-critical (0)
+
+None. See summary rationale.
+
+### Correctness (28)
+
+| # | Gap | Where |
+|---|---|---|
+| 1–7 | `DEFAULT_DIRECTION` fallback unasserted for `price`, `collateral`, `ship_name`, `volume`, `reward_per_volume`, `days_to_complete`, `buyout` (7 rows; Phase 1 Task 1.2 was added precisely because this was wrong) | filters.ts:188–200, 289 |
+| 8 | `search: ''` → undefined branch untested | filters.ts:268 |
+| 9 | `search` non-string junk → undefined untested | filters.ts:268 |
+| 10 | `is_bpc` non-boolean junk → undefined untested (only parser field with zero junk coverage) | filters.ts:281 |
+| 11 | `page` bounds: 0 / negative / non-integer → DEFAULT_PAGE; min boundary 1 kept | filters.ts:284, 215–218 |
+| 12 | `size` bounds: exactly MAX_SIZE=100 kept, 101 → fallback, 0 → fallback, 1 kept | filters.ts:285 |
+| 13 | `region_ids: []` → undefined untested | filters.ts:220–226, 271 |
+| 14 | `category_id: []` → undefined untested | filters.ts:273 |
+| 15 | `group_id: []` → undefined untested | filters.ts:274 |
+| 16 | `contract_type: []` → undefined untested | filters.ts:228–237 |
+| 17 | `activeSegment` no-selection → undefined branch unpinned | filters.ts:105–107 |
+| 18 | `activeSegment` multi-selection → undefined branch unpinned | filters.ts:105–107 |
+| 19 | `reconcileSort` with a multi-type selection (segment undefined, widened sort must reconcile away) untested | filters.ts:308 |
+| 20 | `toApiQuery` sends the **trimmed** ≥3-char search value — regression to raw passes today's suite | filters.ts:321–322 |
+| 21 | `formatComposition` with `total_volume === 0` → `'0 m³'` branch unpinned despite its docstring claim | format.ts:182 |
+| 22 | `sameSearch` scalar Object.is branch — zero direct tests (module-private) | useContracts.ts:23–35 |
+| 23 | `sameSearch` array branches (length / element mismatch / equality; array-vs-scalar) — no test varies a list param mid-debounce; reference-equality regression → render loop caught by nothing | useContracts.ts:28–31 |
+| 24 | `sameSearch` NaN branch (`Object.is` semantics) unpinned | useContracts.ts:29, 31 |
+| 25 | `useDebouncedValue` has **no test file**: timer-reset-on-change (continuous typing extends the window) has no dedicated assertion at any level | src/lib/useDebouncedValue.ts:7–10 |
+| 26 | Independent control click (sort/segment/Clear) during the debounce window folding into the settled request — a documented behavior (useContracts.ts:57–61) with no test | useContracts.ts:62–64 |
+| 27 | `useTaxonomy` `refetchInterval` re-poll — the D1 "degrades on its own" mechanism — untested; deleting it fails nothing | useTaxonomy.ts:54 |
+| 28 | `useContract` non-404 error retried exactly once (`failureCount < 1`) untested | useContract.ts:8–9 |
+
+### Nice-to-have (13)
+
+| # | Gap | Where |
+|---|---|---|
+| 1 | `hasOfferedItemFilters` appears unused and untested (dead export or missing consumer test) | filters.ts:139–143 |
+| 2 | `isItemLessSelection([])` vacuous-true contract undocumented by any test | filters.ts:167 |
+| 3 | Price fields' non-numeric junk (`'abc'`, `''`, Infinity) only tested via the blueprint-bounds path | filters.ts:170–174, 269–270 |
+| 4 | `toApiQuery` `is_bpc` pass-through unasserted | filters.ts:335 |
+| 5 | `formatIsk(undefined)` → '—' | format.ts:31 |
+| 6 | `formatIsk(0)` → `'0'` (courier price) | format.ts:31 |
+| 7 | `formatVolume` boundaries: exactly 0.005; just-below-100 | format.ts:55–56 |
+| 8 | `formatComposition` empty-categories contract | format.ts:172–183 |
+| 9 | `sortableFieldsFor` per-segment membership snapshot (current test is self-referential vs `columnsFor`) | columns.tsx:363–367 |
+| 10 | Blueprint cell: single copy with one null figure → blank cell at list level | columns.tsx:199–200 |
+| 11 | `EXPIRES_COLUMN` `text-warn` class fork on an expired row | columns.tsx:141–143 |
+| 12 | `regions.ts` id-uniqueness invariant | regions.ts:3–74; format.ts:28 |
+| 13 | `raiseApiError` non-401 leaves `['auth','me']` untouched; `useDebouncedValue` unmount cleanup / delayMs change (grouped) | client.ts:51–53; useDebouncedValue.ts:9 |
+
+---
+
+## Observations for the fixer
+
+- The strongest cluster is exactly the code the remediation plan just touched: Phase 1's B5
+  fix (per-field default direction) shipped with 2/9 fields pinned, and the week's debounce/
+  freeze machinery has three good integration tests but zero unit coverage of its two pure
+  functions (`sameSearch`, `useDebouncedValue`) — `sameSearch` isn't even exported, so its
+  edge branches are untestable without either exporting it or driving them through the hook
+  with list-param changes mid-debounce.
+- Per TEST-12, several of the "Covered" verdicts above rest on component tests; where a fix
+  lands for a gap, mutation-verify against the *new* test, not the neighboring page test.
+- Per TEST-2, none of the timing-adjacent gaps (debounce reset, refetchInterval) should be
+  closed with sleeps — fake timers (`vi.useFakeTimers`, as the taxonomy timeout test already
+  does) keep them deterministic.


### PR DESCRIPTION
## Summary

Coverage-review Wave 1 — the test-only three of the four security-critical gaps (report: `docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md`, committed here with the four per-file registers):

- `size<=100` and `search` min-length now have wire-level 422 tests (their removal was test-invisible on an anonymous endpoint).
- The generic 500 handler's fixed body is pinned at the HTTP surface against an exception carrying statement internals — the SQLA-4 scrub was previously pinned at log layers only. (Implementation note: Starlette's `Exception` handler builds the response then re-raises, so the test uses its own non-raising ASGI transport.)
- The secret-hygiene assertion asserted `DATABASE_URL[:16]` — the dialect prefix every URL shares — and now asserts the planted credentials and host individually. **Mutation-verified**: a planted URL log turns it red.

The fourth security-critical item (`search` has no max_length — unbounded text into a double-wildcard ILIKE) is a **code change** and follows as its own PR under `Review — public API contract`.

## Test evidence

Backend 691 passed (688 + 3 new), lint clean.

## Merge classification

Routine

Test-only + report docs. Sam directed "fix all gaps" for this campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)