### PR TITLE
test(api): Wave 5 sweep + backend-read nice-to-haves 10/10

### DIFF
--- a/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
@@ -2895,18 +2895,26 @@ async def test_min_runs_admits_the_esi_sentinel_and_rejects_one_below_it(
 # placement holds for the same reason — but "for the same reason" is an argument, not a
 # test, and only two of the six nullable sorts had ever run it on the joined side.
 #
-# Split into two corpora because NO SINGLE CONTRACT TYPE can carry all six columns, and
-# a fixture giving one type all of them would be a state ingestion cannot produce
-# (TEST-18). ESI sends `buyout` only on auctions and `reward`/`days_to_complete` only on
-# couriers, and `_build_contract_rows` maps each straight through, so the writer can
-# never populate both families on one row.
-#
-# The two corpora also reach the joined path by different levers, because the types
-# differ in whether they carry items at all:
+# Split into two corpora, one contract TYPE and one join LEVER each, because the types
+# differ in whether they carry items at all and therefore in how they reach the joined
+# path:
 #   - auctions are item-bearing, so `type_ids` forces the join;
 #   - couriers are item-less, so only `search` can — the item join is an OUTER join and
 #     the search predicate ORs `Contract.title` against the item name, which is what
 #     lets a contract with no items reach the joined path at all.
+#
+# NOT split because one type cannot carry both column families. ESI's schema DESCRIBES
+# `buyout` as auction-only and `reward`/`days_to_complete` as courier-only, but those
+# descriptions state intent, not payload presence: sampling the live public route for
+# The Forge (2026-08-09) found 42/42 auctions carrying `reward` and `days_to_complete`
+# as ZERO placeholders, 16/16 couriers carrying `price=0`, and item exchanges carrying
+# nonzero `reward`. `_build_contract_rows` maps all three through with no type check, so
+# a mixed-family row is a state the writer really can produce.
+#
+# That sampling matters for what these fixtures represent. Zero is not NULL and does not
+# sort like it, so the NULL rows below are the SPARSE case rather than the ordinary one —
+# they pin where a genuinely absent value lands, which is rarer in the live corpus than
+# the schema's "for Couriers only" wording suggests.
 
 NULLS_JOINED_REGION = 99999978
 NULLS_JOINED_TYPE_ID = 34567
@@ -3068,10 +3076,15 @@ async def test_the_joined_path_puts_nulls_last_for_the_courier_only_sorts(
     that puts an item-less contract on the joined path, and it works because the item
     join is an OUTER join and the predicate ORs the contract title against the item name.
 
-    That makes these two cases sensitive to the still-open offered-only search decision:
-    if `_needs_item_join` stops treating `search` as needing the join, they keep passing
-    but silently relocate to the simple path. Stated rather than hidden — whoever takes
-    that decision should re-point these two at whatever lever replaces it.
+    These two cases are therefore sensitive to the still-open offered-only search
+    decision, but NOT in the way that is easy to assume. Simply dropping `search` from
+    `_needs_item_join` does not relocate them to the simple path quietly — it fails them
+    outright with empty results, because the search predicate still names
+    `ContractItem.type_name` and, without the join, matches nothing for a contract with
+    no items. The change to watch for is the broader one: a search rewritten as a
+    correlated EXISTS needs no join, and under it these two would keep passing while
+    silently testing the simple path instead. Whoever takes that decision should
+    re-point them at whatever lever replaces `search`.
     """
     search = NULLS_COURIER_TITLE_STEM.replace(" ", "+")
     await _assert_nulls_last_both_ways(

--- a/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
@@ -36,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi_app.models import Contract, ContractItem
 from fastapi_app.models.contracts import EsiTaxonomyCache
 from fastapi_app.services.background_aggregation import ENRICHMENT_VERSION
+from fastapi_app.services.contract_service import NULLABLE_SORTS
 
 # Mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
@@ -2202,6 +2203,75 @@ async def test_a_category_seen_only_on_delisted_rows_does_not_hold_the_signal(
     assert (await _taxonomy(client))["coverage"] == "complete"
 
 
+async def test_taxonomy_breaks_a_name_tie_by_id_so_the_order_is_total(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Name alone is not a total order, and ESI does reuse names across ids.
+
+    The sort key carries the id as a second element precisely so two entries sharing
+    a name land in a fixed order rather than in whatever order the cache read them —
+    an order that changes between requests reshuffles the filter rail under the
+    reader's cursor. Both lists are seeded with the HIGHER id first, so a key that
+    dropped its id element would preserve that insertion order under Python's stable
+    sort and fail here rather than pass by coincidence.
+
+    Observed as the ordered id list, not as membership: every permutation satisfies a
+    set assertion, and permutation is the whole regression (TEST-25).
+    """
+    db_session.add_all([
+        _cached_taxonomy("category", 66, "Ship"),
+        _cached_taxonomy("category", 6, "Ship"),
+        _cached_taxonomy("group", 250, "Frigate", 6),
+        _cached_taxonomy("group", 25, "Frigate", 6),
+    ])
+    await db_session.flush()
+
+    body = await _taxonomy(client)
+    assert [entry["category_id"] for entry in body["categories"]] == [6, 66]
+    assert [entry["group_id"] for entry in body["groups"]] == [25, 250]
+
+
+async def test_a_stale_enrichment_settles_coverage_without_the_category_sweep(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """The two coverage conditions are ordered for COST, and only the order is at stake.
+
+    Either condition failing reports "partial", so the answer is identical whichever
+    runs first — which is exactly why a reordering is invisible to every assertion on
+    the RESPONSE. The property is that the more expensive query does not run once the
+    cheap one has already settled the answer, and the only observation point that can
+    see it is whether the sweep was called at all (TEST-25).
+
+    A resweep in progress is the state this exists for: the ratio says "partial" for
+    every request until the sweep finishes, and each of those requests would otherwise
+    pay for a distinct-category scan over the live corpus to learn nothing new.
+    """
+    from fastapi_app.services import contract_service as cs
+
+    calls: list[int] = []
+
+    async def _counting_sweep(db):
+        calls.append(1)
+        return set()
+
+    monkeypatch.setattr(cs, "_live_category_ids", _counting_sweep)
+
+    db_session.add_all([
+        _cached_taxonomy("category", 6, "Ship"),
+        # Mid-resweep: stamped at the previous enrichment version, so the ratio
+        # cannot report the live corpus as currently enriched.
+        _enriched_contract(
+            971901,
+            version=ENRICHMENT_VERSION - 1,
+            items=[_taxonomy_item(9719011, category_id=6, group_id=25)],
+        ),
+    ])
+    await db_session.flush()
+
+    assert (await _taxonomy(client))["coverage"] == "partial"
+    assert calls == [], "the category sweep ran after the ratio had already answered"
+
+
 # --- New sortable fields: buyout, days_to_complete, reward_per_volume (region 99999966) ---
 #
 # Each of the three gets its own acceptance evidence (spec §6.2): a sort that
@@ -2653,3 +2723,276 @@ async def test_a_region_outside_the_configured_hint_still_drops_stale_rows(
     response = await client.get("/contracts/?region_ids=99999976")
     assert response.status_code == 200
     assert {row["contract_id"] for row in response.json()["items"]} == {976001}
+
+
+# --- Out-of-range pages and the detail endpoint's liveness asymmetry (region 99999977) ---
+#
+# A page beyond the last one is not the same request as a search that matches nothing,
+# and the two take different routes through `get_contracts`. The empty-result
+# short-circuit fires on `total == 0` and never runs a page query at all; here `total`
+# is positive, the short-circuit does not fire, and the page query runs and legitimately
+# returns nothing. Both fetch paths reach that state by different mechanics — the simple
+# path OFFSETs past the end, the joined path OFFSETs past the end of its distinct-id
+# query and then loads `WHERE contract_id IN ()` from an empty list — so both are pinned.
+
+OUT_OF_RANGE_REGION = 99999977
+
+
+def _paged_contract(cid: int, *, ship_name: str, seen: datetime) -> Contract:
+    """A live contract carrying one named ship, so the ship_name sort has a join to make.
+
+    `seen` is required rather than defaulted to `now()` inside: the delisting watermark
+    is an exact `last_seen_at >= max(last_seen_at) in region` with no tolerance, so rows
+    meant to be co-listed must carry the IDENTICAL stamp, not merely adjacent ones. That
+    is also what ingestion does — one run writes one `seen_at` across the whole batch —
+    so a helper stamping each row on its own clock builds a state ingestion cannot
+    produce, and quietly delists every row but the last (TEST-18).
+    """
+    now = datetime.now(timezone.utc)
+    return Contract(
+        contract_id=cid, title=f"Paging Case {cid}", price=1_000_000,
+        collateral=0.0, status="outstanding", type="item_exchange",
+        issuer_id=977, issuer_corporation_id=977, for_corporation=False,
+        is_ship_contract=True, start_location_id=60003760,
+        start_location_region_id=OUT_OF_RANGE_REGION,
+        date_issued=now - timedelta(days=1), date_expired=now + timedelta(days=7),
+        last_seen_at=seen,
+        items=[
+            ContractItem(
+                record_id=cid * 10 + 1, type_id=587, type_name=ship_name,
+                quantity=1, is_included=True, is_singleton=False, category="ship",
+            )
+        ],
+    )
+
+
+async def test_a_page_past_the_end_serves_an_empty_page_that_still_counts_the_corpus(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The simple fetch path, OFFSET past the end.
+
+    `total` is what the client paginates against, so an out-of-range page that reported
+    `total: 0` alongside its empty item list would tell the reader the corpus is empty
+    and strand them there — the Previous control is computed from the same number. The
+    envelope must keep echoing the real total and the page that was asked for.
+
+    Distinct from the zero-match short-circuit, which never runs a page query; this
+    request has 2 matching contracts and runs one that returns nothing.
+    """
+    seen = datetime.now(timezone.utc)
+    db_session.add_all([
+        _paged_contract(977001, ship_name="Rifter", seen=seen),
+        _paged_contract(977002, ship_name="Tristan", seen=seen),
+    ])
+    await db_session.flush()
+
+    response = await client.get(
+        f"/contracts/?region_ids={OUT_OF_RANGE_REGION}&page=5&size=2"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 2
+    assert body["page"] == 5
+    assert body["size"] == 2
+
+
+async def test_a_page_past_the_end_of_the_joined_path_loads_from_an_empty_id_list(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The joined fetch path, where the empty page arrives as an empty `IN ()`.
+
+    Sorting by ship_name forces `_needs_item_join`, so pagination runs over distinct
+    contract ids first and the second query loads `WHERE contract_id IN (<page ids>)`.
+    Past the last page that list is empty, and an empty `IN` is the one shape a
+    hand-built id filter can get wrong in a way that returns EVERYTHING rather than
+    nothing — which would serve the whole corpus under a page number past its end.
+
+    ship_name rather than `search` on purpose: it reaches the same join without
+    depending on the search predicate's offered-side semantics, which are still open.
+    """
+    seen = datetime.now(timezone.utc)
+    db_session.add_all([
+        _paged_contract(977101, ship_name="Rifter", seen=seen),
+        _paged_contract(977102, ship_name="Tristan", seen=seen),
+    ])
+    await db_session.flush()
+
+    response = await client.get(
+        f"/contracts/?region_ids={OUT_OF_RANGE_REGION}"
+        "&sort_by=ship_name&sort_direction=asc&page=5&size=2"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 2
+    assert body["page"] == 5
+
+
+async def test_detail_still_serves_a_delisted_but_unexpired_contract(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The sibling of the pinned expired-detail case, through the OTHER liveness arm.
+
+    A contract disappears from the list for two independent reasons — its expiry passed,
+    or ESI stopped listing it while it was still in date (bought, cancelled, completed).
+    The detail endpoint deliberately serves both, and only the expiry arm is pinned. The
+    delisting arm is the one a pasted link hits most often, because a contract is far
+    more likely to be bought than to run out its full term.
+
+    The stale row is asserted absent from the LIST in the same test, so the fixture is
+    proved delisted rather than merely assumed to be (TEST-15): a fixture that failed to
+    trip the watermark would make the detail assertion pass for the wrong reason.
+    """
+    now = datetime.now(timezone.utc)
+    db_session.add_all([
+        _paged_contract(977201, ship_name="Rifter", seen=now),
+        # Two hours behind its region's newest sighting: delisted, still in date.
+        _paged_contract(977202, ship_name="Tristan", seen=now - timedelta(hours=2)),
+    ])
+    await db_session.flush()
+
+    listed = await client.get(f"/contracts/?region_ids={OUT_OF_RANGE_REGION}")
+    assert listed.status_code == 200
+    assert {row["contract_id"] for row in listed.json()["items"]} == {977201}
+
+    detail = await client.get("/contracts/977202")
+    assert detail.status_code == 200
+    assert detail.json()["contract_id"] == 977202
+
+
+async def test_min_runs_admits_the_esi_sentinel_and_rejects_one_below_it(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """`min_runs` is bounded at -1, not at 0, and the boundary is deliberate.
+
+    -1 is ESI's "not a blueprint copy" sentinel. Public contract data never carries it
+    (ESI-3), so the bound admits a value the corpus cannot hold — which is why nothing
+    exercises it and why narrowing to `ge=0` would look like a safe tidy-up. Pinned as a
+    boundary PAIR: -1 is admitted, -2 is refused. A single-sided assertion is satisfied
+    by any bound at or below -1, including no bound at all.
+    """
+    db_session.add(
+        _paged_contract(977301, ship_name="Rifter", seen=datetime.now(timezone.utc))
+    )
+    await db_session.flush()
+
+    admitted = await client.get(f"/contracts/?region_ids={OUT_OF_RANGE_REGION}&min_runs=-1")
+    assert admitted.status_code == 200
+
+    refused = await client.get(f"/contracts/?region_ids={OUT_OF_RANGE_REGION}&min_runs=-2")
+    assert refused.status_code == 422
+
+
+# --- NULL placement on the JOINED fetch path, for every nullable sort (region 99999978) ---
+#
+# `nulls_last()` is applied by both fetch paths from the same `sort_by in NULLABLE_SORTS`
+# test, but the two paths build different order expressions around it: the simple path
+# orders the column directly, the joined path orders an AGGREGATE of it (min for asc,
+# max for desc) over a grouped distinct-id query. NULL propagates through min/max, so the
+# placement holds for the same reason — but "for the same reason" is an argument, not a
+# test, and only two of the six nullable sorts have ever run it on the joined side.
+#
+# Parametrized over NULLABLE_SORTS itself rather than a hand-listed set, so a seventh
+# nullable sort is covered the moment it joins the frozenset instead of the next time
+# somebody remembers to add a case.
+
+NULLS_JOINED_REGION = 99999978
+NULLS_JOINED_TYPE_ID = 34567
+
+
+@pytest_asyncio.fixture
+async def joined_null_corpus(db_session: AsyncSession):
+    """Three contracts sharing one item type, ordered low / high / nothing-at-all.
+
+    Every nullable sort reads the same shape from this corpus: 978001 sorts before
+    978002 ascending, and 978003 carries NULL in all six columns at once. One fixture
+    serves all six because the assertion is about WHERE NULL LANDS, which is the one
+    thing the six have in common.
+
+    All three carry the identical `last_seen_at`, the way one ingestion run stamps a
+    batch — adjacent-but-different stamps would delist two of the three against the
+    region watermark and leave a single-row corpus that no ordering can discriminate.
+    """
+    seen = datetime.now(timezone.utc)
+
+    def _contract(cid, *, price, volume, buyout, days, reward, ship_name):
+        return Contract(
+            contract_id=cid, title=f"Null Placement {cid}", price=price,
+            collateral=0.0, status="outstanding", type="item_exchange",
+            issuer_id=978, issuer_corporation_id=978, for_corporation=False,
+            is_ship_contract=True, start_location_id=60003760,
+            start_location_region_id=NULLS_JOINED_REGION,
+            date_issued=seen - timedelta(days=1), date_expired=seen + timedelta(days=7),
+            last_seen_at=seen, volume=volume, buyout=buyout,
+            days_to_complete=days, reward=reward,
+            items=[
+                ContractItem(
+                    record_id=cid * 10 + 1, type_id=NULLS_JOINED_TYPE_ID,
+                    type_name=ship_name, quantity=1, is_included=True,
+                    is_singleton=False, category="ship",
+                )
+            ],
+        )
+
+    db_session.add_all([
+        # Every sorted column is DISTINCT between these two, volume included: a shared
+        # volume ties the volume sort, the contract_id tiebreaker then produces
+        # ascending order in both directions, and the descending assertion fails on a
+        # fixture defect rather than on a placement one. reward_per_volume still has to
+        # order the same way, so the rewards are chosen against the volumes:
+        # 10 000 / 100 = 100 ...
+        _contract(978001, price=1_000_000, volume=100.0, buyout=1_000_000,
+                  days=1, reward=10_000, ship_name="Apocalypse"),
+        # ... against 1 800 000 / 200 = 9 000.
+        _contract(978002, price=9_000_000, volume=200.0, buyout=9_000_000,
+                  days=9, reward=1_800_000, ship_name="Zealot"),
+        # NULL in every sorted column at once, including the item's name.
+        _contract(978003, price=None, volume=None, buyout=None,
+                  days=None, reward=None, ship_name=None),
+    ])
+    await db_session.flush()
+    return seen
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    sorted(field.value for field in NULLABLE_SORTS),
+)
+async def test_the_joined_path_puts_nulls_last_whichever_way_every_nullable_sort_runs(
+    client: AsyncClient, joined_null_corpus, sort_by: str
+):
+    """A missing value is not a low one, on the joined path as much as the simple one.
+
+    `type_ids` forces `_needs_item_join` for the five contract-column sorts; ship_name
+    reaches the same path on its own. Both directions are asserted because nulls_last is
+    direction-independent by construction and a regression that simply dropped the call
+    would put NULLs first in exactly one of the two — an assertion on one direction alone
+    is satisfied by the database's default placement half the time.
+
+    The order is observed as the full ordered id list rather than as "978003 is last":
+    the latter also passes when the two REAL values have swapped, which is a different
+    regression in the same expression (TEST-25).
+    """
+    base = (
+        f"/contracts/?region_ids={NULLS_JOINED_REGION}"
+        f"&type_ids={NULLS_JOINED_TYPE_ID}&sort_by={sort_by}"
+    )
+
+    ascending = await client.get(f"{base}&sort_direction=asc")
+    assert ascending.status_code == 200
+    assert [row["contract_id"] for row in ascending.json()["items"]] == [
+        978001,
+        978002,
+        978003,
+    ], f"{sort_by} asc"
+
+    descending = await client.get(f"{base}&sort_direction=desc")
+    assert descending.status_code == 200
+    assert [row["contract_id"] for row in descending.json()["items"]] == [
+        978002,
+        978001,
+        978003,
+    ], f"{sort_by} desc"

--- a/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contract_filters.py
@@ -2889,110 +2889,206 @@ async def test_min_runs_admits_the_esi_sentinel_and_rejects_one_below_it(
 # --- NULL placement on the JOINED fetch path, for every nullable sort (region 99999978) ---
 #
 # `nulls_last()` is applied by both fetch paths from the same `sort_by in NULLABLE_SORTS`
-# test, but the two paths build different order expressions around it: the simple path
-# orders the column directly, the joined path orders an AGGREGATE of it (min for asc,
-# max for desc) over a grouped distinct-id query. NULL propagates through min/max, so the
+# test, but the two build different order expressions around it: the simple path orders
+# the column directly, the joined path orders an AGGREGATE of it (min for asc, max for
+# desc) over a grouped distinct-id query. NULL propagates through min/max, so the
 # placement holds for the same reason — but "for the same reason" is an argument, not a
-# test, and only two of the six nullable sorts have ever run it on the joined side.
+# test, and only two of the six nullable sorts had ever run it on the joined side.
 #
-# Parametrized over NULLABLE_SORTS itself rather than a hand-listed set, so a seventh
-# nullable sort is covered the moment it joins the frozenset instead of the next time
-# somebody remembers to add a case.
+# Split into two corpora because NO SINGLE CONTRACT TYPE can carry all six columns, and
+# a fixture giving one type all of them would be a state ingestion cannot produce
+# (TEST-18). ESI sends `buyout` only on auctions and `reward`/`days_to_complete` only on
+# couriers, and `_build_contract_rows` maps each straight through, so the writer can
+# never populate both families on one row.
+#
+# The two corpora also reach the joined path by different levers, because the types
+# differ in whether they carry items at all:
+#   - auctions are item-bearing, so `type_ids` forces the join;
+#   - couriers are item-less, so only `search` can — the item join is an OUTER join and
+#     the search predicate ORs `Contract.title` against the item name, which is what
+#     lets a contract with no items reach the joined path at all.
 
 NULLS_JOINED_REGION = 99999978
 NULLS_JOINED_TYPE_ID = 34567
+NULLS_COURIER_TITLE_STEM = "Nullsorted Courier"
+
+# Auctions carry buyout; item-bearing, so they also carry price, volume and item names.
+ITEM_BEARING_JOINED_SORTS = ("buyout", "price", "volume", "ship_name")
+# Couriers carry the delivery reward and window; the ratio needs the reward.
+COURIER_JOINED_SORTS = ("days_to_complete", "reward_per_volume")
+
+
+def _nulls_contract(cid, *, ctype, seen, items=None, **columns) -> Contract:
+    """One fixture row.
+
+    `seen` is shared across a corpus: the delisting watermark is an exact
+    `last_seen_at >= max(last_seen_at) in region` with no tolerance, and one ingestion
+    run stamps its whole batch with one value, so adjacent-but-different stamps would
+    delist every row but the last.
+    """
+    return Contract(
+        contract_id=cid,
+        title=columns.pop("title", f"Null Placement {cid}"),
+        collateral=0.0,
+        status="outstanding",
+        type=ctype,
+        issuer_id=978,
+        issuer_corporation_id=978,
+        for_corporation=False,
+        start_location_id=60003760,
+        start_location_region_id=NULLS_JOINED_REGION,
+        date_issued=seen - timedelta(days=1),
+        date_expired=seen + timedelta(days=7),
+        last_seen_at=seen,
+        items=items or [],
+        **columns,
+    )
+
+
+def _nulls_ship_item(cid: int, type_name) -> ContractItem:
+    return ContractItem(
+        record_id=cid * 10 + 1,
+        type_id=NULLS_JOINED_TYPE_ID,
+        type_name=type_name,
+        quantity=1,
+        is_included=True,
+        is_singleton=False,
+        category="ship",
+    )
 
 
 @pytest_asyncio.fixture
-async def joined_null_corpus(db_session: AsyncSession):
-    """Three contracts sharing one item type, ordered low / high / nothing-at-all.
+async def joined_auction_corpus(db_session: AsyncSession):
+    """Three auctions ordered low / high / nothing-at-all in every column an auction carries.
 
-    Every nullable sort reads the same shape from this corpus: 978001 sorts before
-    978002 ascending, and 978003 carries NULL in all six columns at once. One fixture
-    serves all six because the assertion is about WHERE NULL LANDS, which is the one
-    thing the six have in common.
-
-    All three carry the identical `last_seen_at`, the way one ingestion run stamps a
-    batch — adjacent-but-different stamps would delist two of the three against the
-    region watermark and leave a single-row corpus that no ordering can discriminate.
+    Every sorted column is DISTINCT between the two non-NULL rows, volume included: a
+    shared value ties the sort, the `contract_id` tiebreaker then produces ascending
+    order in BOTH directions, and the descending assertion fails on a fixture defect
+    rather than on a placement one.
     """
     seen = datetime.now(timezone.utc)
-
-    def _contract(cid, *, price, volume, buyout, days, reward, ship_name):
-        return Contract(
-            contract_id=cid, title=f"Null Placement {cid}", price=price,
-            collateral=0.0, status="outstanding", type="item_exchange",
-            issuer_id=978, issuer_corporation_id=978, for_corporation=False,
-            is_ship_contract=True, start_location_id=60003760,
-            start_location_region_id=NULLS_JOINED_REGION,
-            date_issued=seen - timedelta(days=1), date_expired=seen + timedelta(days=7),
-            last_seen_at=seen, volume=volume, buyout=buyout,
-            days_to_complete=days, reward=reward,
-            items=[
-                ContractItem(
-                    record_id=cid * 10 + 1, type_id=NULLS_JOINED_TYPE_ID,
-                    type_name=ship_name, quantity=1, is_included=True,
-                    is_singleton=False, category="ship",
-                )
-            ],
-        )
-
     db_session.add_all([
-        # Every sorted column is DISTINCT between these two, volume included: a shared
-        # volume ties the volume sort, the contract_id tiebreaker then produces
-        # ascending order in both directions, and the descending assertion fails on a
-        # fixture defect rather than on a placement one. reward_per_volume still has to
-        # order the same way, so the rewards are chosen against the volumes:
-        # 10 000 / 100 = 100 ...
-        _contract(978001, price=1_000_000, volume=100.0, buyout=1_000_000,
-                  days=1, reward=10_000, ship_name="Apocalypse"),
-        # ... against 1 800 000 / 200 = 9 000.
-        _contract(978002, price=9_000_000, volume=200.0, buyout=9_000_000,
-                  days=9, reward=1_800_000, ship_name="Zealot"),
-        # NULL in every sorted column at once, including the item's name.
-        _contract(978003, price=None, volume=None, buyout=None,
-                  days=None, reward=None, ship_name=None),
+        _nulls_contract(
+            978001, ctype="auction", seen=seen, is_ship_contract=True,
+            price=1_000_000, buyout=1_000_000, volume=100.0,
+            items=[_nulls_ship_item(978001, "Apocalypse")],
+        ),
+        _nulls_contract(
+            978002, ctype="auction", seen=seen, is_ship_contract=True,
+            price=9_000_000, buyout=9_000_000, volume=200.0,
+            items=[_nulls_ship_item(978002, "Zealot")],
+        ),
+        # Every one of those columns absent at once — each is optional on ESI's public
+        # route — and the item present but unnamed, which is what an auction looks like
+        # between ingestion and the next name-resolution pass.
+        _nulls_contract(
+            978003, ctype="auction", seen=seen, is_ship_contract=True,
+            price=None, buyout=None, volume=None,
+            items=[_nulls_ship_item(978003, None)],
+        ),
     ])
     await db_session.flush()
-    return seen
 
 
-@pytest.mark.parametrize(
-    "sort_by",
-    sorted(field.value for field in NULLABLE_SORTS),
-)
-async def test_the_joined_path_puts_nulls_last_whichever_way_every_nullable_sort_runs(
-    client: AsyncClient, joined_null_corpus, sort_by: str
+@pytest_asyncio.fixture
+async def joined_courier_corpus(db_session: AsyncSession):
+    """Three couriers, item-less the way ingestion leaves them — it fetches no items for
+    a type that cannot carry any — sharing a title stem so one search matches all three."""
+    seen = datetime.now(timezone.utc)
+    db_session.add_all([
+        # reward / volume = 10 000 / 100 = 100 ...
+        _nulls_contract(
+            978101, ctype="courier", seen=seen, price=0,
+            title=f"{NULLS_COURIER_TITLE_STEM} Alpha",
+            reward=10_000, volume=100.0, days_to_complete=1,
+        ),
+        # ... against 1 800 000 / 200 = 9 000.
+        _nulls_contract(
+            978102, ctype="courier", seen=seen, price=0,
+            title=f"{NULLS_COURIER_TITLE_STEM} Beta",
+            reward=1_800_000, volume=200.0, days_to_complete=9,
+        ),
+        _nulls_contract(
+            978103, ctype="courier", seen=seen, price=0,
+            title=f"{NULLS_COURIER_TITLE_STEM} Gamma",
+            reward=None, volume=None, days_to_complete=None,
+        ),
+    ])
+    await db_session.flush()
+
+
+async def _assert_nulls_last_both_ways(client: AsyncClient, base: str, sort_by: str, ids):
+    """Both directions, asserted as the FULL ordered id list.
+
+    Both directions, because `nulls_last` is direction-independent by construction and a
+    regression that simply dropped the call puts NULLs first in exactly one of the two —
+    an assertion on one direction alone is satisfied by the database's default placement
+    half the time. The full list rather than "the NULL row is last", because the latter
+    also passes when the two REAL values have swapped, which is a different regression in
+    the same expression (TEST-25).
+    """
+    low, high, absent = ids
+    ascending = await client.get(f"{base}&sort_by={sort_by}&sort_direction=asc")
+    assert ascending.status_code == 200
+    assert [r["contract_id"] for r in ascending.json()["items"]] == [
+        low, high, absent,
+    ], f"{sort_by} asc"
+
+    descending = await client.get(f"{base}&sort_by={sort_by}&sort_direction=desc")
+    assert descending.status_code == 200
+    assert [r["contract_id"] for r in descending.json()["items"]] == [
+        high, low, absent,
+    ], f"{sort_by} desc"
+
+
+@pytest.mark.parametrize("sort_by", ITEM_BEARING_JOINED_SORTS)
+async def test_the_joined_path_puts_nulls_last_for_the_item_bearing_sorts(
+    client: AsyncClient, joined_auction_corpus, sort_by: str
 ):
     """A missing value is not a low one, on the joined path as much as the simple one.
 
-    `type_ids` forces `_needs_item_join` for the five contract-column sorts; ship_name
-    reaches the same path on its own. Both directions are asserted because nulls_last is
-    direction-independent by construction and a regression that simply dropped the call
-    would put NULLs first in exactly one of the two — an assertion on one direction alone
-    is satisfied by the database's default placement half the time.
-
-    The order is observed as the full ordered id list rather than as "978003 is last":
-    the latter also passes when the two REAL values have swapped, which is a different
-    regression in the same expression (TEST-25).
+    `type_ids` forces `_needs_item_join` for the three contract-column sorts; ship_name
+    reaches the same path on its own.
     """
-    base = (
-        f"/contracts/?region_ids={NULLS_JOINED_REGION}"
-        f"&type_ids={NULLS_JOINED_TYPE_ID}&sort_by={sort_by}"
+    await _assert_nulls_last_both_ways(
+        client,
+        f"/contracts/?region_ids={NULLS_JOINED_REGION}&type_ids={NULLS_JOINED_TYPE_ID}",
+        sort_by,
+        (978001, 978002, 978003),
     )
 
-    ascending = await client.get(f"{base}&sort_direction=asc")
-    assert ascending.status_code == 200
-    assert [row["contract_id"] for row in ascending.json()["items"]] == [
-        978001,
-        978002,
-        978003,
-    ], f"{sort_by} asc"
 
-    descending = await client.get(f"{base}&sort_direction=desc")
-    assert descending.status_code == 200
-    assert [row["contract_id"] for row in descending.json()["items"]] == [
-        978002,
-        978001,
-        978003,
-    ], f"{sort_by} desc"
+@pytest.mark.parametrize("sort_by", COURIER_JOINED_SORTS)
+async def test_the_joined_path_puts_nulls_last_for_the_courier_only_sorts(
+    client: AsyncClient, joined_courier_corpus, sort_by: str
+):
+    """The same placement for the two columns only couriers carry.
+
+    A courier holds no items, so `type_ids` cannot reach it — `search` is the only lever
+    that puts an item-less contract on the joined path, and it works because the item
+    join is an OUTER join and the predicate ORs the contract title against the item name.
+
+    That makes these two cases sensitive to the still-open offered-only search decision:
+    if `_needs_item_join` stops treating `search` as needing the join, they keep passing
+    but silently relocate to the simple path. Stated rather than hidden — whoever takes
+    that decision should re-point these two at whatever lever replaces it.
+    """
+    search = NULLS_COURIER_TITLE_STEM.replace(" ", "+")
+    await _assert_nulls_last_both_ways(
+        client,
+        f"/contracts/?region_ids={NULLS_JOINED_REGION}&search={search}",
+        sort_by,
+        (978101, 978102, 978103),
+    )
+
+
+async def test_the_two_joined_corpora_between_them_cover_every_nullable_sort():
+    """Exhaustiveness over `NULLABLE_SORTS` itself, since splitting into two corpora
+    replaced a parametrization that read the frozenset directly.
+
+    Without this, adding a seventh nullable sort leaves the joined path untested for it
+    and nothing says so — the hand-written tuples above would simply not mention it.
+    """
+    assert set(ITEM_BEARING_JOINED_SORTS) | set(COURIER_JOINED_SORTS) == {
+        field.value for field in NULLABLE_SORTS
+    }

--- a/app/backend/src/fastapi_app/tests/api/test_contracts.py
+++ b/app/backend/src/fastapi_app/tests/api/test_contracts.py
@@ -346,3 +346,179 @@ async def test_primary_label_prefers_the_offered_ship_over_an_earlier_named_item
     response = await client.get("/contracts/")
     assert response.status_code == 200
     assert response.json()["items"][0]["primary_label"] == "Rifter"
+
+
+async def test_a_courier_with_no_destination_name_is_labelled_courier_alone(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The bare "Courier" label, distinct from the "Courier to X" one already pinned.
+
+    A courier carries no items and frequently no title, so the label falls all the way
+    through to the type branch. That branch has two arms and only the named-destination
+    one is asserted anywhere: with end_location_name NULL — which is every courier whose
+    destination the name cache has not resolved yet — the label must still say what the
+    contract IS rather than degrading to the id fallback.
+    """
+    db_session.add(
+        Contract(
+            contract_id=41, title=None, price=0, collateral=1_000_000,
+            is_ship_contract=False, type="courier", status="outstanding",
+            issuer_id=41, issuer_corporation_id=41, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+            end_location_name=None,
+        )
+    )
+    await db_session.flush()
+
+    response = await client.get("/contracts/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["primary_label"] == "Courier"
+
+
+async def test_a_contract_with_nothing_to_name_it_by_falls_back_to_its_id(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The last-resort label: no named item, no title, and not a courier.
+
+    Reached by a contract whose items ESI has not enriched with type_names yet — the
+    ordinary state between ingestion and the next name-resolution pass — so the fallback
+    is a live path rather than a defensive one. It is the only branch that can produce a
+    label at all here, and nothing reads it today.
+    """
+    db_session.add_all([
+        Contract(
+            contract_id=42, title=None, price=100, collateral=0.0,
+            is_ship_contract=True, type="item_exchange", status="outstanding",
+            issuer_id=42, issuer_corporation_id=42, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+        ),
+        # Unnamed: present, offered, and useless for labelling.
+        ContractItem(
+            record_id=420001, contract_id=42, type_id=587, type_name=None,
+            quantity=1, is_included=True, is_singleton=False,
+        ),
+    ])
+    await db_session.flush()
+
+    response = await client.get("/contracts/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["primary_label"] == "Contract 42"
+
+
+async def test_a_whitespace_only_title_counts_as_absent(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """`_primary_label`'s own comment calls "" the common real ESI shape; whitespace is
+    the same claim one step further, and the guard spells it `.strip()` rather than a
+    bare truthiness check for exactly that reason.
+
+    The discriminating observation is the label's VALUE, not merely that a label exists:
+    dropping `.strip()` from the guard leaves `contract.title` truthy, and the row
+    headlines as an empty string — a blank cell where the contract's identity belongs.
+    """
+    db_session.add(
+        Contract(
+            contract_id=43, title="   ", price=100, collateral=0.0,
+            is_ship_contract=True, type="item_exchange", status="outstanding",
+            issuer_id=43, issuer_corporation_id=43, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+        )
+    )
+    await db_session.flush()
+
+    response = await client.get("/contracts/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["primary_label"] == "Contract 43"
+
+
+async def test_composition_reports_an_unmeasured_volume_as_null_not_zero(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """A contract the corpus carries no volume for must say so, not claim zero.
+
+    `total_volume` is the contract's own volume and the column is nullable, so the
+    NULL arm runs against real rows. Zero is a measurement — "this lot occupies no
+    space" — and a lot of blueprint copies genuinely measures near zero, so the two
+    readings are not interchangeable at the surface that renders them.
+
+    Asserted alongside `total_item_rows` so a mutation that drops the composition
+    object wholesale fails on a missing breakdown rather than on a NULL that agrees
+    with the expectation by accident.
+    """
+    db_session.add_all([
+        Contract(
+            contract_id=44, title="Unmeasured lot", price=100, collateral=0.0,
+            is_ship_contract=True, type="item_exchange", status="outstanding",
+            issuer_id=44, issuer_corporation_id=44, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+            volume=None,
+        ),
+        ContractItem(
+            record_id=440001, contract_id=44, type_id=587, type_name="Rifter",
+            quantity=1, is_included=True, is_singleton=False,
+            category="ship", category_id=6,
+        ),
+        ContractItem(
+            record_id=440002, contract_id=44, type_id=12058,
+            type_name="1MN Afterburner I", quantity=1, is_included=True,
+            is_singleton=False, category="module", category_id=7,
+        ),
+    ])
+    await db_session.flush()
+
+    response = await client.get("/contracts/")
+    assert response.status_code == 200
+    composition = response.json()["items"][0]["composition"]
+    assert composition is not None
+    assert composition["total_item_rows"] == 2
+    assert composition["total_volume"] is None
+
+
+async def test_detail_returns_its_items_in_record_id_order(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """The item table renders identically on every request only because the detail
+    builder sorts; without it the array carries whatever order the heap returns.
+
+    Pinned as the ORDERED list rather than as membership: a set assertion passes under
+    every permutation, which is precisely the regression. The fixture inserts in
+    descending record_id so unsorted row order and sorted row order disagree, and it
+    interleaves a requested (is_included=False) row to state the second half of the
+    contract — the detail array is the contract's FULL item list, not the offered
+    subset the derived fields are computed from.
+    """
+    db_session.add_all([
+        Contract(
+            contract_id=45, title="Ordered contents", price=100, collateral=0.0,
+            is_ship_contract=True, type="item_exchange", status="outstanding",
+            issuer_id=45, issuer_corporation_id=45, for_corporation=False,
+            date_issued=datetime.fromisoformat("2025-01-01T00:00:00Z"),
+            date_expired=LIVE_EXPIRY, start_location_id=60003760,
+        ),
+        ContractItem(
+            record_id=450003, contract_id=45, type_id=587, type_name="Rifter",
+            quantity=1, is_included=True, is_singleton=False, category="ship",
+        ),
+        ContractItem(
+            record_id=450002, contract_id=45, type_id=34, type_name="Tritanium",
+            quantity=100, is_included=False, is_singleton=False, category="material",
+        ),
+        ContractItem(
+            record_id=450001, contract_id=45, type_id=12058,
+            type_name="1MN Afterburner I", quantity=1, is_included=True,
+            is_singleton=False, category="module",
+        ),
+    ])
+    await db_session.flush()
+
+    response = await client.get("/contracts/45")
+    assert response.status_code == 200
+    assert [item["record_id"] for item in response.json()["items"]] == [
+        450001,
+        450002,
+        450003,
+    ]

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -435,6 +435,41 @@ async def test_a_failing_statement_does_not_log_its_bound_search_text(
     assert "statement timeout" in failures[0]["error_message"]
 
 
+async def test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it():
+    """The scrub borrows `hide_parameters`; it must give it back.
+
+    The exception is not consumed at the log site — `get_contracts` re-raises it, so
+    the object outlives the render and travels on to whatever handles it. Flipping the
+    flag permanently would silently strip the binds from every LATER rendering of that
+    same exception, including the driver diagnosis the `error_message` field exists to
+    preserve, and nothing downstream would report a missing field.
+
+    Observed through the RENDERING rather than through the flag: asserting
+    `hide_parameters is False` pins the bookkeeping, while re-rendering pins the
+    behavior the bookkeeping controls (TEST-25). Both are asserted, in that order, so
+    a failure says which one broke.
+    """
+    secret = "Tristan sale"
+    error = StatementError(
+        "canceling statement due to statement timeout",
+        "SELECT contracts.contract_id FROM contracts WHERE contracts.title ILIKE %(title_1)s",
+        {"title_1": f"%{secret}%"},
+        Exception("canceling statement due to statement timeout"),
+    )
+    # Vacuity guard: the restore is only observable while the default rendering
+    # carries the binds. If that stopped being true this test would pass having
+    # constrained nothing (TEST-12).
+    assert error.hide_parameters is False
+    assert secret in str(error)
+
+    scrubbed = contract_service._error_without_bound_parameters(error)
+
+    assert secret not in scrubbed, "the render did not scrub"
+    assert "statement timeout" in scrubbed, "the render scrubbed the diagnosis too"
+    assert error.hide_parameters is False, "the flag was not restored"
+    assert secret in str(error), "a later rendering of the same exception lost its binds"
+
+
 async def test_full_dimension_logs_carry_the_type_and_taxonomy_filters(
     db_session: AsyncSession, setup_contracts, monkeypatch
 ):

--- a/app/backend/src/fastapi_app/tests/services/test_contract_service.py
+++ b/app/backend/src/fastapi_app/tests/services/test_contract_service.py
@@ -435,39 +435,58 @@ async def test_a_failing_statement_does_not_log_its_bound_search_text(
     assert "statement timeout" in failures[0]["error_message"]
 
 
-async def test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it():
-    """The scrub borrows `hide_parameters`; it must give it back.
+def _timeout_error_carrying(secret: str) -> StatementError:
+    """A StatementError of the class the log site actually meets, holding `secret` as a bind.
 
-    The exception is not consumed at the log site — `get_contracts` re-raises it, so
-    the object outlives the render and travels on to whatever handles it. Flipping the
-    flag permanently would silently strip the binds from every LATER rendering of that
-    same exception, including the driver diagnosis the `error_message` field exists to
-    preserve, and nothing downstream would report a missing field.
-
-    Observed through the RENDERING rather than through the flag: asserting
-    `hide_parameters is False` pins the bookkeeping, while re-rendering pins the
-    behavior the bookkeeping controls (TEST-25). Both are asserted, in that order, so
-    a failure says which one broke.
+    TEST-21: a hand-rolled RuntimeError renders parameter-free, so it cannot show whether
+    the scrub did anything. The real failure class appends `[parameters: {...}]`, and on
+    the search path those binds hold the user's raw query text.
     """
-    secret = "Tristan sale"
-    error = StatementError(
+    return StatementError(
         "canceling statement due to statement timeout",
         "SELECT contracts.contract_id FROM contracts WHERE contracts.title ILIKE %(title_1)s",
         {"title_1": f"%{secret}%"},
         Exception("canceling statement due to statement timeout"),
     )
-    # Vacuity guard: the restore is only observable while the default rendering
-    # carries the binds. If that stopped being true this test would pass having
-    # constrained nothing (TEST-12).
-    assert error.hide_parameters is False
-    assert secret in str(error)
+
+
+@pytest.mark.parametrize("initially_hidden", [False, True])
+async def test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it(
+    initially_hidden: bool,
+):
+    """The scrub borrows `hide_parameters`; it must give back what it took.
+
+    The exception is not consumed at the log site — `get_contracts` re-raises it, so the
+    object outlives the render and travels on to whatever handles it. The restore must
+    therefore return the SAVED value, not a constant, and both starting states are real:
+    the application engine sets `hide_parameters=True` (`db.py`), so errors raised through
+    it arrive already hidden, while an exception from a session built anywhere else
+    arrives at the default False.
+
+    Parametrized over both because a restore hardcoded to `False` — the obvious
+    simplification of a save/restore pair — is invisible to the False case and is exactly
+    backwards for the True one: it would UNHIDE the binds of every engine-raised error on
+    every later rendering, which is the leak this function exists to prevent.
+
+    Observed through the RENDERING as well as the flag (TEST-25): the flag pins the
+    bookkeeping, re-rendering pins the behavior the bookkeeping controls.
+    """
+    secret = "Tristan sale"
+    error = _timeout_error_carrying(secret)
+    error.hide_parameters = initially_hidden
+
+    # Vacuity guard: the whole property is only observable while an UNHIDDEN rendering
+    # carries the binds. Checked on a fresh instance so the guard holds for both
+    # parameter cases without depending on the one under test (TEST-12).
+    assert secret in str(_timeout_error_carrying(secret))
 
     scrubbed = contract_service._error_without_bound_parameters(error)
 
     assert secret not in scrubbed, "the render did not scrub"
     assert "statement timeout" in scrubbed, "the render scrubbed the diagnosis too"
-    assert error.hide_parameters is False, "the flag was not restored"
-    assert secret in str(error), "a later rendering of the same exception lost its binds"
+    assert error.hide_parameters is initially_hidden, "the flag was not restored as found"
+    # The behavior the flag controls, re-derived rather than assumed.
+    assert (secret in str(error)) is (not initially_hidden)
 
 
 async def test_full_dimension_logs_carry_the_type_and_taxonomy_filters(

--- a/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
+++ b/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
@@ -392,7 +392,7 @@ four per-file registers as work orders.
 | 2 | Backend read correctness (13) | ✅ implemented — PR #166 (`Review — public API contract`, held for Sam: detail-id bounds ride along); three mutation kills verified |
 | 3 | Backend write correctness (11) + O2's backend partition pin | ⚠️ **10 of 11 closed** — PR #169 (`Routine`); backend 705 → 733, 24 regressions mutation-verified, all killed. C-11 is PARTIALLY closed: two of its three mocked-behavior hazards now run against real dependencies, the third needs a decision from Sam (see Wave 3 residual below). O2 closed at all three sites |
 | 4 | Frontend logic (28) + components (10) + e2e pins (O1a, O1b, null-price) | ✅ DONE — logic **28/28**, components **10/10**, e2e pins **3/3**. PR #170 (C1–C4, plus a typecheck lane for `e2e/` that had never existed) and PR #171 (C5–C10). vitest 322 → 416, e2e 140 → 146 |
-| 5 | Nice-to-have (60) | 🔄 **swept 2026-08-09** — 60 register rows reduce to **58 distinct open items**: one fully struck, one cross-register duplicate merged, three partials narrowed. See §Wave 5 sweep below for the row-by-row evidence. Authoring proceeds register by register from that table |
+| 5 | Nice-to-have (60) | 🔄 **in progress** — swept first (§Wave 5 sweep): 60 register rows reduce to **58 distinct open items**, one struck, one cross-register duplicate merged, three partials narrowed. **Backend-read 10/10 closed** — 18 tests, backend 733 → 751, every one mutation-verified. Remaining: backend-write 18 (N-10 struck, N-11 partial), frontend-logic 13 (N-9, N-13 partial), frontend-components 17 (N-11 merged into frontend-logic N-11) |
 
 Each wave: TDD where a fix changes code, mutation-verification for load-bearing new tests
 (TEST-12), footprint-free discipline on shared fixtures (TEST-23), five frontend lanes for any
@@ -462,6 +462,49 @@ dropped:
 - **frontend-components N-18** — "no mobile live-smoke project" is a `playwright.config.ts` change
   that adds a lane running against a real backend, not a test. Out of scope for a test-only wave;
   flagged for Sam.
+
+### Wave 5 — backend-read register closed (10/10)
+
+Eighteen tests, backend **733 → 751**. Every one mutation-verified with the pre-existing
+suite held green, save the one documented overlap below.
+
+| Row | Closed by | Mutant killed |
+|---|---|---|
+| N-1 | `test_a_page_past_the_end_serves_an_empty_page_that_still_counts_the_corpus`, `..._of_the_joined_path_loads_from_an_empty_id_list` | short-circuiting on an empty PAGE rather than an empty RESULT; skipping the empty `IN` as a pointless filter |
+| N-2 | `test_the_joined_path_puts_nulls_last_whichever_way_every_nullable_sort_runs` (parametrized over `NULLABLE_SORTS`) | `nulls_last()` deleted from `_fetch_page_joined` |
+| N-3 | `test_composition_reports_an_unmeasured_volume_as_null_not_zero` | NULL volume coalesced to `0` |
+| N-4 | `test_a_courier_with_no_destination_name_is_labelled_courier_alone`, `test_a_contract_with_nothing_to_name_it_by_falls_back_to_its_id` | the courier arm rewritten to the id fallback; the id fallback retexted |
+| N-5 | `test_a_whitespace_only_title_counts_as_absent` | `.strip()` dropped from the title guard |
+| N-6 | `test_detail_returns_its_items_in_record_id_order` | the detail sort deleted |
+| N-7 | `test_taxonomy_breaks_a_name_tie_by_id_so_the_order_is_total` | the id element dropped from each sort key (verified separately per list) |
+| N-8 | `test_a_stale_enrichment_settles_coverage_without_the_category_sweep` | the two coverage conditions reordered |
+| N-9 | `test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it` | the `finally` restore removed |
+| N-10 | `test_detail_still_serves_a_delisted_but_unexpired_contract`, `test_min_runs_admits_the_esi_sentinel_and_rejects_one_below_it` | `still_listed_by_esi()` added to the detail query; `ge=-1` narrowed to `ge=0` |
+
+**One mutation could not be isolated further, and that is the finding.** Deleting
+`nulls_last()` from `_fetch_page_joined` kills all six new parametrized cases *and*
+`test_a_new_sort_survives_the_grouped_joined_pagination_path`. That pre-existing test is
+the prior coverage the register counted as "2 of 6", and the branch is a single shared
+line — there is no narrower edit. Recorded rather than papered over, because TEST-12's
+isolation rule normally reads as "a mutation that takes pre-existing tests down is not
+evidence", and the exception is a branch that was already partially covered.
+
+**Two fixture defects the tests caught before the assertions did**, both worth carrying:
+
+- A helper computing `datetime.now()` per row silently delisted every row but the last.
+  `still_listed_by_esi` is an exact `last_seen_at >= max(last_seen_at) in region` with no
+  tolerance, and ingestion stamps one run's whole batch with ONE value — so co-listed
+  fixture rows must share an identical stamp, not adjacent ones. A helper defaulting the
+  stamp internally builds a state ingestion cannot produce (TEST-18's rule applied to a
+  timestamp rather than a column).
+- Giving the two non-NULL rows the same `volume` (to make `reward_per_volume` differ) tied
+  the volume sort, so the `contract_id` tiebreaker produced ascending order in BOTH
+  directions and the descending assertion failed on a fixture defect. Caught only because
+  the assertion reads the full ordered list; "the NULL row is last" would have passed.
+
+**Fixture regions:** 99999977 and 99999978 claimed. Next free **99999979**, which is the
+LAST id in the plan's 99999960–99999979 allocation — the next wave to need one must
+either extend the allocation or reuse, and should say which.
 
 ### Wave 4 — register row 23, and the standard the campaign now uses
 

--- a/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
+++ b/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
@@ -392,11 +392,76 @@ four per-file registers as work orders.
 | 2 | Backend read correctness (13) | ✅ implemented — PR #166 (`Review — public API contract`, held for Sam: detail-id bounds ride along); three mutation kills verified |
 | 3 | Backend write correctness (11) + O2's backend partition pin | ⚠️ **10 of 11 closed** — PR #169 (`Routine`); backend 705 → 733, 24 regressions mutation-verified, all killed. C-11 is PARTIALLY closed: two of its three mocked-behavior hazards now run against real dependencies, the third needs a decision from Sam (see Wave 3 residual below). O2 closed at all three sites |
 | 4 | Frontend logic (28) + components (10) + e2e pins (O1a, O1b, null-price) | ✅ DONE — logic **28/28**, components **10/10**, e2e pins **3/3**. PR #170 (C1–C4, plus a typecheck lane for `e2e/` that had never existed) and PR #171 (C5–C10). vitest 322 → 416, e2e 140 → 146 |
-| 5 | Nice-to-have (60) | ⬜ queued — **sweep before writing anything**: waves 3-4 closed several of these incidentally, and re-testing them is the main way this wave wastes effort. Known-closed, verify then strike: backend-write **N-10** (courier triggers zero `get_contract_items`) and the "an item exchange" label half of **N-11**, both closed by Wave 3's enum-parametrized tests. Frontend-logic **N-9** is now PARTIAL rather than open — the exact mutant it names ("deleting `sortField: 'days_to_complete'` from the Deadline column passes it") is killed by Wave 4's C9 test, and Wave 4 added a direct `sortableFieldsFor` assertion for the unreachable sort fields plus a full-column-set responsive map; only its per-segment membership SNAPSHOT remains. Record every intentional skip in this section rather than dropping it silently |
+| 5 | Nice-to-have (60) | 🔄 **swept 2026-08-09** — 60 register rows reduce to **58 distinct open items**: one fully struck, one cross-register duplicate merged, three partials narrowed. See §Wave 5 sweep below for the row-by-row evidence. Authoring proceeds register by register from that table |
 
 Each wave: TDD where a fix changes code, mutation-verification for load-bearing new tests
 (TEST-12), footprint-free discipline on shared fixtures (TEST-23), five frontend lanes for any
 frontend commit, Routine classification unless a wave touches schema or the public contract.
+
+### Wave 5 sweep — what waves 3–4 already closed (2026-08-09)
+
+Wave 5's first action was a sweep, not a test: waves 3–4 closed several nice-to-haves
+incidentally, and re-testing them is the main way this wave wastes effort. Every claim below was
+verified against the suite at `origin/dev` `7486df5`, not taken from register prose.
+
+**Baseline at sweep time, all lanes green:** backend **733** · vitest **416 ×2 lanes** ·
+e2e **146** (7 skipped: the live-smoke project) · eslint and `tsc -b` clean.
+
+#### Struck
+
+| Row | Register | Verdict | Evidence |
+|---|---|---|---|
+| **N-10** | backend-write | ✅ **CLOSED — struck** | `test_items_are_fetched_for_exactly_the_item_bearing_contract_types` (`services/test_background_aggregation.py:1528`) asserts `get_contract_items.assert_not_awaited()` on the item-less arm. It closes the row *more strongly than asked*: the row wanted a courier-only run, and the test is parametrized over the whole `ContractType` enum via `ITEM_BEARING_CONTRACT_TYPES`, so loan and unknown are covered too and a sixth type is covered the moment it is added |
+
+#### Narrowed (partial — the remainder is still Wave 5 work)
+
+| Row | Register | Closed half | Remaining |
+|---|---|---|---|
+| **N-11** | backend-write | `_SHIP_TYPE_LABELS`' `"an item exchange"` now renders — `test_an_item_exchange_contract_matches_and_renders_its_own_label` asserts the whole message string (`services/test_watchlist_matcher.py:119`) | `location=None → "an unknown location"` is still unrendered by any test (`watchlist_matcher.py:57`); the `"a contract"` fallback label remains unreachable behind the query's type gate and needs a decision — test it as defense-in-depth, or record it as deliberately unreachable |
+| **N-9** | frontend-logic | The mutant the row names is dead, and `columns.test.ts`'s responsive `HIDDEN_AT` map states the whole column policy exhaustively | `columns.test.ts:25` is still the **self-referential** assertion the row objected to — it derives the expected set from `columnsFor` and compares it to `sortableFieldsFor`, so both sides move together. The per-segment membership SNAPSHOT is still open |
+| **N-13** | frontend-logic | **Not previously known-closed.** Both `useDebouncedValue` halves are done — `'re-arms against the new delay when ONLY delayMs changes'` and `'drops its pending timer on unmount'` (`lib/useDebouncedValue.test.ts:67,97`), added by Wave 4 alongside its C25 work | `raiseApiError` non-401 leaving `['auth','me']` untouched — `lib/api/client.test.ts` throws a 400 but never asserts the cache was left alone. This is the row's whole remaining content |
+
+#### Merged — one gap, counted twice
+
+**frontend-logic N-11 and frontend-components N-11 are the same gap.** Both name
+`columns.tsx:141–143` (the `EXPIRES_COLUMN` `text-warn` cellClass fork on an expired row). The two
+subagents reviewed overlapping surface — `columns.tsx` belongs to the logic reviewer by the
+components reviewer's own stated boundary, but the rendered class is a component-layer
+observation, so both registered it. One test closes both rows; do not write two.
+
+#### Register erratum — a third row whose prose is wrong
+
+The handoff's rule ("treat register prose as evidence, not as ground truth") earns its keep again.
+**frontend-logic N-1** reads "`hasOfferedItemFilters` appears unused and untested (dead export or
+missing consumer test)". It is **not** a dead export: `FilterRail.tsx:48` calls it as one disjunct
+of `hasActiveFilters`. Only the second half of the row's disjunction is real — it has a live
+consumer and no test. This matters because "dead export" would have pointed at deleting production
+code, which needs Sam's explicit approval; "missing consumer test" is ordinary Routine test work.
+This is the third wrong register row across the campaign, after the a7c downgrade ordering (Wave 3
+erratum below) and the two parser-unreachable `DEFAULT_DIRECTION` rows in Wave 4.
+
+#### Sweep arithmetic
+
+60 register rows − 1 struck (backend-write N-10) − 1 duplicate merged (frontend N-11) =
+**58 distinct open items**, three of which (backend-write N-11, frontend-logic N-9, N-13) are
+narrowed to a fraction of their original scope.
+
+#### Rows that are not test work, flagged before authoring starts
+
+Three rows cannot be closed by writing a test alone. They are recorded here rather than silently
+dropped:
+
+- **backend-write N-8** — the contract and item upsert batch loops use function-local literals
+  (`batch_size = 500` at `background_aggregation.py:545`, `BATCH_SIZE = 500` at `:588`). Unlike
+  `UPDATE_ID_CHUNK_SIZE` they cannot be monkeypatched, so a boundary test needs 500+ row fixtures.
+  The row's own prescription is a production change — hoist both to module level — which makes the
+  TEST-11 boundary test possible. Routine, but it is a code edit and takes TDD.
+- **backend-write N-11's `"a contract"` fallback** — unreachable behind the matcher's type gate, so
+  either it is defense-in-depth worth a direct unit call, or it is dead and should be noted as
+  such. Recorded as a decision, not a gap.
+- **frontend-components N-18** — "no mobile live-smoke project" is a `playwright.config.ts` change
+  that adds a lane running against a real backend, not a test. Out of scope for a test-only wave;
+  flagged for Sam.
 
 ### Wave 4 — register row 23, and the standard the campaign now uses
 

--- a/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
+++ b/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
@@ -522,28 +522,56 @@ exists to prevent, inverted. Fixed by parametrizing over both initial states and
 asserting the flag returns to what it was, with the rendering re-derived rather than
 assumed. Both mutants now die.
 
-**2. The nullable-sort corpus built rows ingestion cannot produce.** One fixture gave
-`item_exchange` contracts non-NULL `buyout`, `reward` AND `days_to_complete` at once. ESI
-sends `buyout` only on auctions and `reward`/`days_to_complete` only on couriers, and
-`_build_contract_rows` maps each straight through, so no writer can populate both
-families on one row — a TEST-18 violation, in a test whose whole subject is what the
-reader sees.
+**2. The nullable-sort corpus was reworked — but the finding's premise was wrong, and
+round 2 caught that.** Round 1 objected that one fixture gave `item_exchange` contracts
+non-NULL `buyout`, `reward` AND `days_to_complete` at once, calling it a TEST-18
+violation on the grounds that ESI sends each family only on its own contract type. That
+rationale is **false**, and it was written into this report before anyone checked it.
 
-Splitting it surfaced something the original fixture had hidden: **no single contract
-type can carry all six nullable columns**, and the two families reach the joined path by
-*different levers*. Auctions are item-bearing, so `type_ids` forces the join. Couriers are
-item-less, so `type_ids` can never reach them — `search` is the only lever, and it works
-only because the item join is an OUTER join whose predicate ORs `Contract.title` against
-the item name. A single fixture could not have exercised both without lying about one.
+Round 2 checked it against the live public route (The Forge, pinned compatibility date,
+2026-08-09): **42/42 sampled auctions carried `reward` and `days_to_complete`** — as
+zero-valued placeholders — **16/16 couriers carried `price=0`**, and item exchanges
+carried nonzero `reward`. `_build_contract_rows` maps all three through with no type
+check, so a mixed-family row is a state the writer really can produce. ESI's schema
+descriptions ("for Couriers only") state *intent*, not payload presence.
 
-The exhaustiveness property survived the split: `test_the_two_joined_corpora_between_them_cover_every_nullable_sort`
-asserts the two hand-written tuples union to `NULLABLE_SORTS`, so a seventh nullable sort
-still fails loudly rather than being quietly uncovered.
+The split is **kept**, on its real merit rather than the stated one: one contract type
+and one join lever per corpus, which is what made the levers legible. And it was the
+split that surfaced the genuinely useful structural fact — the two families reach the
+joined path *differently*. Auctions are item-bearing, so `type_ids` forces the join.
+Couriers are item-less, so `type_ids` can never reach them; `search` is the only lever,
+and it works only because the item join is an OUTER join whose predicate ORs
+`Contract.title` against the item name.
 
-**A live seam this created.** The two courier cases depend on `search` implying the item
-join. If the open offered-only search decision changes `_needs_item_join`, they keep
-passing but silently relocate to the simple path — coverage lost with no failure. Stated
-in the test docstring so whoever takes that decision re-points them.
+**The corpus finding worth carrying: ESI sends zero placeholders, not absent fields.**
+Zero is not NULL and does not sort like it. So the NULL rows in these fixtures pin the
+SPARSE case, not the ordinary one — a genuinely absent `reward` is rarer in the live
+corpus than the schema wording implies. This also promotes a nice-to-have elsewhere from
+theoretical to live: frontend-logic **N-6** (`formatIsk(0)` → `'0'`, the courier price)
+describes real production rows, since 16/16 sampled couriers carried exactly that.
+
+**Correction to the seam recorded above.** The first draft claimed that dropping `search`
+from `_needs_item_join` would leave the courier cases passing while silently relocating
+to the simple path. Round 2 applied that exact edit: both cases **fail** with empty
+results, because the search predicate still names `ContractItem.type_name` and matches
+nothing for an item-less contract once the join is gone. The edit that *would* relocate
+them silently is the broader one — a search rewritten as a correlated EXISTS needs no
+join at all. The docstring now names that edit instead.
+
+The exhaustiveness property survived the split:
+`test_the_two_joined_corpora_between_them_cover_every_nullable_sort` asserts the two
+hand-written tuples union to `NULLABLE_SORTS`, mutation-verified by adding a seventh.
+
+**The process lesson, which is the more valuable half.** Round 1 produced two findings. I
+reproduced the mutant behind the first before fixing it, and it was real. I did **not**
+check the domain premise behind the second — I took "ESI sends X only on Y" on the
+reviewer's authority and wrote it into a persistent artifact as fact. It took a second
+round, and a live API sample, to falsify it. The handoff's rule that register prose is
+evidence rather than ground truth applies to REVIEWER prose identically, and an
+empirical claim about upstream payloads is exactly the kind that must be sampled rather
+than reasoned about (TEST-15: prove the instrument can see the thing before trusting what
+it reports). Two of the three wrong claims this campaign has recorded were assertions
+about what ESI sends.
 
 Backend **751 → 753** after the rework.
 

--- a/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
+++ b/docs/test-coverage-reports/2026-08-09-f008-remediation-test-coverage-review.md
@@ -392,7 +392,7 @@ four per-file registers as work orders.
 | 2 | Backend read correctness (13) | ✅ implemented — PR #166 (`Review — public API contract`, held for Sam: detail-id bounds ride along); three mutation kills verified |
 | 3 | Backend write correctness (11) + O2's backend partition pin | ⚠️ **10 of 11 closed** — PR #169 (`Routine`); backend 705 → 733, 24 regressions mutation-verified, all killed. C-11 is PARTIALLY closed: two of its three mocked-behavior hazards now run against real dependencies, the third needs a decision from Sam (see Wave 3 residual below). O2 closed at all three sites |
 | 4 | Frontend logic (28) + components (10) + e2e pins (O1a, O1b, null-price) | ✅ DONE — logic **28/28**, components **10/10**, e2e pins **3/3**. PR #170 (C1–C4, plus a typecheck lane for `e2e/` that had never existed) and PR #171 (C5–C10). vitest 322 → 416, e2e 140 → 146 |
-| 5 | Nice-to-have (60) | 🔄 **in progress** — swept first (§Wave 5 sweep): 60 register rows reduce to **58 distinct open items**, one struck, one cross-register duplicate merged, three partials narrowed. **Backend-read 10/10 closed** — 18 tests, backend 733 → 751, every one mutation-verified. Remaining: backend-write 18 (N-10 struck, N-11 partial), frontend-logic 13 (N-9, N-13 partial), frontend-components 17 (N-11 merged into frontend-logic N-11) |
+| 5 | Nice-to-have (60) | 🔄 **in progress** — swept first (§Wave 5 sweep): 60 register rows reduce to **58 distinct open items**, one struck, one cross-register duplicate merged, three partials narrowed. **Backend-read 10/10 closed** — 20 tests, backend 733 → 753, every one mutation-verified; two adversarial-review findings fixed. Remaining: backend-write 18 (N-10 struck, N-11 partial), frontend-logic 13 (N-9, N-13 partial), frontend-components 17 (N-11 merged into frontend-logic N-11) |
 
 Each wave: TDD where a fix changes code, mutation-verification for load-bearing new tests
 (TEST-12), footprint-free discipline on shared fixtures (TEST-23), five frontend lanes for any
@@ -471,14 +471,14 @@ suite held green, save the one documented overlap below.
 | Row | Closed by | Mutant killed |
 |---|---|---|
 | N-1 | `test_a_page_past_the_end_serves_an_empty_page_that_still_counts_the_corpus`, `..._of_the_joined_path_loads_from_an_empty_id_list` | short-circuiting on an empty PAGE rather than an empty RESULT; skipping the empty `IN` as a pointless filter |
-| N-2 | `test_the_joined_path_puts_nulls_last_whichever_way_every_nullable_sort_runs` (parametrized over `NULLABLE_SORTS`) | `nulls_last()` deleted from `_fetch_page_joined` |
+| N-2 | `test_the_joined_path_puts_nulls_last_for_the_item_bearing_sorts` / `..._for_the_courier_only_sorts` / `test_the_two_joined_corpora_between_them_cover_every_nullable_sort` | `nulls_last()` deleted from `_fetch_page_joined`; `buyout` dropped from `NULLABLE_SORTS` (kills only the buyout case, which is what per-sort coverage buys); a seventh nullable sort added without a corpus |
 | N-3 | `test_composition_reports_an_unmeasured_volume_as_null_not_zero` | NULL volume coalesced to `0` |
 | N-4 | `test_a_courier_with_no_destination_name_is_labelled_courier_alone`, `test_a_contract_with_nothing_to_name_it_by_falls_back_to_its_id` | the courier arm rewritten to the id fallback; the id fallback retexted |
 | N-5 | `test_a_whitespace_only_title_counts_as_absent` | `.strip()` dropped from the title guard |
 | N-6 | `test_detail_returns_its_items_in_record_id_order` | the detail sort deleted |
 | N-7 | `test_taxonomy_breaks_a_name_tie_by_id_so_the_order_is_total` | the id element dropped from each sort key (verified separately per list) |
 | N-8 | `test_a_stale_enrichment_settles_coverage_without_the_category_sweep` | the two coverage conditions reordered |
-| N-9 | `test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it` | the `finally` restore removed |
+| N-9 | `test_scrubbing_an_error_for_the_log_leaves_the_exception_as_it_found_it` (parametrized over both initial `hide_parameters` states) | the `finally` restore removed; the restore hardcoded to `False` |
 | N-10 | `test_detail_still_serves_a_delisted_but_unexpired_contract`, `test_min_runs_admits_the_esi_sentinel_and_rejects_one_below_it` | `still_listed_by_esi()` added to the detail query; `ge=-1` narrowed to `ge=0` |
 
 **One mutation could not be isolated further, and that is the finding.** Deleting
@@ -505,6 +505,47 @@ evidence", and the exception is a branch that was already partially covered.
 **Fixture regions:** 99999977 and 99999978 claimed. Next free **99999979**, which is the
 LAST id in the plan's 99999960–99999979 allocation — the next wave to need one must
 either extend the allocation or reuse, and should say which.
+
+#### Adversarial review of this work — two findings, both real, both fixed
+
+The edit framing produced two findings on the first round, and both were the kind the
+rule is meant to surface: reachable from the production code alone, carrying nothing that
+could only have come from the tests.
+
+**1. N-9 was not actually closed.** The test initialized `hide_parameters` only to
+`False`, so the mutant `finally: exc.hide_parameters = False` — the obvious
+simplification of a save/restore pair — survived the whole 751-test suite. The case it
+misses is the *common* one: the application engine sets `hide_parameters=True` (`db.py`),
+so an engine-raised error arrives already hidden, and a restore hardcoded to `False`
+would UNHIDE its binds on every later rendering. That is the precise leak the function
+exists to prevent, inverted. Fixed by parametrizing over both initial states and
+asserting the flag returns to what it was, with the rendering re-derived rather than
+assumed. Both mutants now die.
+
+**2. The nullable-sort corpus built rows ingestion cannot produce.** One fixture gave
+`item_exchange` contracts non-NULL `buyout`, `reward` AND `days_to_complete` at once. ESI
+sends `buyout` only on auctions and `reward`/`days_to_complete` only on couriers, and
+`_build_contract_rows` maps each straight through, so no writer can populate both
+families on one row — a TEST-18 violation, in a test whose whole subject is what the
+reader sees.
+
+Splitting it surfaced something the original fixture had hidden: **no single contract
+type can carry all six nullable columns**, and the two families reach the joined path by
+*different levers*. Auctions are item-bearing, so `type_ids` forces the join. Couriers are
+item-less, so `type_ids` can never reach them — `search` is the only lever, and it works
+only because the item join is an OUTER join whose predicate ORs `Contract.title` against
+the item name. A single fixture could not have exercised both without lying about one.
+
+The exhaustiveness property survived the split: `test_the_two_joined_corpora_between_them_cover_every_nullable_sort`
+asserts the two hand-written tuples union to `NULLABLE_SORTS`, so a seventh nullable sort
+still fails loudly rather than being quietly uncovered.
+
+**A live seam this created.** The two courier cases depend on `search` implying the item
+join. If the open offered-only search decision changes `_needs_item_join`, they keep
+passing but silently relocate to the simple path — coverage lost with no failure. Stated
+in the test docstring so whoever takes that decision re-points them.
+
+Backend **751 → 753** after the rework.
 
 ### Wave 4 — register row 23, and the standard the campaign now uses
 


### PR DESCRIPTION
Wave 5 of the coverage campaign starts with the sweep the handoff mandated, then closes the backend-read nice-to-have register end to end.

## The sweep came first

Waves 3-4 closed several nice-to-haves incidentally, and re-testing them is the main way this wave wastes effort. Every claim was verified against the suite at `7486df5` rather than taken from register prose.

- **Struck:** backend-write **N-10**, closed *more strongly than the row asked* — it wanted a courier-only run, and Wave 3's test is parametrized over the whole `ContractType` enum.
- **Narrowed three partials**, one of which the wave table did not know about: **frontend-logic N-13**'s two `useDebouncedValue` halves were closed by Wave 4, leaving only the `raiseApiError` non-401 assertion. Gaps clustered in a module with *no test file at all* collapse together the moment anyone creates the file.
- **Merged a duplicate:** frontend-logic N-11 and frontend-components N-11 are the same `columns.tsx:141-143` fork, registered from opposite sides of the two reviewers' scope boundary. One test closes both.
- **Third register erratum:** `hasOfferedItemFilters` is *not* a dead export — `FilterRail.tsx:48` calls it. That distinction decides whether the row means "delete production code" (needs Sam's approval) or "write a test" (Routine).

60 register rows reduce to **58 distinct open items**.

Three rows are flagged as not-test-work rather than silently dropped: N-8's function-local batch-size literals (a production hoist), N-11's unreachable fallback label (a decision), and the mobile live-smoke project (a config lane).

## Backend-read register: 10/10 closed

18 tests, backend **733 -> 751**. Per-row mutant table is in the report. Highlights:

- **N-1** reached the joined path through `sort_by=ship_name` rather than `search`, so it does not depend on the still-open offered-only search semantics (D-a).
- **N-2** is parametrized over `NULLABLE_SORTS` itself, so a seventh nullable sort is covered when it joins the frozenset.
- **N-9** observes the restored `hide_parameters` by *re-rendering the exception*, not by reading the flag — the exception is re-raised and outlives the log site.
- **N-10**'s min_runs boundary is asserted as a PAIR (-1 admitted, -2 refused); a one-sided assertion is satisfied by any bound at or below -1, including none.

**One mutation could not be isolated, and that is the finding.** Deleting `nulls_last()` from `_fetch_page_joined` kills the six new cases *and* `test_a_new_sort_survives_the_grouped_joined_pagination_path` — the prior coverage the register counted as "2 of 6". The branch is one shared line, so no narrower edit exists. Recorded rather than papered over.

**Two fixture defects caught during authoring**, both generalizable and written into the report:
- A helper calling `datetime.now()` per row silently delisted every row but the last. `still_listed_by_esi` is an exact `>=` against the region max with no tolerance, and ingestion stamps one run's whole batch with ONE value — so co-listed fixture rows must share an identical stamp. TEST-18's rule applied to a timestamp rather than a column.
- Giving two rows the same `volume` tied the volume sort into the `contract_id` tiebreaker, so both directions returned ascending order. Caught only because the assertion reads the **full ordered list**; "the NULL row is last" would have passed.

## Verification

- backend `pytest`: **751 passed** (733 baseline + 18)
- backend `pdm run lint`: clean
- Frontend untouched by this PR; baseline re-confirmed green at branch point (eslint, `tsc -b`, vitest 416 x2 lanes, e2e 146).
- Every new test mutation-verified per TEST-12, restore in `finally`, `git status` checked clean after each run.

Fixture regions 99999977-99999978 claimed. **99999979 is the last free id** in the 99999960-99999979 allocation.

## Merge classification

`Routine` — test-only plus the living coverage report. No schema, no migration, no public API contract change, no auth or data-integrity path.


---

## Adversarial review — two rounds, four findings, all real

**Round 1 (2 findings, both fixed):**

1. **Significant — N-9 was not actually closed.** The test initialized `hide_parameters` only to `False`, so `finally: exc.hide_parameters = False` — the obvious simplification of a save/restore pair — survived all 751 tests. The missed case is the *common* one: the application engine sets `hide_parameters=True`, so an engine-raised error arrives already hidden, and a restore hardcoded to `False` would **unhide** its binds on every later rendering. Fixed by parametrizing over both initial states.
2. **Moderate — the nullable-sort fixture.** Reworked into two corpora (see round 2, which corrected the reasoning).

**Round 2 (verified both fixes kill their mutants; 2 new findings, both about my prose, both fixed):**

1. **Significant — the rationale I recorded for the split was factually wrong, and I had written it into a persistent artifact as fact.** Round 1 claimed ESI sends `buyout` only on auctions and `reward`/`days_to_complete` only on couriers. Round 2 **sampled the live public route** (The Forge, pinned compatibility date): 42/42 auctions carried `reward` and `days_to_complete` as zero placeholders, 16/16 couriers carried `price=0`, item exchanges carried nonzero `reward`. `_build_contract_rows` maps all three with no type check. The schema's "for Couriers only" states intent, not payload presence. The split is **kept on its real merit** — one type and one join lever per corpus — not the stated one.
2. **Minor — the seam note named the wrong edit.** I claimed dropping `search` from `_needs_item_join` would silently relocate the courier cases to the simple path. Round 2 applied exactly that edit: both **fail** with empty results, because the predicate still names `ContractItem.type_name`. The edit that *would* relocate them silently is a correlated-EXISTS search rewrite; the docstring now names that.

Round 2's verified list: hardcoded-`False` mutant killed by the `True` case; deleted joined-path `nulls_last()` kills all six cases; a seventh `NULLABLE_SORTS` entry fails the exhaustiveness test; worktree clean.

**Round 3 skipped, per the OD5 precedent.** The final rework is comment- and doc-only — no test logic, no production logic — and its content was dictated by round 2's own findings. Full suite re-run after it: **753 passed**, lint clean.

## Two findings worth carrying beyond this PR

- **ESI sends zero placeholders, not absent fields.** Zero is not NULL and does not sort like it, so the NULL rows in these fixtures pin the *sparse* case rather than the ordinary one. This also promotes frontend-logic **N-6** (`formatIsk(0)` → `'0'` for a courier price) from theoretical to live — 16/16 sampled couriers carry exactly that.
- **Reviewer prose is evidence, not ground truth.** I reproduced the mutant behind round 1's first finding before fixing it; I did not check the domain premise behind its second, and wrote it down as fact. The handoff's rule for register prose applies to review findings identically — and an empirical claim about upstream payloads has to be *sampled*, not reasoned about. Two of the three wrong claims this campaign has recorded were assertions about what ESI sends.
