### PR TITLE
test(api): cover the backend read-path correctness register, bounding the detail id

### DIFF
--- a/app/backend/src/fastapi_app/api/contracts.py
+++ b/app/backend/src/fastapi_app/api/contracts.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -59,7 +59,10 @@ async def list_contract_taxonomy(
 
 @router.get("/{contract_id}", response_model=ContractDetailSchema)
 async def get_contract(
-    contract_id: int,
+    # Bounded to the ids that can exist: ESI contract ids are positive int64,
+    # and an unbounded int previously rode past validation into the driver,
+    # which surfaced an out-of-range id as a 500 instead of a 422.
+    contract_id: Annotated[int, Path(ge=1, le=2**63 - 1)],
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
@@ -2522,3 +2522,134 @@ async def test_price_sorts_both_ways_and_leaves_unpriced_contracts_last(
     assert ascending == [973001, 973002, 973003, 973004]
     assert descending == [973003, 973002, 973001, 973004]
     assert ascending[0] != descending[0]
+
+
+# --- The pre-F008 sorts and bounds nobody ever pinned (region 99999974) ---
+#
+# date_expired, collateral, and date_issued-ascending are non-null columns that
+# predate F008's both-directions-exact-order discipline; a silently no-op'd sort
+# there is the same defect class §6.2 names for the new sorts. The three orders
+# are mutually distinct permutations, so no sort can pass by echoing another.
+
+LEGACY_SORT_REGION = 99999974
+
+
+@pytest_asyncio.fixture
+async def legacy_sort_contracts(db_session: AsyncSession):
+    now = datetime.now(timezone.utc)
+
+    def _contract(cid: int, **overrides) -> Contract:
+        fields = dict(
+            contract_id=cid, title=f"Legacysort {cid}", price=1_000_000,
+            collateral=0, status="outstanding", type="item_exchange", issuer_id=974,
+            issuer_corporation_id=974, start_location_id=60003760,
+            start_location_region_id=LEGACY_SORT_REGION, for_corporation=False,
+            date_issued=now, date_expired=now + timedelta(days=7), last_seen_at=now,
+        )
+        fields.update(overrides)
+        return Contract(**fields)
+
+    db_session.add_all([
+        _contract(974001, date_issued=datetime(2026, 7, 1, tzinfo=timezone.utc),
+                  date_expired=now + timedelta(days=3), collateral=900.0),
+        _contract(974002, date_issued=datetime(2026, 7, 2, tzinfo=timezone.utc),
+                  date_expired=now + timedelta(days=9), collateral=100.0),
+        _contract(974003, date_issued=datetime(2026, 7, 3, tzinfo=timezone.utc),
+                  date_expired=now + timedelta(days=6), collateral=5_000.0),
+    ])
+    await db_session.flush()
+
+
+async def test_date_expired_sorts_both_ways(client: AsyncClient, legacy_sort_contracts):
+    """The Time-left column — the courier segment's default sort field."""
+    ascending = await _sorted_ids(client, "date_expired", "asc", region=LEGACY_SORT_REGION)
+    descending = await _sorted_ids(client, "date_expired", "desc", region=LEGACY_SORT_REGION)
+
+    assert ascending == [974001, 974003, 974002]
+    assert descending == [974002, 974003, 974001]
+
+
+async def test_collateral_sorts_both_ways(client: AsyncClient, legacy_sort_contracts):
+    ascending = await _sorted_ids(client, "collateral", "asc", region=LEGACY_SORT_REGION)
+    descending = await _sorted_ids(client, "collateral", "desc", region=LEGACY_SORT_REGION)
+
+    assert ascending == [974002, 974001, 974003]
+    assert descending == [974003, 974001, 974002]
+
+
+async def test_date_issued_sorts_ascending_too(client: AsyncClient, legacy_sort_contracts):
+    """Descending is pinned as the default everywhere; the explicit ascending
+    direction had no assertion anywhere."""
+    ascending = await _sorted_ids(client, "date_issued", "asc", region=LEGACY_SORT_REGION)
+    assert ascending == [974001, 974002, 974003]
+
+
+async def test_min_collateral_filters_alone(client: AsyncClient, legacy_sort_contracts):
+    """min_collateral had zero assertions anywhere — only max_collateral, and
+    only in combination."""
+    response = await client.get(
+        f"/contracts/?region_ids={LEGACY_SORT_REGION}&min_collateral=850"
+    )
+    assert response.status_code == 200
+    assert {row["contract_id"] for row in response.json()["items"]} == {974001, 974003}
+
+
+async def test_an_expired_item_bearing_contract_leaves_the_readiness_denominator(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Ingestion never revisits an expired contract, so counting one would hold
+    the ratio below the threshold forever on an up-to-date corpus. Vacuity
+    guard first: the same row degrades the signal while it is live."""
+    now = datetime.now(timezone.utc)
+    stale = _enriched_contract(974102, processing_status="PENDING_ITEMS", version=0)
+    db_session.add_all([_enriched_contract(974101), stale])
+    await db_session.flush()
+
+    assert (await _taxonomy(client))["coverage"] == "partial"
+
+    stale.date_expired = now - timedelta(hours=1)
+    await db_session.flush()
+
+    assert (await _taxonomy(client))["coverage"] == "complete"
+
+
+# --- Watermark fallback for a region outside the configured hint (region 99999976) ---
+
+async def test_a_region_outside_the_configured_hint_still_drops_stale_rows(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """AGGREGATION_REGION_IDS is an optimization hint, never a semantic input:
+    a region the config does not name must get the same delisted-row exclusion
+    through the correlated fallback (the case else_ branch) that configured
+    regions get through the hoisted watermark. Verified manually in the
+    2026-08-02 perf audit; pinned here."""
+    from fastapi_app.services import contract_service as cs
+
+    patched = cs.get_settings().model_copy(
+        update={"AGGREGATION_REGION_IDS": [10000002]}
+    )
+    monkeypatch.setattr(cs, "get_settings", lambda: patched)
+
+    now = datetime.now(timezone.utc)
+
+    def _contract(cid: int, seen: datetime) -> Contract:
+        return Contract(
+            contract_id=cid, title=f"Driftwatch {cid}", price=1_000_000,
+            collateral=0, status="outstanding", type="item_exchange", issuer_id=976,
+            issuer_corporation_id=976, start_location_id=60003760,
+            start_location_region_id=99999976, for_corporation=False,
+            date_issued=now - timedelta(days=1), date_expired=now + timedelta(days=7),
+            last_seen_at=seen,
+        )
+
+    db_session.add_all([
+        _contract(976001, seen=now),
+        # Two hours behind its region's newest sighting: delisted, and only the
+        # fallback branch can know it — 99999976 is not in the patched config.
+        _contract(976002, seen=now - timedelta(hours=2)),
+    ])
+    await db_session.flush()
+
+    response = await client.get("/contracts/?region_ids=99999976")
+    assert response.status_code == 200
+    assert {row["contract_id"] for row in response.json()["items"]} == {976001}

--- a/app/backend/src/fastapi_app/tests/api/test_contracts.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contracts.py
@@ -249,3 +249,100 @@ async def test_a_search_above_max_length_is_rejected_at_the_wire(client: AsyncCl
 
     at_cap = await client.get("/contracts/", params={"search": "x" * 100})
     assert at_cap.status_code == 200
+
+
+# --- The detail path's own guardrails (coverage register C-1..C-3) ---
+
+async def test_detail_serves_404_for_an_absent_contract(client: AsyncClient, db_session: AsyncSession):
+    """The 404 branch had zero tests anywhere in the suite."""
+    response = await client.get("/contracts/424242")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Contract not found"}
+
+
+async def test_detail_rejects_a_non_integer_id_at_the_wire(client: AsyncClient):
+    response = await client.get("/contracts/not-a-number")
+    assert response.status_code == 422
+
+
+async def test_detail_rejects_ids_outside_the_representable_range(client: AsyncClient):
+    """An id above int64 previously rode past validation into the driver and
+    surfaced as a 500; ids that cannot exist are a validation failure, not a
+    server error. Zero and negatives fall under the same floor."""
+    over = await client.get("/contracts/99999999999999999999")
+    assert over.status_code == 422
+
+    zero = await client.get("/contracts/0")
+    assert zero.status_code == 422
+
+
+# --- Endpoint 422 sweep over the list params (coverage register C-11..C-13) ---
+
+async def test_page_zero_and_negatives_are_rejected(client: AsyncClient):
+    """page ge=1 stands between a caller and a negative OFFSET 500."""
+    for value in ("0", "-1"):
+        response = await client.get(f"/contracts/?page={value}")
+        assert response.status_code == 422, f"page={value}"
+
+
+async def test_below_floor_numeric_bounds_are_rejected_per_family(client: AsyncClient):
+    """Every numeric family's floor, one row each — testing one does not cover
+    its siblings. runs floors at -1 (the ESI sentinel the wire tolerates), the
+    rest at 0."""
+    cases = {
+        "min_price": "-1", "max_price": "-1",
+        "min_collateral": "-1", "max_collateral": "-1",
+        "min_runs": "-2", "max_runs": "-2",
+        "min_me": "-1", "max_me": "-1",
+        "min_te": "-1", "max_te": "-1",
+    }
+    for param, value in cases.items():
+        response = await client.get(f"/contracts/?{param}={value}")
+        assert response.status_code == 422, f"{param}={value}"
+
+
+async def test_malformed_value_types_are_rejected_per_param(client: AsyncClient):
+    """Type junk per param family: id-list members, booleans, and both sort
+    enums each parse through different validators."""
+    cases = [
+        "region_ids=abc",
+        "category_id=1.5",
+        "is_bpc=maybe",
+        "sort_by=bogus_field",
+        "sort_direction=sideways",
+    ]
+    for query in cases:
+        response = await client.get(f"/contracts/?{query}")
+        assert response.status_code == 422, query
+
+
+async def test_primary_label_prefers_the_offered_ship_over_an_earlier_named_item(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The hull is the headline on a ship marketplace: a fitted-hull contract
+    whose module row precedes the ship row must still headline the ship. With
+    the module first by record_id, named[0] alone produces the wrong answer —
+    only the ship-priority branch produces this label."""
+    db_session.add_all([
+        Contract(
+            contract_id=31, title="Fitted hull", price=100, collateral=0.0,
+            is_ship_contract=True, type="item_exchange", status="outstanding",
+            issuer_id=1, issuer_corporation_id=1, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+        ),
+        ContractItem(
+            record_id=310001, contract_id=31, type_id=12058,
+            type_name="1MN Afterburner I", quantity=1, is_included=True,
+            is_singleton=False, category="module",
+        ),
+        ContractItem(
+            record_id=310002, contract_id=31, type_id=587, type_name="Rifter",
+            quantity=1, is_included=True, is_singleton=False, category="ship",
+        ),
+    ])
+    await db_session.flush()
+
+    response = await client.get("/contracts/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["primary_label"] == "Rifter"

--- a/app/frontend/web/openapi.json
+++ b/app/frontend/web/openapi.json
@@ -2284,6 +2284,8 @@
             "name": "contract_id",
             "required": true,
             "schema": {
+              "maximum": 9223372036854775807,
+              "minimum": 1,
               "title": "Contract Id",
               "type": "integer"
             }


### PR DESCRIPTION
## Summary

Coverage campaign Wave 2 — all 13 backend read-path correctness gaps (register: `docs/test-coverage-reports/subagent-backend-read-findings.md` §3, C-1..C-13):

- **Detail endpoint**: 404 pinned (had zero tests anywhere), non-integer 422 pinned, and the id is now `Annotated[int, Path(ge=1, le=2**63-1)]` — an int64-overflow id previously surfaced as a driver 500. Mutation-verified: without the bound the test goes red.
- **Endpoint 422 sweep**: page floors, all ten numeric-family floors individually (`runs` floors at −1, the ESI sentinel), and per-param type junk (id-list member, boolean, both sort enums).
- **Legacy sorts**: `date_expired` and `collateral` both directions, `date_issued` ascending — exact orders over mutually distinct permutations (region 99999974); a SORT_MAP mutation was watched red. `min_collateral` gets its first assertion anywhere.
- **Service internals**: readiness denominator's expiry criterion (with vacuity guard), watermark correlated fallback for unconfigured regions (region 99999976, patched config), and the primary-label ship-priority discriminator (mutation-verified — `named[0]` alone now fails a test).

## Contract note

Garbage detail ids (≤0 or >int64) move from 404/500 to **422**. No legitimate caller sends them; the frontend already treats them as not-found client-side. `openapi.json` regenerated (`schema.d.ts` byte-identical).

## Test evidence

Backend **704 passed** (692 + 12 new/expanded), lint clean. Three mutation kills watched red→green.

## Merge classification

Review — public API contract

Held for Sam — same family as #164 (input-validation narrowing on public endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)