### PR TITLE
fix(api): make the matcher's label table fail loudly when the enum grows

### DIFF
--- a/app/backend/src/fastapi_app/services/watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/services/watchlist_matcher.py
@@ -41,6 +41,12 @@ _RELEASE_LOCK_LUA = (
     "return redis.call('del', KEYS[1]) else return 0 end"
 )
 
+# One label per item-bearing contract type. The set must equal
+# ITEM_BEARING_CONTRACT_TYPES, which is DERIVED from the enum — so a new ContractType
+# member widens the matcher's gate to admit it while this hand-written table stays put,
+# and its alerts would render through the "a contract" fallback below. Pinned by
+# test_every_item_bearing_type_has_a_label_of_its_own so that drift fails at the moment
+# the member is added rather than in somebody's notification feed.
 _SHIP_TYPE_LABELS = {
     ContractType.item_exchange.value: "an item exchange",
     ContractType.auction.value: "an auction",
@@ -53,6 +59,11 @@ class ConcurrencyLockError(Exception):
 
 def _render_message(type_name: str, contract_type: str, price, location: Optional[str]) -> str:
     # Price-honest: name the CONTRACT as the priced thing (bundle price), not the ship (design §4.4).
+    # The fallback is defense in depth, not a live branch: the query gates on
+    # ITEM_BEARING_CONTRACT_TYPES and the label table is asserted equal to it, so a type
+    # reaching here unlabelled is already a caught test failure. It renders a vague noun
+    # rather than raising, because a KeyError here would abort the whole matching run
+    # over one alert's wording.
     label = _SHIP_TYPE_LABELS.get(contract_type, "a contract")
     where = location or "an unknown location"
     # ESI marks price optional and the column is nullable; the dash is the same

--- a/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
+++ b/app/backend/src/fastapi_app/tests/services/test_watchlist_matcher.py
@@ -653,3 +653,26 @@ async def test_the_unknown_location_fallback_covers_every_falsy_name(
         assert wm._render_message("Caracal", "auction", 10_500_000, absent) == (
             "Caracal available in an auction priced 10,500,000 ISK in an unknown location"
         ), f"location={absent!r}"
+
+
+async def test_every_item_bearing_type_has_a_label_of_its_own():
+    """The label table and the matcher's type gate must name the same set of types.
+
+    These two update ASYMMETRICALLY, which is the whole reason this test exists.
+    `ITEM_BEARING_CONTRACT_TYPES` is DERIVED — every `ContractType` member minus the
+    item-less ones — so adding a member to the enum (which is forced, since an unknown
+    value 422s) silently widens the matcher's gate to admit it. `_SHIP_TYPE_LABELS` is a
+    hand-written dict and does not widen with it. Nobody has to forget anything: one
+    side maintains itself and the other does not.
+
+    Without this test the consequence is a notification reading "Caracal available in a
+    contract priced ..." — the `.get` fallback, which reads as a rendering bug to the
+    person receiving the alert and is invisible to every other test, because the gate,
+    the match count and the notification row are all still correct.
+
+    Comparing the two constants is NOT the self-referential trap: they are independently
+    authored in different modules, one derived from the enum and one written by hand, so
+    the comparison is a genuine cross-check rather than an expectation computed from the
+    thing under test.
+    """
+    assert set(wm._SHIP_TYPE_LABELS) == ITEM_BEARING_CONTRACT_TYPES


### PR DESCRIPTION
Sam's decision on backend-write **N-11**'s unreachable `"a contract"` fallback: **option (d) — close the drift**, rather than test the branch or record it as dead.

## Why the branch was never really unreachable

`ITEM_BEARING_CONTRACT_TYPES` is **derived**:

```python
ITEM_BEARING_CONTRACT_TYPES = frozenset(t.value for t in ContractType) - ITEMLESS_CONTRACT_TYPES
```

`_SHIP_TYPE_LABELS` is a hand-written dict of two. So the two update **asymmetrically**: adding a member to `ContractType` — which is *forced*, since an unknown value 422s — automatically widens the matcher's gate to admit the new type, and the label table does not widen with it. Nobody has to forget anything for them to drift.

The fallback isn't dead code. It's the symptom of the one remaining hand-listed restatement of a partition Wave 3 centralized at all three other sites.

## What it would have cost

An alert reading *"Caracal available in **a contract** priced 10,500,000 ISK in Jita"* — invisible to every other test, because the gate, the match count, and the notification row all stay correct. Only the wording degrades, and only for the reader.

## The guard

```python
assert set(wm._SHIP_TYPE_LABELS) == ITEM_BEARING_CONTRACT_TYPES
```

**This is not the self-referential trap** that bit an earlier PR in this campaign. The two constants are independently authored in different modules — one derived from the enum, one written by hand — so comparing them is a genuine cross-check rather than an expectation computed from the thing under test.

**Mutation-verified** by adding a sixth `ContractType` member (`bulk_exchange`): the guard fails and *names the type missing its label*.

```
AssertionError: assert {'auction', 'item_exchange'} == frozenset({...})
  Extra items in the right set: 'bulk_exchange'
```

The fallback stays, now documented as defense in depth — a `KeyError` there would abort a whole matching run over one alert's wording.

## Verification

- backend `pytest`: **773 passed** (772 + 1)
- backend `pdm run lint`: clean
- Frontend untouched.

## Merge classification

`Routine` — one test plus two explanatory comments. No schema, no migration, no public API contract change, no behavior change.

---

## Adversarial review — clean on the first round

Category (a) empty. All four checks confirmed independently:

- **The sixth-type guard works.** An in-memory mutant added `collateral_exchange` to `ContractType`; the new test failed and explicitly named the type missing its label.
- **The cross-check is genuine, not self-referential.** The enum-derived set and the hand-written label dict have independent authorship and independent update mechanisms — so comparing them constrains something, unlike an expectation computed from the thing under test.
- **The added comments state nothing false.** "Unreachable" is correctly scoped to the current production call graph.
- **The fallback is unreachable through `_match_and_notify`** — its sole production caller sits behind the item-bearing-type gate, and the keys now provably match that set. It stays directly reachable by calling `_render_message` with an arbitrary string, which is what makes it defense in depth rather than dead code.

One category (b) survivor, recorded not fixed: changing the fallback text from `"a contract"` to `"a listing"` is uncaught. That is adjacent to the key-set invariant this test claims, and pinning a fallback string nothing can currently produce would be pinning trivia.
