### PR TITLE
fix(api): bound the search text at 100 characters

### DIFF
--- a/app/backend/src/fastapi_app/schemas/contracts.py
+++ b/app/backend/src/fastapi_app/schemas/contracts.py
@@ -332,6 +332,10 @@ class ContractFilters(BaseModel):
     search: Optional[str] = Field(
         default=None,
         min_length=3,
+        # Bounded: the box carries ship and contract names, and without a
+        # ceiling arbitrary-length text binds into a double-wildcard ILIKE
+        # over two columns on an anonymous endpoint.
+        max_length=100,
         description="Case-insensitive search across contract title and ship name.",
     )
     # Numeric ranges

--- a/app/backend/src/fastapi_app/tests/api/test_contracts.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contracts.py
@@ -238,3 +238,14 @@ async def test_a_read_path_failure_serves_the_fixed_body_with_no_internals(
     assert response.status_code == 500
     assert response.json() == {"detail": "An unexpected server error occurred."}
     assert "SECRET-BIND-TEXT" not in response.text
+
+
+async def test_a_search_above_max_length_is_rejected_at_the_wire(client: AsyncClient):
+    """The search box carries ship and contract names — nothing legitimate needs
+    more than 100 characters, and without a ceiling arbitrary-length text binds
+    into a double-wildcard ILIKE over two columns on an anonymous endpoint."""
+    over = await client.get("/contracts/", params={"search": "x" * 101})
+    assert over.status_code == 422
+
+    at_cap = await client.get("/contracts/", params={"search": "x" * 100})
+    assert at_cap.status_code == 200

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -1789,6 +1789,7 @@
             "schema": {
               "anyOf": [
                 {
+                  "maxLength": 100,
                   "minLength": 3,
                   "type": "string"
                 },


### PR DESCRIPTION
## Summary

The fourth security-critical coverage gap (report §Security-critical item 2, the code half): `search` had `min_length=3` but no ceiling — unbounded user text into a double-wildcard `ILIKE` over two columns on an anonymous endpoint. Now `max_length=100`; nothing legitimate in that box (ship/contract names) approaches it. Wire 422 pinned at 101, 200 pinned at 100; `openapi.json` regenerated (one line; `schema.d.ts` byte-identical).

**Contract note:** callers sending >100-char searches previously got results (or empties); they now get 422. The frontend is unaffected (its own input feeds through the same parser and no UI path produces 100+ chars).

## Test evidence

TDD RED→GREEN at the boundary; full backend suite 692 passed, lint clean.

## Merge classification

Review — public API contract

Held for Sam — it narrows accepted input on a public endpoint. Codex round skipped: single Field constraint with boundary tests; Sam's review is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)