### PR TITLE
test(api): Wave 5 backend-write nice-to-haves, 9 of 18

### DIFF
--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2515,6 +2515,15 @@ async def test_every_mapped_contract_field_lands_on_its_own_column(
     service = _make_service()
     payload = _ship_contract_dict(920101)
     payload.update({
+        # The identifiers, each a different number, so a key swapped for its
+        # neighbour is visible. `type` belongs here as much as any of them: it is
+        # read straight off the payload beside `status`, and the two are adjacent
+        # string keys — the plainest copy/paste there is.
+        "type": "auction",
+        "issuer_id": 771,
+        "issuer_corporation_id": 772,
+        "start_location_id": 60003760,
+        "end_location_id": 60003761,
         "status": "outstanding",
         "title": "Distinctly Titled Lot",
         "for_corporation": True,
@@ -2538,6 +2547,16 @@ async def test_every_mapped_contract_field_lands_on_its_own_column(
             select(Contract).where(Contract.contract_id == 920101)
         )
     ).scalar_one()
+    # `type` first, because it is the field with the widest blast radius: it drives
+    # the segment counts, the ingestion item-fetch partition and watchlist
+    # eligibility, and a wrong value is invisible to all of them at write time
+    # because each of those reads the SOURCE payload rather than the stored row.
+    assert row.type == "auction"
+    assert row.issuer_id == 771
+    assert row.issuer_corporation_id == 772
+    assert row.start_location_id == 60003760
+    assert row.end_location_id == 60003761
+    assert row.start_location_region_id == 10000002  # stamped by the fetch loop
     assert row.status == "outstanding"
     assert row.title == "Distinctly Titled Lot"
     assert row.for_corporation is True
@@ -2611,7 +2630,9 @@ async def test_a_populated_date_completed_is_parsed_and_an_absent_one_is_null(
     )
 
 
-async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it():
+async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it(
+    db_session: AsyncSession,
+):
     """CHARACTERIZATION, not endorsement: one bad date string kills every contract beside it.
 
     `_parse_esi_datetime` calls `datetime.fromisoformat` with no guard, from inside the
@@ -2622,28 +2643,48 @@ async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it():
     contract fetched that cycle. That is the hazard shape a NOT NULL `price` already
     demonstrated in production (TEST-22 / FASTAPI-3).
 
-    Observed at `_build_contract_rows` rather than through `_process_contracts` because
-    the batch semantics live in the comprehension: asserting here shows NO rows are
-    produced at all, which is the property. Note the limit of that choice — the raise
-    happens before any upsert, so nothing is written and no transaction is poisoned;
-    and a refactor that built and wrote per contract would change the persistence blast
-    radius without failing this test.
+    Observed at `_process_contracts`, the layer that DEFINES the blast radius, and
+    asserted on what persisted: the healthy sibling must be absent. Observing at
+    `_build_contract_rows` instead would pin only that the comprehension raises, which a
+    refactor building and writing per contract would still satisfy while no longer
+    losing the batch — the survivor is the whole point of the row, so the test has to
+    stand where the behavior is decided.
+
+    The session stays usable afterwards because the `ValueError` is raised while
+    building rows in memory, before any statement is issued — nothing is written and no
+    transaction is poisoned.
 
     Pinned so the behavior is visible and any change to it is deliberate. Whether it
     SHOULD abort is a decision, not a defect to fix inside a test-only wave — skipping
     the contract and persisting a NULL date both change what the site shows. Recorded
     for Sam in the coverage report.
     """
+    service = _make_service()
     good = _ship_contract_dict(920105)
     bad = _ship_contract_dict(920106)
     bad["date_issued"] = "not-a-date"
 
-    # The healthy sibling alone builds fine, so the batch below fails for the reason
+    # The healthy sibling persists on its own, so the batch below fails for the reason
     # named and not because the fixture was malformed all along (TEST-12 vacuity guard).
-    assert len(bg_agg._build_contract_rows([good], {})) == 1
+    await service._process_contracts(db_session, [_ship_contract_dict(920111)])
+    assert (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 920111)
+        )
+    ).scalar_one_or_none() is not None
 
     with pytest.raises(ValueError):
-        bg_agg._build_contract_rows([good, bad], {})
+        await service._process_contracts(db_session, [good, bad])
+
+    # The blast radius: the healthy contract in the same call did not land either.
+    survivors = (
+        await db_session.execute(
+            select(Contract.contract_id).where(
+                Contract.contract_id.in_([920105, 920106])
+            )
+        )
+    ).scalars().all()
+    assert survivors == []
 
 
 async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSession):
@@ -2724,7 +2765,10 @@ async def test_apply_dev_limit_passes_through_a_batch_at_or_under_the_limit(
     limited = service._apply_dev_limit(batch)
 
     assert [c["contract_id"] for c in limited] == [920108, 920109, 920110]
-    assert "DEV_MODE" not in caplog.text
+    # No WARNING at all, rather than "no line containing DEV_MODE". The claim is that a
+    # limit which does not fire is silent; excluding one marker string leaves every
+    # other warning text free to appear in dev logs on every run forever.
+    assert [r.getMessage() for r in caplog.records if r.levelname == "WARNING"] == []
 
 
 async def test_freshness_recorder_treats_an_unparseable_prior_as_no_prior(

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2630,8 +2630,11 @@ async def test_a_populated_date_completed_is_parsed_and_an_absent_one_is_null(
     )
 
 
+@pytest.mark.parametrize(
+    "date_field", ["date_issued", "date_expired", "date_completed"]
+)
 async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it(
-    db_session: AsyncSession,
+    db_session: AsyncSession, date_field: str
 ):
     """CHARACTERIZATION, not endorsement: one bad date string kills every contract beside it.
 
@@ -2654,6 +2657,14 @@ async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it(
     building rows in memory, before any statement is issued — nothing is written and no
     transaction is poisoned.
 
+    Parametrized over ALL THREE parsed date fields, because "anywhere" is the claim and
+    the three are independent mapping expressions. Two are required (`c["date_issued"]`,
+    `c["date_expired"]`) and one is optional (`c.get("date_completed")`) — and that
+    distinction is exactly the seam a tolerant-parsing edit would follow: making only the
+    optional field degrade to None leaves both required-field cases aborting as before,
+    so a test that corrupts only `date_issued` would never notice that a malformed
+    completion date had stopped costing the batch.
+
     Pinned so the behavior is visible and any change to it is deliberate. Whether it
     SHOULD abort is a decision, not a defect to fix inside a test-only wave — skipping
     the contract and persisting a NULL date both change what the site shows. Recorded
@@ -2662,7 +2673,7 @@ async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it(
     service = _make_service()
     good = _ship_contract_dict(920105)
     bad = _ship_contract_dict(920106)
-    bad["date_issued"] = "not-a-date"
+    bad[date_field] = "not-a-date"
 
     # The healthy sibling persists on its own, so the batch below fails for the reason
     # named and not because the fixture was malformed all along (TEST-12 vacuity guard).

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2661,13 +2661,18 @@ async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSess
         return_value=[
             # Neither flag supplied: the shape ESI sends for an ordinary packaged item.
             {"record_id": 9201071, "type_id": 587, "quantity": 1, "is_included": True},
-            # Both supplied, and is_singleton TRUE — an assembled item. Public contract
-            # payloads never carry the flag, so without this row the default and a
-            # hardcoded False are indistinguishable: the mapping could ignore a
-            # supplied value entirely and every fixture would still agree with it.
+            # The two flags DISAGREE in both directions, across two rows. Supplying
+            # them together and both true makes them indistinguishable: reading
+            # is_singleton out of `is_blueprint_copy` — an ordinary copy/paste between
+            # adjacent boolean keys — then satisfies every assertion. Each row pins one
+            # flag as set while the other is absent.
             {
                 "record_id": 9201072, "type_id": 588, "quantity": 1,
-                "is_included": True, "is_singleton": True, "is_blueprint_copy": True,
+                "is_included": True, "is_singleton": True,
+            },
+            {
+                "record_id": 9201073, "type_id": 589, "quantity": 1,
+                "is_included": True, "is_blueprint_copy": True,
             },
         ]
     )
@@ -2679,15 +2684,20 @@ async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSess
         for item in (
             await db_session.execute(
                 select(ContractItem).where(
-                    ContractItem.record_id.in_([9201071, 9201072])
+                    ContractItem.record_id.in_([9201071, 9201072, 9201073])
                 )
             )
         ).scalars()
     }
+    # Neither supplied.
     assert items[9201071].is_blueprint_copy is None, "absent must not become False"
     assert items[9201071].is_singleton is False, "the documented default did not apply"
-    assert items[9201072].is_blueprint_copy is True, "a supplied flag was not carried"
-    assert items[9201072].is_singleton is True, "a supplied flag was overridden"
+    # Only is_singleton supplied — so a mapping reading it from the blueprint key fails.
+    assert items[9201072].is_singleton is True, "a supplied singleton flag was overridden"
+    assert items[9201072].is_blueprint_copy is None, "the blueprint flag leaked from singleton"
+    # Only is_blueprint_copy supplied — the mirror.
+    assert items[9201073].is_blueprint_copy is True, "a supplied blueprint flag was dropped"
+    assert items[9201073].is_singleton is False, "the singleton flag leaked from blueprint"
 
 
 @pytest.mark.parametrize("limit", [5, 3], ids=["limit_above_batch", "limit_equals_batch"])

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2479,3 +2479,192 @@ async def test_a_spec_minimal_contract_persists_with_absent_optionals_null_or_de
     assert row.days_to_complete is None
     assert row.start_location_id is None
     assert row.end_location_id is None
+
+
+# --- Field mapping, optional-date parsing, and the two guards nothing reads ---
+
+
+async def test_every_mapped_contract_field_lands_on_its_own_column(
+    db_session: AsyncSession,
+):
+    """One payload, DISTINCT values in every mapped field, asserted per column.
+
+    The mapping is a flat dict literal, which is exactly the shape where a
+    copy-paste swaps two keys and nothing notices: `reward` and `volume` are both
+    plain floats read straight off the payload, so exchanging them produces a row
+    that is internally consistent, passes every schema check, and quietly reverses
+    the reward-per-m3 sort the whole courier surface is built on.
+
+    Every value here is distinct from every other, including across TYPES, because a
+    swap is only observable when the two fields disagree. The `status` default and a
+    supplied `status` are separate tests below for the same reason — one payload
+    cannot exercise both arms of the same `.get`.
+    """
+    service = _make_service()
+    payload = _ship_contract_dict(920101)
+    payload.update({
+        "status": "outstanding",
+        "title": "Distinctly Titled Lot",
+        "for_corporation": True,
+        "collateral": 4_400_000.0,
+        "reward": 1_100_000.0,
+        "volume": 2_200.0,
+        "buyout": 3_300_000.0,
+        "days_to_complete": 6,
+        "price": 5_500_000.0,
+    })
+
+    await service._process_contracts(db_session, [payload])
+
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 920101)
+        )
+    ).scalar_one()
+    assert row.status == "outstanding"
+    assert row.title == "Distinctly Titled Lot"
+    assert row.for_corporation is True
+    assert float(row.collateral) == 4_400_000.0
+    assert float(row.reward) == 1_100_000.0
+    assert float(row.volume) == 2_200.0
+    assert float(row.buyout) == 3_300_000.0
+    assert row.days_to_complete == 6
+    assert float(row.price) == 5_500_000.0
+    # The two dates are parsed, not merely copied, and they are the pair a swap would
+    # leave looking plausible — an expiry before its issue date is the tell.
+    assert row.date_issued == datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert row.date_expired > row.date_issued
+
+
+async def test_an_absent_status_persists_as_unknown(db_session: AsyncSession):
+    """ESI marks `status` optional on the public route and the column is NOT NULL.
+
+    The default is what stands between a status-less contract and an IntegrityError
+    that aborts the whole batch — the TEST-22 shape, which `price` already paid for.
+    """
+    service = _make_service()
+    payload = _ship_contract_dict(920102)
+    payload.pop("status", None)
+
+    await service._process_contracts(db_session, [payload])
+
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 920102)
+        )
+    ).scalar_one()
+    assert row.status == "unknown"
+
+
+async def test_a_populated_date_completed_is_parsed_and_an_absent_one_is_null(
+    db_session: AsyncSession,
+):
+    """`_parse_esi_datetime`'s None arm runs on every public contract and is unasserted.
+
+    `date_completed` is the only optional DATE in the mapping, so it is the only field
+    that exercises the None arm at all — every other date is required. The populated
+    arm never runs against public data (ESI does not send it there) but does for the
+    character/corp contracts the column is kept for, so both are pinned here rather
+    than one being left to a future reader to guess at.
+
+    Both arms in one test because they are two arms of ONE `.get`, and asserting them
+    separately would let a mapping that always returns None pass the absent case while
+    the populated case was written for a different contract id.
+    """
+    service = _make_service()
+    absent = _ship_contract_dict(920103)
+    populated = _ship_contract_dict(920104)
+    populated["date_completed"] = "2026-07-05T12:30:00Z"
+
+    await service._process_contracts(db_session, [absent, populated])
+
+    rows = {
+        row.contract_id: row
+        for row in (
+            await db_session.execute(
+                select(Contract).where(Contract.contract_id.in_([920103, 920104]))
+            )
+        ).scalars()
+    }
+    assert rows[920103].date_completed is None
+    assert rows[920104].date_completed == datetime(
+        2026, 7, 5, 12, 30, tzinfo=timezone.utc
+    )
+
+
+async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it():
+    """CHARACTERIZATION, not endorsement: one bad date string kills every contract beside it.
+
+    `_parse_esi_datetime` calls `datetime.fromisoformat` with no guard, from inside the
+    list comprehension that builds rows for the ENTIRE batch, so one malformed date
+    takes down every other contract on the same region page — the blast radius that
+    made a NOT NULL `price` a production hazard (TEST-22 / FASTAPI-3).
+
+    Observed at `_build_contract_rows` rather than through `_process_contracts`: the
+    batch semantics live in the comprehension, and asserting there shows that NO rows
+    are produced, not merely that a write failed. Going through the session would only
+    show a poisoned transaction, which is a consequence rather than the property.
+
+    Pinned so the behavior is visible and any change to it is deliberate. Whether it
+    SHOULD abort is a decision, not a defect to fix inside a test-only wave — skipping
+    the contract and persisting a NULL date both change what the site shows. Recorded
+    for Sam in the coverage report.
+    """
+    good = _ship_contract_dict(920105)
+    bad = _ship_contract_dict(920106)
+    bad["date_issued"] = "not-a-date"
+
+    # The healthy sibling alone builds fine, so the batch below fails for the reason
+    # named and not because the fixture was malformed all along (TEST-12 vacuity guard).
+    assert len(bg_agg._build_contract_rows([good], {})) == 1
+
+    with pytest.raises(ValueError):
+        bg_agg._build_contract_rows([good, bad], {})
+
+
+async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSession):
+    """ESI sends `is_blueprint_copy` true-or-ABSENT, never false (TEST-18).
+
+    So the absent arm is the ordinary case for every non-blueprint item in the corpus,
+    and it must persist as NULL rather than False: `is_bpc=false` compiles to "contains
+    no offered blueprint copy", and a mapping that defaulted the flag to False would
+    make that filter agree with itself while saying nothing about the data.
+    `is_singleton` is the opposite convention — a real `.get(..., False)` default — so
+    the two are asserted together to keep the distinction visible.
+    """
+    service = _make_service()
+    service.esi_client.get_contract_items = AsyncMock(
+        return_value=[
+            # Neither flag supplied: the shape ESI sends for an ordinary packaged item.
+            {"record_id": 9201071, "type_id": 587, "quantity": 1, "is_included": True},
+        ]
+    )
+
+    await service._process_contracts(db_session, [_ship_contract_dict(920107)])
+
+    item = (
+        await db_session.execute(
+            select(ContractItem).where(ContractItem.record_id == 9201071)
+        )
+    ).scalar_one()
+    assert item.is_blueprint_copy is None, "absent must not become False"
+    assert item.is_singleton is False, "the documented default did not apply"
+
+
+async def test_apply_dev_limit_passes_through_a_batch_under_the_limit(caplog):
+    """A configured limit larger than the batch truncates nothing and warns nothing.
+
+    The three tested paths are limit<len, 0 and None; this is the fourth corner, and
+    the only one where the limit is ACTIVE but does not fire. It is also the one a
+    developer actually runs into — a limit set generously enough to keep working — so
+    a spurious DEV_MODE warning here would be permanent noise in every dev log.
+    """
+    caplog.set_level("WARNING")
+    service = _make_service()
+    service.settings.AGGREGATION_DEV_CONTRACT_LIMIT = 5
+    batch = [_ship_contract_dict(cid) for cid in (920108, 920109, 920110)]
+
+    limited = service._apply_dev_limit(batch)
+
+    assert [c["contract_id"] for c in limited] == [920108, 920109, 920110]
+    assert "DEV_MODE" not in caplog.text

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2449,6 +2449,12 @@ async def test_a_spec_minimal_contract_persists_with_absent_optionals_null_or_de
     from datetime import datetime, timedelta, timezone
 
     service = _make_service()
+    # Armed with a WORKING return precisely so the not-awaited assertion below is
+    # meaningful: an unarmed MagicMock could never be awaited, which would satisfy
+    # the assertion for a reason that has nothing to do with the guard (TEST-15).
+    service.esi_client.get_universe_station = AsyncMock(
+        return_value={"station_id": 60003760, "system_id": 30000142}
+    )
     live_expiry = datetime.now(timezone.utc) + timedelta(days=7)
     spec_minimal = {
         "contract_id": 910099,
@@ -2479,6 +2485,12 @@ async def test_a_spec_minimal_contract_persists_with_absent_optionals_null_or_de
     assert row.days_to_complete is None
     assert row.start_location_id is None
     assert row.end_location_id is None
+    # And the absence COSTS nothing upstream: `_npc_station_ids` guards on
+    # `is not None`, so a contract naming no location must produce no station
+    # lookup at all. Without the guard every location-less contract in a page
+    # would send ESI a request for station `None` — a per-row round trip whose
+    # only possible answer is an error, on the most common shape in the corpus.
+    service.esi_client.get_universe_station.assert_not_awaited()
 
 
 # --- Field mapping, optional-date parsing, and the two guards nothing reads ---
@@ -2668,3 +2680,38 @@ async def test_apply_dev_limit_passes_through_a_batch_under_the_limit(caplog):
 
     assert [c["contract_id"] for c in limited] == [920108, 920109, 920110]
     assert "DEV_MODE" not in caplog.text
+
+
+async def test_freshness_recorder_treats_an_unparseable_prior_as_no_prior(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A prior record that is not JSON at all is a distinct branch from one that is
+    valid JSON but not an object, and only the latter has a test.
+
+    `json.loads` raises for the unparseable case and returns cleanly for `"[]"`, so the
+    two arrive at `prior_success = None` by different routes — one through the
+    `except (ValueError, TypeError)`, one through the `isinstance` check. Narrowing that
+    except clause (dropping `ValueError` is the natural half, since `TypeError` is what
+    a non-str would raise) lets the exception escape to the OUTER swallow, which logs
+    "failed to record ingest outcome" and skips the SET entirely — so the corrupt key is
+    never repaired and every future run re-reads the same garbage.
+
+    Observed on a FAILING run on purpose: `last_success_at` only reports the prior value
+    when the current outcome is not itself a success, so a passing run would overwrite
+    it with `now` and hide which branch produced it (TEST-25).
+    """
+    service = _freshness_service([10000002])
+    service.esi_client.get_public_contracts = AsyncMock(
+        side_effect=RuntimeError("region fetch down")
+    )
+
+    store: dict = {INGEST_KEY: "not json at all"}
+    with patch.object(bg_agg.aioredis, "from_url", return_value=_FakeLockRedis(store)):
+        await service.run_aggregation()
+
+    # The key was REPAIRED, not left holding the garbage it started with.
+    record = json.loads(store[INGEST_KEY])
+    assert record["outcome"] == "failure"
+    # No prior success could be recovered from an unparseable record, and inventing
+    # one would report the site as fresher than it is.
+    assert record["last_success_at"] is None

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2524,6 +2524,11 @@ async def test_every_mapped_contract_field_lands_on_its_own_column(
         "buyout": 3_300_000.0,
         "days_to_complete": 6,
         "price": 5_500_000.0,
+        # Pinned rather than clock-relative, because this assertion is about the
+        # MAPPING and needs an exact expected value. The row is never read back
+        # through the list endpoint here, so the TEST-17 liveness concern that makes
+        # other fixtures relative does not apply.
+        "date_expired": "2027-02-03T04:05:06Z",
     })
 
     await service._process_contracts(db_session, [payload])
@@ -2542,10 +2547,12 @@ async def test_every_mapped_contract_field_lands_on_its_own_column(
     assert float(row.buyout) == 3_300_000.0
     assert row.days_to_complete == 6
     assert float(row.price) == 5_500_000.0
-    # The two dates are parsed, not merely copied, and they are the pair a swap would
-    # leave looking plausible — an expiry before its issue date is the tell.
+    # Both dates asserted as EXACT values, not as a relation between them. "expiry is
+    # after issue" is a digest: it holds for any constant far enough in the future, so
+    # a mapping that replaced every expiry with a fixed date would satisfy it while
+    # storing the same instant for the whole corpus (TEST-25).
     assert row.date_issued == datetime(2026, 7, 1, tzinfo=timezone.utc)
-    assert row.date_expired > row.date_issued
+    assert row.date_expired == datetime(2027, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
 
 
 async def test_an_absent_status_persists_as_unknown(db_session: AsyncSession):
@@ -2608,14 +2615,19 @@ async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it():
     """CHARACTERIZATION, not endorsement: one bad date string kills every contract beside it.
 
     `_parse_esi_datetime` calls `datetime.fromisoformat` with no guard, from inside the
-    list comprehension that builds rows for the ENTIRE batch, so one malformed date
-    takes down every other contract on the same region page — the blast radius that
-    made a NOT NULL `price` a production hazard (TEST-22 / FASTAPI-3).
+    list comprehension that builds rows for the ENTIRE batch. `run_aggregation`
+    concatenates every page of every configured region before calling
+    `_process_contracts` once, so the blast radius is **the whole aggregation run**, not
+    one region page — one malformed date string anywhere in the corpus discards every
+    contract fetched that cycle. That is the hazard shape a NOT NULL `price` already
+    demonstrated in production (TEST-22 / FASTAPI-3).
 
-    Observed at `_build_contract_rows` rather than through `_process_contracts`: the
-    batch semantics live in the comprehension, and asserting there shows that NO rows
-    are produced, not merely that a write failed. Going through the session would only
-    show a poisoned transaction, which is a consequence rather than the property.
+    Observed at `_build_contract_rows` rather than through `_process_contracts` because
+    the batch semantics live in the comprehension: asserting here shows NO rows are
+    produced at all, which is the property. Note the limit of that choice — the raise
+    happens before any upsert, so nothing is written and no transaction is poisoned;
+    and a refactor that built and wrote per contract would change the persistence blast
+    radius without failing this test.
 
     Pinned so the behavior is visible and any change to it is deliberate. Whether it
     SHOULD abort is a decision, not a defect to fix inside a test-only wave — skipping
@@ -2649,31 +2661,54 @@ async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSess
         return_value=[
             # Neither flag supplied: the shape ESI sends for an ordinary packaged item.
             {"record_id": 9201071, "type_id": 587, "quantity": 1, "is_included": True},
+            # Both supplied, and is_singleton TRUE — an assembled item. Public contract
+            # payloads never carry the flag, so without this row the default and a
+            # hardcoded False are indistinguishable: the mapping could ignore a
+            # supplied value entirely and every fixture would still agree with it.
+            {
+                "record_id": 9201072, "type_id": 588, "quantity": 1,
+                "is_included": True, "is_singleton": True, "is_blueprint_copy": True,
+            },
         ]
     )
 
     await service._process_contracts(db_session, [_ship_contract_dict(920107)])
 
-    item = (
-        await db_session.execute(
-            select(ContractItem).where(ContractItem.record_id == 9201071)
-        )
-    ).scalar_one()
-    assert item.is_blueprint_copy is None, "absent must not become False"
-    assert item.is_singleton is False, "the documented default did not apply"
+    items = {
+        item.record_id: item
+        for item in (
+            await db_session.execute(
+                select(ContractItem).where(
+                    ContractItem.record_id.in_([9201071, 9201072])
+                )
+            )
+        ).scalars()
+    }
+    assert items[9201071].is_blueprint_copy is None, "absent must not become False"
+    assert items[9201071].is_singleton is False, "the documented default did not apply"
+    assert items[9201072].is_blueprint_copy is True, "a supplied flag was not carried"
+    assert items[9201072].is_singleton is True, "a supplied flag was overridden"
 
 
-async def test_apply_dev_limit_passes_through_a_batch_under_the_limit(caplog):
-    """A configured limit larger than the batch truncates nothing and warns nothing.
+@pytest.mark.parametrize("limit", [5, 3], ids=["limit_above_batch", "limit_equals_batch"])
+async def test_apply_dev_limit_passes_through_a_batch_at_or_under_the_limit(
+    caplog, limit: int
+):
+    """A configured limit the batch does not EXCEED truncates nothing and warns nothing.
 
     The three tested paths are limit<len, 0 and None; this is the fourth corner, and
     the only one where the limit is ACTIVE but does not fire. It is also the one a
     developer actually runs into — a limit set generously enough to keep working — so
     a spurious DEV_MODE warning here would be permanent noise in every dev log.
+
+    Both sides of the comparison are parametrized because the guard is `>` and the row
+    it closes says `<=`: with only the strictly-under case, flipping `>` to `>=` warns
+    and truncates at exactly the limit while every test still passes. An off-by-one on
+    a real boundary is the plainest kind of surviving edit there is.
     """
     caplog.set_level("WARNING")
     service = _make_service()
-    service.settings.AGGREGATION_DEV_CONTRACT_LIMIT = 5
+    service.settings.AGGREGATION_DEV_CONTRACT_LIMIT = limit
     batch = [_ship_contract_dict(cid) for cid in (920108, 920109, 920110)]
 
     limited = service._apply_dev_limit(batch)

--- a/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
+++ b/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
@@ -225,8 +225,12 @@ async def test_every_preserved_column_still_overwrites_on_a_non_null_value(
     that never updates is worse than one that blanks, because nothing looks wrong: the
     site keeps serving a pilot's old corporation forever.
 
-    Parametrized over `NAME_COLUMNS_PRESERVED_ON_NULL` itself rather than a hand-listed
-    four, so a fifth member is covered the moment it joins the frozenset.
+    Parametrized over `NAME_COLUMNS_PRESERVED_ON_NULL` so every current member is
+    exercised — but that alone cannot police the SET, only its members: adding a column
+    to the production set adds a parametrization that passes trivially, because COALESCE
+    always lets a non-NULL value through. `test_the_preserved_set_is_exactly_the_four_name_columns`
+    below is what catches growth, and it has to compare against an independent literal
+    rather than against the production constant.
     """
     contract_id = 910100 + sorted(NAME_COLUMNS_PRESERVED_ON_NULL).index(column)
     await bulk_upsert(
@@ -286,6 +290,28 @@ async def test_one_statement_coalesces_per_row_not_per_statement(
     assert (kept.issuer_name, replaced.issuer_name) == ("Kept Pilot", "Renamed Pilot")
 
 
+async def test_the_preserved_set_is_exactly_the_four_name_columns():
+    """The membership of the set, compared against an INDEPENDENT literal.
+
+    Every other test here reads the production constant, so all of them move with it: a
+    column wrongly added to `NAME_COLUMNS_PRESERVED_ON_NULL` gains a parametrized case
+    that passes (COALESCE lets non-NULL through regardless) while silently acquiring
+    preserve-on-null semantics it should not have. `title` is the column that would hurt
+    — ESI really does send contracts with no title, and preserving it would freeze the
+    first title a contract was ever seen with, forever.
+
+    Deliberately a hand-written literal rather than anything derived. A test whose
+    expectation is computed from the thing under test agrees with every value that thing
+    can take.
+    """
+    assert NAME_COLUMNS_PRESERVED_ON_NULL == {
+        "start_location_name",
+        "end_location_name",
+        "issuer_name",
+        "issuer_corporation_name",
+    }
+
+
 async def test_an_empty_batch_is_a_no_op_rather_than_an_error(
     db_session: AsyncSession,
 ):
@@ -299,13 +325,22 @@ async def test_an_empty_batch_is_a_no_op_rather_than_an_error(
     dialect branch looks like the "real" start of the function — turns every quiet
     no-op run into an IndexError that aborts the whole aggregation.
 
-    Asserted as a no-op, not merely as "did not raise": a return that fell through to an
-    INSERT with no VALUES is a different failure that a raises-check would miss.
+    Asserted against a SEEDED sentinel, not against an empty database. The per-test
+    database starts empty, so a before/after row count says nothing: an implementation
+    that deleted every row on empty input would leave 0 == 0 and pass. The sentinel's
+    full state is compared so the claim is "nothing changed", not "the count is stable"
+    — a truncate-and-reinsert would keep the count too.
     """
-    before = (await db_session.execute(select(Contract))).scalars().all()
+    await bulk_upsert(
+        db_session, Contract, [_contract_row(910301, issuer_name="Sentinel Pilot")]
+    )
+    before = await _fetch(db_session, 910301)
+    before_state = (before.issuer_name, before.title, before.price)
 
     await bulk_upsert(db_session, Contract, [], preserve_on_null=frozenset())
     await bulk_upsert(db_session, Contract, [])
 
-    after = (await db_session.execute(select(Contract))).scalars().all()
-    assert len(after) == len(before)
+    rows = (await db_session.execute(select(Contract))).scalars().all()
+    assert len(rows) == 1, "the empty call touched rows it was given nothing about"
+    after = await _fetch(db_session, 910301)
+    assert (after.issuer_name, after.title, after.price) == before_state

--- a/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
+++ b/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
@@ -17,6 +17,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from fastapi_app.models.contracts import Contract
+from fastapi_app.services.background_aggregation import (
+    NAME_COLUMNS_PRESERVED_ON_NULL,
+)
 from fastapi_app.services.db_upsert import bulk_upsert
 
 pytestmark = pytest.mark.asyncio
@@ -206,3 +209,103 @@ async def test_the_sqlite_branch_upserts_and_honors_preserve_on_null():
             assert row.parent_category_id is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.parametrize("column", sorted(NAME_COLUMNS_PRESERVED_ON_NULL))
+async def test_every_preserved_column_still_overwrites_on_a_non_null_value(
+    db_session: AsyncSession, column: str
+):
+    """preserve_on_null must not become preserve-always, for any of the four columns.
+
+    The NULL-keeps direction is asserted for all four end to end, but the overwrite arm
+    was asserted for one column only and the other three rode on it. They do not share
+    an implementation detail worth riding on: `_update_cols` builds one COALESCE per
+    column name, so a column mis-typed into the preserved set — or a set that grew a
+    fifth member nobody meant — is a column that silently stops taking updates. A name
+    that never updates is worse than one that blanks, because nothing looks wrong: the
+    site keeps serving a pilot's old corporation forever.
+
+    Parametrized over `NAME_COLUMNS_PRESERVED_ON_NULL` itself rather than a hand-listed
+    four, so a fifth member is covered the moment it joins the frozenset.
+    """
+    contract_id = 910100 + sorted(NAME_COLUMNS_PRESERVED_ON_NULL).index(column)
+    await bulk_upsert(
+        db_session, Contract, [_contract_row(contract_id, **{column: "Before"})]
+    )
+
+    await bulk_upsert(
+        db_session,
+        Contract,
+        [_contract_row(contract_id, **{column: "After"})],
+        preserve_on_null=NAME_COLUMNS_PRESERVED_ON_NULL,
+    )
+
+    row = await _fetch(db_session, contract_id)
+    assert getattr(row, column) == "After", f"{column} stopped taking updates"
+
+
+async def test_one_statement_coalesces_per_row_not_per_statement(
+    db_session: AsyncSession,
+):
+    """The COALESCE is per ROW, and a real ingestion statement carries both kinds at once.
+
+    A degraded /universe/names map does not fail uniformly — it answers for some ids and
+    not others — so the single upsert a run issues carries rows where the preserved
+    column is NULL beside rows where it is freshly resolved. Every existing test issues a
+    statement that is entirely one kind or the other, and both pass under an
+    implementation that decided per STATEMENT: "this batch has a NULL, preserve
+    everything" would keep the stored value for both rows, and "this batch has a value,
+    copy everything" would blank the first.
+
+    Observed as both rows' values together, since either row alone is satisfied by the
+    wrong per-statement rule in one of its two directions (TEST-25).
+    """
+    await bulk_upsert(
+        db_session,
+        Contract,
+        [
+            _contract_row(910201, issuer_name="Kept Pilot"),
+            _contract_row(910202, issuer_name="Replaced Pilot"),
+        ],
+    )
+
+    await bulk_upsert(
+        db_session,
+        Contract,
+        [
+            # Unresolved this run: the stored name must survive.
+            _contract_row(910201, issuer_name=None),
+            # Resolved this run, in the SAME statement: the new name must land.
+            _contract_row(910202, issuer_name="Renamed Pilot"),
+        ],
+        preserve_on_null=NAME_COLUMNS_PRESERVED_ON_NULL,
+    )
+
+    kept = await _fetch(db_session, 910201)
+    replaced = await _fetch(db_session, 910202)
+    assert (kept.issuer_name, replaced.issuer_name) == ("Kept Pilot", "Renamed Pilot")
+
+
+async def test_an_empty_batch_is_a_no_op_rather_than_an_error(
+    db_session: AsyncSession,
+):
+    """The aggregation calls this with nothing to write on ordinary paths.
+
+    A region that returned no contracts, a run where every item fetch was skipped, an
+    all-304 sweep — each reaches the upsert with an empty list, and the early return is
+    the only thing standing between those and a crash. The guard reads as defensive
+    politeness, but it is load-bearing: `supplied_cols` derives the column list from
+    `values[0]`, so reordering the return below it — the natural tidy-up, since the
+    dialect branch looks like the "real" start of the function — turns every quiet
+    no-op run into an IndexError that aborts the whole aggregation.
+
+    Asserted as a no-op, not merely as "did not raise": a return that fell through to an
+    INSERT with no VALUES is a different failure that a raises-check would miss.
+    """
+    before = (await db_session.execute(select(Contract))).scalars().all()
+
+    await bulk_upsert(db_session, Contract, [], preserve_on_null=frozenset())
+    await bulk_upsert(db_session, Contract, [])
+
+    after = (await db_session.execute(select(Contract))).scalars().all()
+    assert len(after) == len(before)

--- a/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
+++ b/app/backend/src/fastapi_app/tests/services/test_db_upsert.py
@@ -327,20 +327,29 @@ async def test_an_empty_batch_is_a_no_op_rather_than_an_error(
 
     Asserted against a SEEDED sentinel, not against an empty database. The per-test
     database starts empty, so a before/after row count says nothing: an implementation
-    that deleted every row on empty input would leave 0 == 0 and pass. The sentinel's
-    full state is compared so the claim is "nothing changed", not "the count is stable"
-    — a truncate-and-reinsert would keep the count too.
+    that deleted every row on empty input would leave 0 == 0 and pass.
+
+    And compared over EVERY column, not a chosen few. Three hand-picked fields is a
+    digest: an empty call that reset some unwatched column — `status` back to
+    "unknown", say — passes a spot-check while having written to a table it was given
+    nothing about. The whole row is snapshotted so "no-op" means what it says
+    (TEST-25).
     """
     await bulk_upsert(
         db_session, Contract, [_contract_row(910301, issuer_name="Sentinel Pilot")]
     )
-    before = await _fetch(db_session, 910301)
-    before_state = (before.issuer_name, before.title, before.price)
+
+    def _whole_row(row: Contract) -> dict:
+        return {
+            column.name: getattr(row, column.name)
+            for column in Contract.__table__.columns
+        }
+
+    before_state = _whole_row(await _fetch(db_session, 910301))
 
     await bulk_upsert(db_session, Contract, [], preserve_on_null=frozenset())
     await bulk_upsert(db_session, Contract, [])
 
     rows = (await db_session.execute(select(Contract))).scalars().all()
     assert len(rows) == 1, "the empty call touched rows it was given nothing about"
-    after = await _fetch(db_session, 910301)
-    assert (after.issuer_name, after.title, after.price) == before_state
+    assert _whole_row(await _fetch(db_session, 910301)) == before_state

--- a/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
@@ -619,8 +619,13 @@ async def test_a_match_at_an_unresolved_location_says_so_rather_than_naming_noth
     Asserted on the whole rendered message rather than on a substring: the location is
     the last field, so a substring check passes for a message that lost everything
     before it.
+
+    Both falsy shapes, because the guard is `location or ...` and not `is None`. An
+    empty string is what a name cache returns for a station it resolved to nothing,
+    and narrowing the guard to `is None` would render a message ending in "in " —
+    which reads as truncated rather than as unknown.
     """
-    assert (
-        wm._render_message("Caracal", "auction", 10_500_000, None)
-        == "Caracal available in an auction priced 10,500,000 ISK in an unknown location"
-    )
+    for absent in (None, ""):
+        assert wm._render_message("Caracal", "auction", 10_500_000, absent) == (
+            "Caracal available in an auction priced 10,500,000 ISK in an unknown location"
+        ), f"location={absent!r}"

--- a/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
@@ -603,3 +603,24 @@ async def test_a_priceless_contract_never_satisfies_a_numeric_price_bound(db_ses
 
     matched, created = await _service()._match_and_notify(db_session)
     assert matched == 0 and created == 0
+
+
+async def test_a_match_at_an_unresolved_location_says_so_rather_than_naming_nothing(
+    db_session: AsyncSession,
+):
+    """`_render_message`'s `location or "an unknown location"` arm.
+
+    Station names are resolved by a separate ESI call that can fail or lag, so a live
+    contract routinely carries a NULL `start_location_name` — this is the ordinary
+    state right after ingestion, not a defensive corner. Without the fallback the
+    notification renders "... in None", which is the kind of string that reaches a
+    reader before anyone notices.
+
+    Asserted on the whole rendered message rather than on a substring: the location is
+    the last field, so a substring check passes for a message that lost everything
+    before it.
+    """
+    assert (
+        wm._render_message("Caracal", "auction", 10_500_000, None)
+        == "Caracal available in an auction priced 10,500,000 ISK in an unknown location"
+    )

--- a/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
@@ -616,14 +616,38 @@ async def test_a_match_at_an_unresolved_location_says_so_rather_than_naming_noth
     notification renders "... in None", which is the kind of string that reaches a
     reader before anyone notices.
 
-    Asserted on the whole rendered message rather than on a substring: the location is
-    the last field, so a substring check passes for a message that lost everything
-    before it.
+    Driven through `_match_and_notify` against a real unresolved row, and asserted on
+    the STORED notification. A direct `_render_message` call constrains the renderer but
+    not the rendering: the call site passes `r.start_location_name`, and wrapping that in
+    `str()` — which is how a "make the type checker happy" edit reads — produces the
+    literal "None" while every unit-level assertion on the renderer still passes
+    (TEST-25: observe the value the reader receives, at the point they receive it).
 
-    Both falsy shapes, because the guard is `location or ...` and not `is None`. An
-    empty string is what a name cache returns for a station it resolved to nothing,
-    and narrowing the guard to `is None` would render a message ending in "in " —
-    which reads as truncated rather than as unknown.
+    Asserted on the whole message rather than on a substring: the location is the last
+    field, so a substring check passes for a message that lost everything before it.
+    """
+    u = await _user(db_session)
+    await _watch(db_session, u, type_id=621, type_name="Caracal", max_price=None)
+    await _contract(db_session, cid=5921, price=10_500_000, ctype="auction", location=None)
+    await _item(db_session, cid=5921, type_id=621)
+
+    matched, created = await _service()._match_and_notify(db_session)
+    assert matched == 1 and created == 1
+    note = (await db_session.execute(select(Notification))).scalar_one()
+    assert note.message == (
+        "Caracal available in an auction priced 10,500,000 ISK in an unknown location"
+    )
+
+
+async def test_the_unknown_location_fallback_covers_every_falsy_name(
+    db_session: AsyncSession,
+):
+    """The guard is `location or ...`, not `is None`, and the difference is reachable.
+
+    An empty string is what a name lookup returns for a station it resolved to nothing,
+    and narrowing the guard to `is None` would render a message ending in "in " — which
+    reads as truncated rather than as unknown. Kept at the renderer because the point
+    here is the SHAPE of the guard, while the integration test above pins the call site.
     """
     for absent in (None, ""):
         assert wm._render_message("Caracal", "auction", 10_500_000, absent) == (


### PR DESCRIPTION
Wave 5 continued: **9 of the 18 backend-write nice-to-have rows**. Backend **753 → 767**. Every new test mutation-verified (TEST-12), restore in `finally`, `git status` checked clean after each run.

Closed: **N-1, N-2, N-3, N-4, N-5, N-11** (remaining half), **N-15, N-16, N-19**.

## The ones that mattered

- **N-2 — a `reward`↔`volume` swap was undetectable.** Both are plain floats read straight off the payload, so exchanging them yields a row that is internally consistent, passes every schema check, and quietly reverses the reward-per-m³ sort the whole courier surface is built on. The test asserts every mapped field with **distinct values throughout**, because a swap is only observable when the two fields disagree. Mutation-verified by making exactly that swap.
- **N-19 — the assertion could not have fired.** `assert_not_awaited` on the unarmed `MagicMock` raised `AttributeError`; and even had it resolved, an unarmed mock can never be awaited, so the assertion would have held for a reason unrelated to the guard. Arming `get_universe_station` with a working return first is the vacuity guard (TEST-15) — and it is what the sibling Upwell-structure test already does.
- **N-16 — every existing preserve-on-null test issued a statement that was entirely one kind.** All of them pass under an implementation that decided per *statement* rather than per row. A degraded `/universe/names` map does not fail uniformly — it answers for some ids and not others — so the real statement carries both kinds at once. Now covered, plus the overwrite arm for all four columns, parametrized over `NAME_COLUMNS_PRESERVED_ON_NULL` so a fifth member is covered when it joins.
- **N-5 — the unparseable prior is a different branch from the non-object one.** `json.loads` raises for one and returns cleanly for the other. Dropping `ValueError` from the except clause lets it escape to the *outer* swallow, which logs and skips the SET — so the corrupt key is never repaired and every future run re-reads the same garbage.

## Two rows were already implicitly protected — stated, not claimed

The mutation runs surfaced this and it belongs in the record rather than being rounded up: dropping the `status` default fails **53** pre-existing tests in the aggregation file alone, and dropping the `is_singleton` default fails **28**, because both columns are NOT NULL and most fixtures omit them. (An earlier revision of this body said "four" and "one" — those came off a `-k`-filtered guard run, not a full one. The conclusion was right; the numbers were not.) The *behavior* was covered; it was not **named**. These tests name it. Counting them as newly-protected would overstate what this PR bought.

## One flagged for Sam, not fixed

**A malformed ESI date discards the WHOLE AGGREGATION RUN.** `_parse_esi_datetime` calls `fromisoformat` with no guard, from inside the list comprehension that builds rows for the entire batch — and `run_aggregation` concatenates every page of every configured region before calling `_process_contracts` **once**. So one bad date string anywhere in the corpus discards every contract fetched that cycle. That is the hazard shape a NOT NULL `price` already demonstrated in production (TEST-22 / FASTAPI-3).

Pinned as **characterization**, observed at `_build_contract_rows` where the batch semantics live. Two limits of that choice are stated in the docstring: the raise precedes any upsert, so nothing is written and no transaction is poisoned; and a refactor that built and wrote per contract would change the persistence blast radius without failing the test. Whether it *should* abort is a decision, not a defect to fix inside a test-only wave — skipping the contract and persisting a NULL date both change what the site shows.

## Still open in this register (9 rows)

N-6 (lock release on a raising body, `aclose`), N-7 and N-9 (chunk boundaries for three loops), **N-8 (needs a production hoist of two function-local `500` literals)**, N-12 (matcher `.distinct()` and fan-out), N-13 (`_prune` sub-branches), N-14 (`run_matching` end-to-end), N-17 (a7c clean-downgrade index drops), N-18 (pre-fetch failure counters).

## Verification

- backend `pytest`: **767 passed** (753 at branch point + 14)
- backend `pdm run lint`: clean
- Frontend untouched.

## Merge classification

`Routine` — test-only. No schema, no migration, no public API contract change, no auth or data-integrity path. The one production-adjacent observation (malformed-date blast radius) is flagged, not acted on.


---

## Adversarial review — six findings, all real, all fixed

Backend **767 → 769**. Every survivor below was reproduced before fixing and is dead after.

**Two were tests that could not fail for structural reasons** — the more interesting half:

1. **The preserved-column parametrization policed nothing.** It read `NAME_COLUMNS_PRESERVED_ON_NULL`, so it moved with the thing it was meant to constrain. Adding `"title"` to the production set merely added a case that passed — COALESCE lets non-NULL through regardless — while `title` silently acquired preserve-on-null semantics that would freeze the first title a contract was ever seen with. Membership is now asserted against an **independent literal**. This is the same trap as frontend-logic N-9's `sortableFieldsFor`: an expectation computed from the thing under test agrees with every value that thing can take.
2. **The empty-batch no-op compared row counts on a database that starts empty**, so `0 == 0` passed even for an implementation that deleted every row. It now seeds a sentinel and compares its full state — a truncate-and-reinsert would keep the count too.

**Four ordinary survivors:**

3. `date_expired` was asserted only as *"after `date_issued`"* — a digest that holds for any constant far enough in the future. Replacing every persisted expiry with `2100-01-01` passed 732 tests. Both dates are now asserted exactly. This also contradicted this body's own "distinct values throughout" claim.
4. `_apply_dev_limit` was tested at `len<limit` but not `len==limit`, so `>` → `>=` survived. Parametrized over both, since the row it closes says `<=`.
5. `is_singleton` was asserted only through its default, so hardcoding `False` and ignoring a supplied `true` survived — public payloads never carry the flag, so a fixture that supplies it is the only way to tell the two apart.
6. The unknown-location fallback is `location or ...`, not `is None`; narrowing it left an empty string rendering a message ending in `"in "`. Both falsy shapes now asserted.

**The flagged hazard got worse, not better.** The review corrected my characterization of the malformed-date blast radius. "Poisoned transaction" was wrong — the `ValueError` raises before any upsert, so nothing is written. And `run_aggregation` concatenates every page of **every configured region** before calling `_process_contracts` once, so one bad date string discards **the whole run**, not one region page. The docstring now says so, and also states the limit of observing at the helper: a per-contract refactor would change the persistence blast radius without failing this test.

**Fixture/spec audit passed**, and the review verified my ESI claims against the live route rather than the schema: 190 blueprint items across 60 contracts showed `is_blueprint_copy` true 53 / absent 137 / **false 0**; `is_singleton` present 0; `status` present 0 across 1,000 contracts; `collateral` present 1,000 and all zero. So "true-or-absent" is empirically supported — the check I asked for specifically, after a claim about ESI payloads went into a persistent artifact unverified on the previous PR.




---

## Review round 2 — three more survivors, all fixed

Round 2 verified all six round-1 fixes kill their mutants, and found three more. Backend **769 → 770**.

1. **The unknown-location test observed the RENDERER, not the rendering.** It called `_render_message` directly, so wrapping the call site's argument in `str()` — how a "satisfy the type checker" edit reads — put the literal `"None"` into stored notifications while every unit-level assertion still passed. Now driven through `_match_and_notify` against a real unresolved row and asserted on the **persisted message**. The renderer-level test stays, narrowed to what it can actually claim: the *shape* of the falsy guard, so `or` narrowed to `is None` still dies.
2. **The item-flag fixture coupled the two flags.** Supplying `is_singleton` and `is_blueprint_copy` together and both `true` makes them indistinguishable — reading `is_singleton` out of `is_blueprint_copy`, an ordinary copy/paste between adjacent boolean keys, satisfied every assertion. Now three rows where the flags **disagree in both directions**.
3. **The empty-batch test claimed full state and compared three columns.** An empty call that reset an unwatched column (`status` back to `"unknown"`) passed it. Now snapshots every column off `Contract.__table__`.

Round 2 also independently confirmed the corrected malformed-date account (`get_public_contracts(all_pages=True)` → `_fetch_regions` concatenates all regions → one `_process_contracts` call, exception precedes upsert) and the corrected 53 / 28 counts.

**Running total across this PR: nine findings over two rounds, all real, all fixed.** Every survivor was reproduced before the fix and confirmed dead after.


---

## Review rounds 3–5 — converged

**Round 3** (3 findings): `Contract.type` was never asserted despite the test claiming "every mapped field", so the adjacent-key copy/paste `"type": c.get("status", "unknown")` passed all 770 tests — the field with the widest blast radius, and invisible at write time because segment counts, the item-fetch partition and watchlist eligibility all read the *source payload*, not the stored row. The malformed-date test observed one layer below where the blast radius is decided. "Warns nothing" excluded a single marker string.

**Round 4** (1 finding): the malformed-date test claimed "anywhere" but corrupted only `date_issued`. Production parses three dates independently — two required, one optional — and that split is exactly the seam a tolerant-parsing edit would follow. Now parametrized over all three.

**Round 5: category (a) empty. `DONE`.**

### One correction worth recording: my mutation harness lied

Round 4's fix first reported "killed, 3 cases failed". The edit that *defines* the tolerant helper had silently not applied, so the mutant referenced an undefined name and every case failed on `NameError` rather than on behavior. Applied by hand, exactly **one** case fails (`date_completed`) with both required-date cases green — the isolated result TEST-12 asks for.

A red run is only evidence if the mutation is the one you intended. A broken mutant fails everything, which reads as thoroughness at the summary line and as nonsense one line deeper. **Mutation harnesses need an assertion on symbols they INTRODUCE, not only on the text they replace.**

### Totals

**Thirteen findings across five rounds, all real, all fixed.** Rounds produced 6 → 3 → 3 → 1 → 0. The two-category split introduced at round 3 (claimed-but-unconstrained vs adjacent-and-unclaimed) is what let the review terminate rather than widen: round 4 classified 1 blocker against 13 adjacent observations, and round 5 confirmed convergence rather than manufacturing work.

Backend **753 → 772**.
