### PR TITLE
fix(api): stop one malformed date from discarding the whole ingest run

### DIFF
--- a/app/backend/src/fastapi_app/core/metrics.py
+++ b/app/backend/src/fastapi_app/core/metrics.py
@@ -1,8 +1,18 @@
 # ABOUTME: Process-global Prometheus instruments that are not per-request (the
 # ABOUTME: instrumentator owns HTTP metrics; this module owns job/ingestion gauges).
-from prometheus_client import Gauge
+from prometheus_client import Counter, Gauge
 
 last_ingest_success_timestamp = Gauge(
     "hangar_bay_last_ingest_success_timestamp",
     "Unix time of the last aggregation run that committed data (success or partial).",
+)
+
+# Contracts ingestion declined to persist. A skip is silent data loss — a real listing
+# the site will not show — so it needs a signal that does not require reading logs, and
+# one an alert can be hung on. Labelled by reason from the start: a label set cannot be
+# widened later without breaking every recorded series.
+contracts_skipped_total = Counter(
+    "hangar_bay_ingest_contracts_skipped_total",
+    "Contracts dropped during ingestion rather than persisted, by reason.",
+    ["reason"],
 )

--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -112,20 +112,37 @@ def _parse_esi_datetime(date_string: str | None) -> datetime | None:
     return datetime.fromisoformat(date_string.replace("Z", "+00:00"))
 
 
+# Every way a JSON value can fail to be a readable date. Narrower than this and the
+# isolation is only about unparseable STRINGS: an absent key raises KeyError, and a
+# number or a list raises AttributeError on `.replace()` — each of which aborts the run
+# exactly as the string case used to, under a different traceback.
+_UNREADABLE_DATE_ERRORS = (AttributeError, KeyError, TypeError, ValueError)
+
+
 def _parse_required_esi_datetime(contract: dict, field: str) -> datetime:
     """Parse a date the contract cannot be stored without, naming it if it fails.
 
     Both required dates back NOT NULL columns and `date_expired` is the liveness
     predicate and the default sort, so there is no honest value to substitute for an
     unparseable one — the caller drops the contract instead.
+
+    An explicit `null` is treated as malformed rather than passed along: it parses
+    cleanly to None and would then fail the NOT NULL insert, which aborts the whole
+    transaction — the outage this policy exists to prevent, reached from inside the
+    parser that is supposed to prevent it.
     """
     try:
-        return _parse_esi_datetime(contract[field])
-    except ValueError as exc:
+        parsed = _parse_esi_datetime(contract[field])
+    except _UNREADABLE_DATE_ERRORS as exc:
         raise MalformedContractDate(contract.get("contract_id"), field, str(exc)) from exc
+    if parsed is None:
+        raise MalformedContractDate(
+            contract.get("contract_id"), field, "required date is null or absent"
+        )
+    return parsed
 
 
-def _parse_optional_esi_datetime(date_string: str | None) -> datetime | None:
+def _parse_optional_esi_datetime(date_string) -> datetime | None:
     """Parse a date whose column is nullable, serving NULL when it cannot be read.
 
     Only `date_completed` qualifies: ESI marks it optional, the public route never
@@ -134,8 +151,8 @@ def _parse_optional_esi_datetime(date_string: str | None) -> datetime | None:
     """
     try:
         return _parse_esi_datetime(date_string)
-    except ValueError:
-        logger.warning("Unparseable optional date %r; storing NULL.", date_string)
+    except _UNREADABLE_DATE_ERRORS:
+        logger.warning("Unreadable optional date %r; storing NULL.", date_string)
         return None
 
 
@@ -618,6 +635,18 @@ class ContractAggregationService:
         # into the format for the database model, enriching with names and systems.
         station_to_system = await self._resolve_station_systems(db_session, contracts)
         contract_values = _build_contract_rows(contracts, id_to_name_map, station_to_system)
+
+        # A dropped contract must leave the RUN, not just this upsert.
+        # `contract_items.contract_id` is a foreign key onto `contracts`, so carrying a
+        # skipped payload on into item enrichment inserts children for a parent that was
+        # never written — PostgreSQL aborts the transaction and every healthy sibling
+        # rolls back with it. That is the whole-run blast radius this policy removes,
+        # restored one layer further down and wearing an IntegrityError instead.
+        #
+        # Derived from what actually persisted rather than from a second list of skips,
+        # so any future reason a row is dropped excludes it downstream automatically.
+        persisted_ids = {row["contract_id"] for row in contract_values}
+        contracts = [c for c in contracts if c.get("contract_id") in persisted_ids]
 
         batch_size = 500  # Number of contracts to process in each batch
         total_contracts = len(contract_values)

--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..core.config import Settings  # Settings type for hinting
 from ..core.esi_client_class import ESIClient  # ESIClient class for type hint
 from ..core.exceptions import ESINotModifiedError  # Restored ESINotModifiedError
-from ..core.metrics import last_ingest_success_timestamp
+from ..core.metrics import contracts_skipped_total, last_ingest_success_timestamp
 
 from ..db import AsyncSessionLocal
 from ..models.contracts import Contract, ContractItem, EsiTaxonomyCache  # Models
@@ -81,6 +81,28 @@ def _chunk_ids(ids: Iterable[int]) -> Iterator[list[int]]:
         yield id_list[start : start + UPDATE_ID_CHUNK_SIZE]
 
 
+class MalformedContractDate(ValueError):
+    """A date ESI marks REQUIRED could not be parsed, named down to the field.
+
+    Carries the contract id and the field so the log line can say which contract and
+    which date, rather than only the offending string — a bare ValueError leaves an
+    operator unable to aim the one workaround available to them (dropping the region
+    from AGGREGATION_REGION_IDS), because nothing in it names a region or a contract.
+    """
+
+    def __init__(self, contract_id, field: str, detail: str):
+        # Every argument goes to super() so the exception survives pickle/copy with its
+        # fields intact; the readable form is built in __str__ rather than baked into
+        # args, which would make the round-tripped copy carry a different message.
+        super().__init__(contract_id, field, detail)
+        self.contract_id = contract_id
+        self.field = field
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"contract {self.contract_id}: unparseable {self.field}: {self.detail}"
+
+
 def _parse_esi_datetime(date_string: str | None) -> datetime | None:
     """Parse ESI's ISO 8601 date strings into datetime objects."""
     if date_string is None:
@@ -88,6 +110,33 @@ def _parse_esi_datetime(date_string: str | None) -> datetime | None:
     # ESI dates are like "2024-05-20T14:47:32Z". The 'Z' means UTC.
     # fromisoformat handles this correctly if we replace 'Z' with '+00:00'.
     return datetime.fromisoformat(date_string.replace("Z", "+00:00"))
+
+
+def _parse_required_esi_datetime(contract: dict, field: str) -> datetime:
+    """Parse a date the contract cannot be stored without, naming it if it fails.
+
+    Both required dates back NOT NULL columns and `date_expired` is the liveness
+    predicate and the default sort, so there is no honest value to substitute for an
+    unparseable one — the caller drops the contract instead.
+    """
+    try:
+        return _parse_esi_datetime(contract[field])
+    except ValueError as exc:
+        raise MalformedContractDate(contract.get("contract_id"), field, str(exc)) from exc
+
+
+def _parse_optional_esi_datetime(date_string: str | None) -> datetime | None:
+    """Parse a date whose column is nullable, serving NULL when it cannot be read.
+
+    Only `date_completed` qualifies: ESI marks it optional, the public route never
+    sends it at all, and no read path consults it. A contract is not worth withholding
+    from the site over a field that would have been NULL had ESI simply omitted it.
+    """
+    try:
+        return _parse_esi_datetime(date_string)
+    except ValueError:
+        logger.warning("Unparseable optional date %r; storing NULL.", date_string)
+        return None
 
 
 def _collect_resolvable_ids(contracts: List[dict]) -> list[int]:
@@ -235,10 +284,39 @@ def _build_contract_rows(
     Every row carries the SAME seen_at for the whole run: a contract is judged present
     by matching the newest stamp in its region, which only works if one run writes one
     value. The upsert copies mapped columns on conflict, so re-sighting restamps.
+
+    A contract whose REQUIRED dates cannot be parsed is dropped from the batch rather
+    than taking the batch with it. `_fetch_regions` concatenates every page of every
+    configured region before a single call here, so an exception escaping this function
+    discards the whole run's ingest — and because the ETag validator is stored at fetch
+    time and a 304 serves the cached body back, the same contract would re-fail every
+    run for as long as it stayed listed, which for a public contract is up to two weeks.
+    Skips are counted and named (see MalformedContractDate) so the loss is visible.
     """
     seen_at = seen_at or datetime.now(timezone.utc)
     station_to_system = station_to_system or {}
-    return [
+    rows = []
+    for contract in contracts:
+        try:
+            rows.append(
+                _build_one_contract_row(
+                    contract, id_to_name_map, station_to_system, seen_at
+                )
+            )
+        except MalformedContractDate as exc:
+            contracts_skipped_total.labels(reason="malformed_date").inc()
+            logger.warning("Skipping contract with an unreadable date: %s", exc)
+    return rows
+
+
+def _build_one_contract_row(
+    c: dict,
+    id_to_name_map: dict,
+    station_to_system: dict[int, int],
+    seen_at: datetime,
+) -> dict:
+    """One contract's upsert row. Raises MalformedContractDate if a required date is unreadable."""
+    return (
         {
             "contract_id": c["contract_id"],
             "issuer_id": c["issuer_id"],
@@ -256,9 +334,9 @@ def _build_contract_rows(
             "status": c.get("status", "unknown"),
             "title": c.get("title"),
             "for_corporation": c.get("for_corporation", False),
-            "date_issued": _parse_esi_datetime(c["date_issued"]),
-            "date_expired": _parse_esi_datetime(c["date_expired"]),
-            "date_completed": _parse_esi_datetime(c.get("date_completed")),
+            "date_issued": _parse_required_esi_datetime(c, "date_issued"),
+            "date_expired": _parse_required_esi_datetime(c, "date_expired"),
+            "date_completed": _parse_optional_esi_datetime(c.get("date_completed")),
             "price": c.get("price"),
             "collateral": c.get("collateral", 0.0),  # Default to 0.0 if null
             "last_seen_at": seen_at,
@@ -279,8 +357,7 @@ def _build_contract_rows(
             # enrichment_version to 0 on every re-sighting, re-queueing the corpus
             # forever. Column defaults cover fresh inserts.
         }
-        for c in contracts
-    ]
+    )
 
 
 class ConcurrencyLockError(Exception):

--- a/app/backend/src/fastapi_app/services/background_aggregation.py
+++ b/app/backend/src/fastapi_app/services/background_aggregation.py
@@ -531,6 +531,7 @@ class ContractAggregationService:
             async with self._concurrency_lock() as redis_client:  # Handles concurrent job runs
                 regions_ok = 0
                 regions_failed = 0
+                ingested_nothing = False
                 try:
                     # Use the ESIClient as a context manager to ensure its http_client is initialized.
                     async with self.esi_client:
@@ -549,14 +550,34 @@ class ContractAggregationService:
                             else:
                                 all_contracts_data = self._apply_dev_limit(all_contracts_data)
 
-                                await self._process_contracts(db_session, all_contracts_data)
+                                persisted = await self._process_contracts(
+                                    db_session, all_contracts_data
+                                )
 
                                 await db_session.commit()
                                 logger.info("Public contract aggregation run finished successfully and changes committed.")
 
+                                # Fetched contracts but stored none: the run ingested
+                                # nothing, whatever the reason, and reporting success
+                                # would freshen the staleness clock over an empty
+                                # write. The realistic cause of wholesale rejection is
+                                # an upstream FORMAT change, which corrupts every
+                                # contract at once rather than one — so this is the
+                                # shape a silent outage would actually take.
+                                if persisted == 0:
+                                    ingested_nothing = True
+                                    logger.error(
+                                        "Fetched %s contracts and persisted none; "
+                                        "recording this run as a failure.",
+                                        len(all_contracts_data),
+                                    )
+
                     # The shared transaction committed (or completed as a valid
                     # no-op — the all-304 path); outcome derives from the counters.
-                    await self._record_run_outcome(redis_client, regions_ok, regions_failed)
+                    await self._record_run_outcome(
+                        redis_client, regions_ok, regions_failed,
+                        forced_failure=ingested_nothing,
+                    )
                 except Exception:
                     # Any processing/commit/top-level abort is a failed run no matter
                     # what the fetch counters say; record while the lock is still held.
@@ -617,7 +638,9 @@ class ContractAggregationService:
         except Exception:
             logger.warning("failed to record ingest outcome", exc_info=True)
 
-    async def _process_contracts(self, db_session: AsyncSession, contracts: List[dict]):
+    async def _process_contracts(
+        self, db_session: AsyncSession, contracts: List[dict]
+    ) -> int:
         """
         Processes a list of contracts, fetches their items, and upserts them using the provided db_session.
         """
@@ -716,6 +739,11 @@ class ContractAggregationService:
             ship_contract_ids,
             unresolved_category_contract_ids,
         )
+
+        # How many contracts this run actually persisted. The caller needs it to tell a
+        # run that ingested nothing from one that ingested normally: skipping per
+        # contract removed the abort that used to make a systemic failure loud.
+        return len(contract_values)
 
     async def _resolve_station_systems(
         self, db_session: AsyncSession, contracts: List[dict]

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2630,73 +2630,6 @@ async def test_a_populated_date_completed_is_parsed_and_an_absent_one_is_null(
     )
 
 
-@pytest.mark.parametrize(
-    "date_field", ["date_issued", "date_expired", "date_completed"]
-)
-async def test_a_malformed_esi_date_takes_the_whole_batch_down_with_it(
-    db_session: AsyncSession, date_field: str
-):
-    """CHARACTERIZATION, not endorsement: one bad date string kills every contract beside it.
-
-    `_parse_esi_datetime` calls `datetime.fromisoformat` with no guard, from inside the
-    list comprehension that builds rows for the ENTIRE batch. `run_aggregation`
-    concatenates every page of every configured region before calling
-    `_process_contracts` once, so the blast radius is **the whole aggregation run**, not
-    one region page — one malformed date string anywhere in the corpus discards every
-    contract fetched that cycle. That is the hazard shape a NOT NULL `price` already
-    demonstrated in production (TEST-22 / FASTAPI-3).
-
-    Observed at `_process_contracts`, the layer that DEFINES the blast radius, and
-    asserted on what persisted: the healthy sibling must be absent. Observing at
-    `_build_contract_rows` instead would pin only that the comprehension raises, which a
-    refactor building and writing per contract would still satisfy while no longer
-    losing the batch — the survivor is the whole point of the row, so the test has to
-    stand where the behavior is decided.
-
-    The session stays usable afterwards because the `ValueError` is raised while
-    building rows in memory, before any statement is issued — nothing is written and no
-    transaction is poisoned.
-
-    Parametrized over ALL THREE parsed date fields, because "anywhere" is the claim and
-    the three are independent mapping expressions. Two are required (`c["date_issued"]`,
-    `c["date_expired"]`) and one is optional (`c.get("date_completed")`) — and that
-    distinction is exactly the seam a tolerant-parsing edit would follow: making only the
-    optional field degrade to None leaves both required-field cases aborting as before,
-    so a test that corrupts only `date_issued` would never notice that a malformed
-    completion date had stopped costing the batch.
-
-    Pinned so the behavior is visible and any change to it is deliberate. Whether it
-    SHOULD abort is a decision, not a defect to fix inside a test-only wave — skipping
-    the contract and persisting a NULL date both change what the site shows. Recorded
-    for Sam in the coverage report.
-    """
-    service = _make_service()
-    good = _ship_contract_dict(920105)
-    bad = _ship_contract_dict(920106)
-    bad[date_field] = "not-a-date"
-
-    # The healthy sibling persists on its own, so the batch below fails for the reason
-    # named and not because the fixture was malformed all along (TEST-12 vacuity guard).
-    await service._process_contracts(db_session, [_ship_contract_dict(920111)])
-    assert (
-        await db_session.execute(
-            select(Contract).where(Contract.contract_id == 920111)
-        )
-    ).scalar_one_or_none() is not None
-
-    with pytest.raises(ValueError):
-        await service._process_contracts(db_session, [good, bad])
-
-    # The blast radius: the healthy contract in the same call did not land either.
-    survivors = (
-        await db_session.execute(
-            select(Contract.contract_id).where(
-                Contract.contract_id.in_([920105, 920106])
-            )
-        )
-    ).scalars().all()
-    assert survivors == []
-
 
 async def test_absent_item_flags_persist_as_null_and_false(db_session: AsyncSession):
     """ESI sends `is_blueprint_copy` true-or-ABSENT, never false (TEST-18).
@@ -2815,3 +2748,145 @@ async def test_freshness_recorder_treats_an_unparseable_prior_as_no_prior(
     # No prior success could be recovered from an unparseable record, and inventing
     # one would report the site as fresher than it is.
     assert record["last_success_at"] is None
+
+
+# --- Malformed ESI dates: per-field policy (Sam's decision, 2026-08-09) ---
+#
+# One unparseable date used to abort the WHOLE aggregation run. `_fetch_regions`
+# concatenates every page of every configured region before a single
+# `_process_contracts` call, and the ETag layer stores its validator at FETCH time and
+# serves the cached body back on a 304 — so the same bad contract was re-processed and
+# re-failed every hour for as long as it stayed listed, which for a public contract is
+# up to two weeks. Nothing surfaced it: /ready reports the failure but never fails
+# readiness, and the frontend has no staleness signal at all.
+#
+# The policy now follows the COLUMN, because the three dates are not interchangeable:
+#   - date_issued / date_expired are required by ESI and NOT NULL here, and
+#     date_expired is the liveness filter and the default sort — there is no honest
+#     value to substitute, so the contract is skipped and counted.
+#   - date_completed is optional, nullable, and never sent on the public route, so a
+#     malformed value degrades to NULL and costs the contract nothing.
+
+
+def _skipped_total() -> float:
+    from fastapi_app.core.metrics import contracts_skipped_total
+
+    return contracts_skipped_total.labels(reason="malformed_date")._value.get()
+
+
+@pytest.mark.parametrize("date_field", ["date_issued", "date_expired"])
+async def test_a_malformed_required_date_skips_only_its_own_contract(
+    db_session: AsyncSession, date_field: str
+):
+    """The blast radius is now one row, not the run.
+
+    Both healthy siblings must land — one BEFORE the malformed contract in the batch
+    and one AFTER it, because a loop that aborted on the first bad row would still
+    persist everything ahead of it and pass a test that only looked backwards.
+    """
+    service = _make_service()
+    first, bad, last = (
+        _ship_contract_dict(920201),
+        _ship_contract_dict(920202),
+        _ship_contract_dict(920203),
+    )
+    bad[date_field] = "not-a-date"
+
+    await service._process_contracts(db_session, [first, bad, last])
+
+    landed = set(
+        (
+            await db_session.execute(
+                select(Contract.contract_id).where(
+                    Contract.contract_id.in_([920201, 920202, 920203])
+                )
+            )
+        ).scalars()
+    )
+    assert landed == {920201, 920203}
+
+
+async def test_a_malformed_optional_date_costs_the_contract_nothing(
+    db_session: AsyncSession,
+):
+    """date_completed is optional, nullable, and absent from every public payload.
+
+    A contract is not worth withholding from the site over a field the public route
+    never sends and no read path consults — so the malformed value becomes the NULL it
+    would have been had ESI simply omitted it, and the contract lands.
+    """
+    service = _make_service()
+    payload = _ship_contract_dict(920204)
+    payload["date_completed"] = "not-a-date"
+
+    await service._process_contracts(db_session, [payload])
+
+    row = (
+        await db_session.execute(
+            select(Contract).where(Contract.contract_id == 920204)
+        )
+    ).scalar_one()
+    assert row.date_completed is None
+
+
+async def test_a_skipped_contract_names_itself_and_the_field_in_the_log(
+    db_session: AsyncSession, caplog
+):
+    """The old failure was not self-diagnosing, and that was half its cost.
+
+    A bare ValueError renders the offending STRING but never the contract or the
+    region, so the only operational workaround — dropping the region from
+    AGGREGATION_REGION_IDS — could not be aimed. The warning now carries the contract
+    id and the field name, which is what makes a skip actionable rather than merely
+    counted.
+    """
+    caplog.set_level("WARNING")
+    service = _make_service()
+    bad = _ship_contract_dict(920205)
+    bad["date_expired"] = "not-a-date"
+
+    await service._process_contracts(db_session, [bad])
+
+    warnings = [
+        r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+    ]
+    assert any("920205" in line and "date_expired" in line for line in warnings), warnings
+
+
+async def test_a_skipped_contract_increments_the_skip_counter(
+    db_session: AsyncSession,
+):
+    """A skip that only logs is a silent data loss with extra steps.
+
+    The counter is what makes "we are quietly dropping listings" answerable without
+    reading logs, and it is the signal an alert can be hung on — the gap this whole
+    decision surfaced. Measured as a DELTA because Prometheus instruments are
+    process-global and other tests in the same run also skip contracts.
+    """
+    service = _make_service()
+    before = _skipped_total()
+    bad = _ship_contract_dict(920206)
+    bad["date_issued"] = "not-a-date"
+
+    await service._process_contracts(db_session, [bad])
+
+    assert _skipped_total() - before == 1
+
+
+async def test_a_healthy_batch_never_touches_the_skip_counter(
+    db_session: AsyncSession,
+):
+    """The counter must mean what an alert would read it to mean.
+
+    Without this, a counter incremented unconditionally — or once per contract rather
+    than once per skip — reads as a permanent trickle of data loss and trains whoever
+    is watching to ignore it.
+    """
+    service = _make_service()
+    before = _skipped_total()
+
+    await service._process_contracts(
+        db_session, [_ship_contract_dict(920207), _ship_contract_dict(920208)]
+    )
+
+    assert _skipped_total() == before

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2768,10 +2768,32 @@ async def test_freshness_recorder_treats_an_unparseable_prior_as_no_prior(
 #     malformed value degrades to NULL and costs the contract nothing.
 
 
-def _skipped_total() -> float:
+def _skip_samples() -> list:
+    """Every sample of the skip counter, across ALL reason labels.
+
+    Reading one label series cannot see a second one appearing beside it: an increment
+    under a NEW reason — say a separate label for the optional-date degrade — raises the
+    "contracts dropped" total that alerts and dashboards read, while a delta measured on
+    `malformed_date` alone stays flat and every assertion passes.
+    """
     from fastapi_app.core.metrics import contracts_skipped_total
 
-    return contracts_skipped_total.labels(reason="malformed_date")._value.get()
+    return [
+        sample
+        for metric in contracts_skipped_total.collect()
+        for sample in metric.samples
+        if sample.name.endswith("_total")
+    ]
+
+
+def _skipped_total() -> float:
+    """The counter's grand total, summed over every reason label."""
+    return sum(sample.value for sample in _skip_samples())
+
+
+def _skip_reasons() -> set:
+    """Which reason labels the counter has actually been incremented under."""
+    return {sample.labels["reason"] for sample in _skip_samples()}
 
 
 @pytest.mark.parametrize("date_field", ["date_issued", "date_expired"])
@@ -2850,6 +2872,9 @@ async def test_a_malformed_optional_date_costs_the_contract_nothing(
     ).scalar_one()
     assert row.date_completed is None, label
     assert _skipped_total() == before, f"{label}: a persisted contract was counted as dropped"
+    assert _skip_reasons() <= {"malformed_date"}, (
+        f"{label}: a degraded optional date invented a new skip reason"
+    )
 
 
 async def test_a_skipped_contract_names_itself_and_the_field_in_the_log(
@@ -3259,3 +3284,49 @@ async def test_zero_persistence_records_failure_even_when_a_region_also_failed(
     assert record["regions_failed"] == 1 and record["regions_ok"] == 1
     assert record["outcome"] == "failure"
     assert record["last_success_at"] == prior
+
+
+_ABSENT = object()
+
+@pytest.mark.parametrize("field", ["date_issued", "date_expired"])
+@pytest.mark.parametrize(
+    "bad_value, shape",
+    [
+        ("not-a-date", "unreadable_string"),
+        (None, "explicit_null"),
+        (12345, "wrong_type_int"),
+        (_ABSENT, "absent_key"),
+    ],
+)
+async def test_every_shape_of_bad_required_date_is_counted_and_named(
+    db_session: AsyncSession, caplog, field: str, bad_value, shape: str
+):
+    """Counted and named for EVERY shape and BOTH required fields, not just one of each.
+
+    The persistence tests already cover these shapes, but persistence alone cannot see
+    where the skip happened. A prefilter that dropped unstorable contracts before
+    `_build_contract_rows` — a natural place to put a guard, and cheaper than building a
+    row to throw it away — still skips the contract while bypassing the shared counter
+    and warning entirely. The site loses a listing and nothing says so.
+
+    The four shapes reach the skip through three different mechanisms: a raise out of
+    the parse, a KeyError on the lookup, and the post-parse `parsed is None` guard. Any
+    instrumentation attached to fewer than all three leaks one of them silently.
+    """
+    caplog.set_level("WARNING")
+    service = _make_service()
+    before = _skipped_total()
+
+    payload = _ship_contract_dict(920280)
+    if bad_value is _ABSENT:
+        del payload[field]
+    else:
+        payload[field] = bad_value
+
+    await service._process_contracts(db_session, [payload])
+
+    assert _skipped_total() - before == 1, f"{field}/{shape} was skipped uncounted"
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "920280" in line and field in line for line in warnings
+    ), f"{field}/{shape} was skipped unnamed: {warnings}"

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -3199,3 +3199,63 @@ async def test_every_skipped_contract_is_counted_and_named_including_the_null_br
     assert any(
         "920261" in line and "date_expired" in line for line in warnings
     ), warnings
+
+
+async def test_zero_persistence_records_failure_even_when_a_region_also_failed(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """"Fetched contracts and stored none" is a failure regardless of the fetch counters.
+
+    A partial fetch is normally the better outcome than a failed one — some regions
+    answered, so `partial` keeps last_success_at moving. That makes `and regions_failed
+    == 0` a natural-looking guard to add here, preserving `partial` whenever any region
+    was already down. It is wrong: the counters describe what was FETCHED, and this run
+    wrote nothing at all, so treating it as a partial success freshens the staleness
+    clock over an empty write — the silent outage the guard exists to prevent, reached
+    through the one path that looks like a courtesy.
+
+    The all-regions-succeed case cannot see this, and neither can the existing partial
+    test, whose surviving region returns no contracts at all.
+    """
+    from fastapi_app.tests.conftest import TEST_DATABASE_URL
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    monkeypatch.setattr(
+        bg_agg,
+        "AsyncSessionLocal",
+        async_sessionmaker(create_async_engine(TEST_DATABASE_URL), expire_on_commit=False),
+        raising=False,
+    )
+
+    prior = "2026-07-18T00:00:00+00:00"
+    malformed = _ship_contract_dict(920270)
+    malformed["date_issued"] = "not-a-date"
+
+    async def _fetch(region_id, *args, **kwargs):
+        if region_id == 10000002:
+            return [malformed]          # answered, but nothing in it is storable
+        raise RuntimeError("region down")
+
+    service = _freshness_service([10000002, 10000043])
+    service.esi_client.get_public_contracts = AsyncMock(side_effect=_fetch)
+
+    store: dict = {
+        INGEST_KEY: json.dumps(
+            {
+                "finished_at": prior,
+                "outcome": "success",
+                "regions_ok": 2,
+                "regions_failed": 0,
+                "last_success_at": prior,
+            }
+        )
+    }
+    with patch.object(bg_agg.aioredis, "from_url", return_value=_FakeLockRedis(store)):
+        await service.run_aggregation()
+
+    record = json.loads(store[INGEST_KEY])
+    # Guard against a vacuous pass: the run really did see a failed region, so the
+    # counters would have produced `partial` on their own (TEST-12).
+    assert record["regions_failed"] == 1 and record["regions_ok"] == 1
+    assert record["outcome"] == "failure"
+    assert record["last_success_at"] == prior

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2890,3 +2890,146 @@ async def test_a_healthy_batch_never_touches_the_skip_counter(
     )
 
     assert _skipped_total() == before
+
+
+async def test_a_skipped_contract_is_dropped_from_ITEM_enrichment_too(
+    db_session: AsyncSession,
+):
+    """A skip has to remove the contract from the WHOLE run, not just the parent upsert.
+
+    `contract_items.contract_id` is a foreign key onto `contracts`. Skipping only the
+    parent row while the original payload list travels on to item enrichment inserts
+    children for a parent that was never written — PostgreSQL aborts the transaction and
+    every healthy sibling rolls back with it. That is the original whole-run blast radius
+    restored through a different layer, and with a worse error: an IntegrityError naming
+    a constraint instead of a ValueError naming a date.
+
+    The other skip tests cannot see this, because the shared service fixture leaves
+    `get_contract_items` returning an empty list — so no child row is ever built and the
+    foreign key is never exercised. This test arms it deliberately.
+    """
+    service = _make_service()
+    service.esi_client.get_contract_items = AsyncMock(
+        return_value=[
+            {"record_id": 9202101, "type_id": 587, "quantity": 1, "is_included": True},
+        ]
+    )
+    service.esi_client.get_universe_type = AsyncMock(
+        return_value={"name": "Tristan", "group_id": 25, "market_group_id": 1367}
+    )
+    service.esi_client.get_universe_group = AsyncMock(
+        return_value={"name": "Frigate", "category_id": 6}
+    )
+
+    healthy, malformed = _ship_contract_dict(920210), _ship_contract_dict(920211)
+    malformed["date_expired"] = "not-a-date"
+
+    await service._process_contracts(db_session, [healthy, malformed])
+
+    landed = set(
+        (
+            await db_session.execute(
+                select(Contract.contract_id).where(
+                    Contract.contract_id.in_([920210, 920211])
+                )
+            )
+        ).scalars()
+    )
+    assert landed == {920210}, "the healthy sibling was rolled back with the skip"
+    # And no orphan child was attempted for the contract that was never written.
+    orphans = (
+        await db_session.execute(
+            select(ContractItem.record_id).where(ContractItem.contract_id == 920211)
+        )
+    ).scalars().all()
+    assert orphans == []
+
+
+@pytest.mark.parametrize(
+    "bad_value, label",
+    [
+        (None, "explicit_null"),
+        (12345, "wrong_type_int"),
+        (["2026-07-01T00:00:00Z"], "wrong_type_list"),
+    ],
+)
+async def test_a_required_date_of_the_wrong_SHAPE_is_skipped_like_a_bad_string(
+    db_session: AsyncSession, bad_value, label: str
+):
+    """"Malformed" is a claim about JSON shapes, not only about unparseable strings.
+
+    Each of these reaches a different failure: an explicit null parses to None and then
+    violates NOT NULL at insert time, while a number or a list raises AttributeError
+    inside the parser. All three abort the batch if only ValueError is isolated, which
+    is the same outage under a different traceback — and all three are ordinary upstream
+    drift rather than exotic corruption.
+    """
+    service = _make_service()
+    healthy, malformed = _ship_contract_dict(920220), _ship_contract_dict(920221)
+    malformed["date_issued"] = bad_value
+
+    await service._process_contracts(db_session, [healthy, malformed])
+
+    landed = set(
+        (
+            await db_session.execute(
+                select(Contract.contract_id).where(
+                    Contract.contract_id.in_([920220, 920221])
+                )
+            )
+        ).scalars()
+    )
+    assert landed == {920220}, label
+
+
+async def test_a_required_date_that_is_absent_entirely_is_skipped(
+    db_session: AsyncSession,
+):
+    """ESI marks these required, so absence is a spec violation — and TEST-22 is the
+    record of what a spec violation costs when the writer assumes presence: a
+    price-less contract aborted every ingestion run for as long as it stayed listed.
+    Indexing the payload directly would raise KeyError past the ValueError guard."""
+    service = _make_service()
+    healthy, malformed = _ship_contract_dict(920230), _ship_contract_dict(920231)
+    del malformed["date_expired"]
+
+    await service._process_contracts(db_session, [healthy, malformed])
+
+    landed = set(
+        (
+            await db_session.execute(
+                select(Contract.contract_id).where(
+                    Contract.contract_id.in_([920230, 920231])
+                )
+            )
+        ).scalars()
+    )
+    assert landed == {920230}
+
+
+async def test_the_skip_counter_counts_contracts_rather_than_batches_or_listings(
+    db_session: AsyncSession,
+):
+    """The counter's unit is one dropped contract, and two natural instrumentation
+    choices would quietly break that.
+
+    Incrementing once per batch that contained ANY malformed date undercounts a batch
+    holding several; deduplicating by contract id — a reasonable-looking way to stop a
+    single bad listing spamming an alert — undercounts the same listing on every later
+    run, which is precisely the case that matters, since a malformed contract stays
+    listed for up to two weeks and is re-processed every hour.
+
+    Both are checked here: two skips in one batch count two, and re-processing the same
+    contract counts again.
+    """
+    service = _make_service()
+    before = _skipped_total()
+    first, second = _ship_contract_dict(920240), _ship_contract_dict(920241)
+    first["date_issued"] = "not-a-date"
+    second["date_expired"] = "also-not-a-date"
+
+    await service._process_contracts(db_session, [first, second])
+    assert _skipped_total() - before == 2, "a batch of two skips counted as one"
+
+    await service._process_contracts(db_session, [first])
+    assert _skipped_total() - before == 3, "the same listing stopped counting on re-sight"

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -3330,3 +3330,26 @@ async def test_every_shape_of_bad_required_date_is_counted_and_named(
     assert any(
         "920280" in line and field in line for line in warnings
     ), f"{field}/{shape} was skipped unnamed: {warnings}"
+
+
+async def test_a_contract_with_both_dates_malformed_counts_once(
+    db_session: AsyncSession,
+):
+    """The counter's unit is one dropped CONTRACT, not one validation error.
+
+    Every other fixture corrupts a single field, so a refactor that validated both
+    required dates — collecting errors rather than raising at the first, which is the
+    ordinary way to give better diagnostics — could increment once per error and pass
+    all of them. One contract would then read as two dropped listings, and a metric
+    that overstates data loss is as unusable as one that understates it: the number is
+    only worth alerting on if it means what its name says.
+    """
+    service = _make_service()
+    before = _skipped_total()
+    payload = _ship_contract_dict(920290)
+    payload["date_issued"] = "not-a-date"
+    payload["date_expired"] = None
+
+    await service._process_contracts(db_session, [payload])
+
+    assert _skipped_total() - before == 1, "one contract counted as more than one drop"

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -3139,3 +3139,65 @@ async def test_a_run_that_persists_something_still_records_success(
     record = json.loads(store[INGEST_KEY])
     assert record["outcome"] == "success"
     assert record["last_success_at"] == record["finished_at"]
+
+
+async def test_every_skipped_contract_is_counted_and_named_including_the_null_branch(
+    db_session: AsyncSession, caplog
+):
+    """One record per skipped contract, however that contract reached the skip.
+
+    Two skips in one batch, reaching MalformedContractDate by DIFFERENT routes: an
+    unreadable string raises out of the parse, while an explicit null parses cleanly
+    and is rejected afterwards by the `parsed is None` guard. Instrumentation hung on
+    the parser's `except` arm alone — the obvious place to put it — counts and logs the
+    first and silently drops the second.
+
+    The batch also makes rate-limiting visible: a warning budget of one per batch, a
+    reasonable-looking response to systemic corruption, would leave the second contract
+    unnamed while the counter still read two. Both signals are asserted per contract,
+    since each is the sole evidence for a listing the site will not show.
+    """
+    caplog.set_level("WARNING")
+    service = _make_service()
+    before = _skipped_total()
+
+    unreadable, explicit_null = _ship_contract_dict(920260), _ship_contract_dict(920261)
+    unreadable["date_issued"] = "not-a-date"
+    explicit_null["date_expired"] = None
+
+    await service._process_contracts(db_session, [unreadable, explicit_null])
+
+    assert _skipped_total() - before == 2, "a skip via the null branch went uncounted"
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "920260" in line and "date_issued" in line for line in warnings
+    ), warnings
+    assert any(
+        "920261" in line and "date_expired" in line for line in warnings
+    ), warnings
+
+
+async def test_a_malformed_optional_date_is_not_counted_as_a_dropped_contract(
+    db_session: AsyncSession,
+):
+    """The counter's name is "contracts dropped", and a contract that persists was not.
+
+    Counting the optional-date degrade would make the metric read as steady data loss
+    while the site is in fact serving every contract it fetched — and an alert hung on
+    a number that rises during healthy operation is an alert nobody keeps.
+    """
+    service = _make_service()
+    before = _skipped_total()
+    payload = _ship_contract_dict(920262)
+    payload["date_completed"] = "not-a-date"
+
+    await service._process_contracts(db_session, [payload])
+
+    landed = (
+        await db_session.execute(
+            select(Contract.contract_id).where(Contract.contract_id == 920262)
+        )
+    ).scalar_one_or_none()
+    assert landed == 920262, "the contract was dropped, not degraded"
+    assert _skipped_total() == before

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -3333,7 +3333,7 @@ async def test_every_shape_of_bad_required_date_is_counted_and_named(
 
 
 async def test_a_contract_with_both_dates_malformed_counts_once(
-    db_session: AsyncSession,
+    db_session: AsyncSession, caplog
 ):
     """The counter's unit is one dropped CONTRACT, not one validation error.
 
@@ -3344,6 +3344,7 @@ async def test_a_contract_with_both_dates_malformed_counts_once(
     that overstates data loss is as unusable as one that understates it: the number is
     only worth alerting on if it means what its name says.
     """
+    caplog.set_level("WARNING")
     service = _make_service()
     before = _skipped_total()
     payload = _ship_contract_dict(920290)
@@ -3353,3 +3354,17 @@ async def test_a_contract_with_both_dates_malformed_counts_once(
     await service._process_contracts(db_session, [payload])
 
     assert _skipped_total() - before == 1, "one contract counted as more than one drop"
+    assert (
+        await db_session.execute(
+            select(Contract.contract_id).where(Contract.contract_id == 920290)
+        )
+    ).scalar_one_or_none() is None
+
+    # Collapsing to one count must not also collapse to an unnamed warning: an
+    # aggregate "unreadable required dates" line satisfies the count while naming
+    # neither field, which is the diagnosis gap this policy was partly written to close.
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(
+        "920290" in line and ("date_issued" in line or "date_expired" in line)
+        for line in warnings
+    ), warnings

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -3368,3 +3368,50 @@ async def test_a_contract_with_both_dates_malformed_counts_once(
         "920290" in line and ("date_issued" in line or "date_expired" in line)
         for line in warnings
     ), warnings
+
+
+@pytest.mark.parametrize(
+    "bad_value, label",
+    [
+        ("not-a-date", "unreadable_string"),
+        (12345, "wrong_type_int"),
+    ],
+)
+async def test_a_malformed_optional_date_clears_a_previously_stored_one(
+    db_session: AsyncSession, bad_value, label: str
+):
+    """The degrade has to hold on RE-SIGHTING, which is the only path production uses.
+
+    Every contract is re-fetched each run, so the upsert's ON CONFLICT arm is where a
+    stored date_completed actually meets a malformed one — and that arm is different SQL
+    from the fresh insert the other optional-date tests exercise. Adding date_completed
+    to preserve_on_null would keep the old value there, which is a defensible-sounding
+    change (the column is exactly the shape preserve_on_null exists for: nullable, and
+    NULL can mean "unknown this run"). It is wrong here: the policy says an unreadable
+    optional date is stored as the NULL ESI would have sent, not that the last readable
+    value is retained forever.
+
+    Seeded through the same writer rather than by hand, so the "before" state is one
+    ingestion can really produce (TEST-18).
+    """
+    service = _make_service()
+    first = _ship_contract_dict(920300)
+    first["date_completed"] = "2026-07-05T12:30:00Z"
+    await service._process_contracts(db_session, [first])
+
+    stored = (
+        await db_session.execute(
+            select(Contract.date_completed).where(Contract.contract_id == 920300)
+        )
+    ).scalar_one()
+    assert stored is not None, "the fixture never stored a value to be cleared"
+
+    resighted = _ship_contract_dict(920300)
+    resighted["date_completed"] = bad_value
+    await service._process_contracts(db_session, [resighted])
+
+    assert (
+        await db_session.execute(
+            select(Contract.date_completed).where(Contract.contract_id == 920300)
+        )
+    ).scalar_one() is None, f"{label}: a stale completion date survived the degrade"

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2936,6 +2936,10 @@ async def test_a_skipped_contract_is_dropped_from_ITEM_enrichment_too(
         ).scalars()
     )
     assert landed == {920210}, "the healthy sibling was rolled back with the skip"
+    # Excluded from the RUN, not filtered out just before persistence: a late
+    # filter would still spend an ESI item fetch, plus type and group resolution,
+    # on a contract already known to be unstorable.
+    service.esi_client.get_contract_items.assert_awaited_once_with(920210)
     # And no orphan child was attempted for the contract that was never written.
     orphans = (
         await db_session.execute(
@@ -3033,3 +3037,105 @@ async def test_the_skip_counter_counts_contracts_rather_than_batches_or_listings
 
     await service._process_contracts(db_session, [first])
     assert _skipped_total() - before == 3, "the same listing stopped counting on re-sight"
+
+
+async def test_a_run_that_persists_nothing_records_failure_though_the_fetch_worked(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch,
+):
+    """Skipping EVERY contract is an outage, and must not be recorded as a success.
+
+    This is the case the whole per-field policy is most likely to meet. The realistic
+    triggers for an unreadable date — an ESI serialization change, a compatibility-date
+    bump — are GLOBAL, so they do not corrupt one contract, they corrupt all of them.
+    Under the old whole-batch abort that produced a loud failure: outcome `failure`,
+    last_success_at frozen, `data_stale` true within two hours.
+
+    Skipping per contract removes the abort, and with it the signal — the fetch
+    succeeded, no exception escaped, and the run would report success while having
+    written nothing at all. That trades a loud total outage for a silent one, in
+    exactly the scenario most likely to occur, which is the opposite of what bounding
+    the blast radius was for.
+
+    A run that fetched contracts and persisted none has not ingested anything,
+    whatever the reason.
+    """
+    from fastapi_app.tests.conftest import TEST_DATABASE_URL
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    # run_aggregation builds its OWN session from AsyncSessionLocal, which points at the
+    # real DATABASE_URL. Without this bind the run dies on "relation contracts does not
+    # exist" and records a failure — so the outcome assertion below would pass for a
+    # reason that has nothing to do with what was persisted (TEST-12).
+    monkeypatch.setattr(
+        bg_agg,
+        "AsyncSessionLocal",
+        async_sessionmaker(create_async_engine(TEST_DATABASE_URL), expire_on_commit=False),
+        raising=False,
+    )
+
+    service = _freshness_service([10000002])
+    prior = "2026-07-18T00:00:00+00:00"
+
+    malformed = _ship_contract_dict(920250)
+    malformed["date_issued"] = "not-a-date"
+    service.esi_client.get_public_contracts = AsyncMock(return_value=[malformed])
+
+    store: dict = {
+        INGEST_KEY: json.dumps(
+            {
+                "finished_at": prior,
+                "outcome": "success",
+                "regions_ok": 1,
+                "regions_failed": 0,
+                "last_success_at": prior,
+            }
+        )
+    }
+    with patch.object(bg_agg.aioredis, "from_url", return_value=_FakeLockRedis(store)):
+        await service.run_aggregation()
+
+    record = json.loads(store[INGEST_KEY])
+    assert record["outcome"] == "failure", "an ingest that wrote nothing reported success"
+    # And the staleness clock keeps measuring against the last REAL refresh, so
+    # /ready reports data_stale rather than resetting on an empty run.
+    assert record["last_success_at"] == prior
+
+
+async def test_a_run_that_persists_something_still_records_success(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch,
+):
+    """The guard must fire on "nothing landed", not on "anything was skipped".
+
+    Without this, the natural over-correction — failing any run that skipped a contract
+    — turns one bad listing into a permanently red freshness signal, which is the same
+    alarm fatigue by another route.
+    """
+    from fastapi_app.tests.conftest import TEST_DATABASE_URL
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    # run_aggregation builds its OWN session from AsyncSessionLocal, which points at the
+    # real DATABASE_URL. Without this bind the run dies on "relation contracts does not
+    # exist" and records a failure — so the outcome assertion below would pass for a
+    # reason that has nothing to do with what was persisted (TEST-12).
+    monkeypatch.setattr(
+        bg_agg,
+        "AsyncSessionLocal",
+        async_sessionmaker(create_async_engine(TEST_DATABASE_URL), expire_on_commit=False),
+        raising=False,
+    )
+
+    service = _freshness_service([10000002])
+    healthy = _ship_contract_dict(920251)
+    malformed = _ship_contract_dict(920252)
+    malformed["date_expired"] = "not-a-date"
+    service.esi_client.get_public_contracts = AsyncMock(
+        return_value=[healthy, malformed]
+    )
+
+    store: dict = {}
+    with patch.object(bg_agg.aioredis, "from_url", return_value=_FakeLockRedis(store)):
+        await service.run_aggregation()
+
+    record = json.loads(store[INGEST_KEY])
+    assert record["outcome"] == "success"
+    assert record["last_success_at"] == record["finished_at"]

--- a/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
+++ b/app/backend/src/fastapi_app/tests/services/test_background_aggregation.py
@@ -2806,18 +2806,40 @@ async def test_a_malformed_required_date_skips_only_its_own_contract(
     assert landed == {920201, 920203}
 
 
+@pytest.mark.parametrize(
+    "bad_value, label",
+    [
+        ("not-a-date", "unreadable_string"),
+        (12345, "wrong_type_int"),
+        (["2026-07-05T12:30:00Z"], "wrong_type_list"),
+    ],
+)
 async def test_a_malformed_optional_date_costs_the_contract_nothing(
-    db_session: AsyncSession,
+    db_session: AsyncSession, bad_value, label: str
 ):
     """date_completed is optional, nullable, and absent from every public payload.
 
     A contract is not worth withholding from the site over a field the public route
     never sends and no read path consults — so the malformed value becomes the NULL it
     would have been had ESI simply omitted it, and the contract lands.
+
+    Parametrized over JSON SHAPES, not just unreadable strings, and deliberately over
+    the same shapes as the required-date test: the two parsers are separate functions,
+    so narrowing this one to `except ValueError` — the conventional exception for
+    `fromisoformat`, reachable without ever seeing a test — passes every string case
+    while an integer or a list raises AttributeError and aborts the run. That is the
+    outage this policy exists to prevent, surviving in the half of it that is supposed
+    to be the forgiving one.
+
+    The counter is asserted unchanged in the same test rather than in a sibling: the
+    claim is that a degraded optional date costs the contract NOTHING, and a metric
+    reading "contracts dropped" while the contract persists is part of that cost. An
+    alert hung on a number that rises during healthy operation is an alert nobody keeps.
     """
     service = _make_service()
+    before = _skipped_total()
     payload = _ship_contract_dict(920204)
-    payload["date_completed"] = "not-a-date"
+    payload["date_completed"] = bad_value
 
     await service._process_contracts(db_session, [payload])
 
@@ -2826,7 +2848,8 @@ async def test_a_malformed_optional_date_costs_the_contract_nothing(
             select(Contract).where(Contract.contract_id == 920204)
         )
     ).scalar_one()
-    assert row.date_completed is None
+    assert row.date_completed is None, label
+    assert _skipped_total() == before, f"{label}: a persisted contract was counted as dropped"
 
 
 async def test_a_skipped_contract_names_itself_and_the_field_in_the_log(
@@ -3176,28 +3199,3 @@ async def test_every_skipped_contract_is_counted_and_named_including_the_null_br
     assert any(
         "920261" in line and "date_expired" in line for line in warnings
     ), warnings
-
-
-async def test_a_malformed_optional_date_is_not_counted_as_a_dropped_contract(
-    db_session: AsyncSession,
-):
-    """The counter's name is "contracts dropped", and a contract that persists was not.
-
-    Counting the optional-date degrade would make the metric read as steady data loss
-    while the site is in fact serving every contract it fetched — and an alert hung on
-    a number that rises during healthy operation is an alert nobody keeps.
-    """
-    service = _make_service()
-    before = _skipped_total()
-    payload = _ship_contract_dict(920262)
-    payload["date_completed"] = "not-a-date"
-
-    await service._process_contracts(db_session, [payload])
-
-    landed = (
-        await db_session.execute(
-            select(Contract.contract_id).where(Contract.contract_id == 920262)
-        )
-    ).scalar_one_or_none()
-    assert landed == 920262, "the contract was dropped, not degraded"
-    assert _skipped_total() == before


### PR DESCRIPTION
Sam's decision on the malformed-date blast radius: **a per-field policy**, because the three parsed dates are not interchangeable.

## What was wrong

An unparseable date raised out of `_build_contract_rows` and aborted the whole run.

- `_fetch_regions` concatenates **every page of every configured region** before a single `_process_contracts` call, so the radius was every region at once.
- It **did not self-heal**: the ETag validator is stored at *fetch* time, and a 304 serves the cached body straight back into processing — so the same contract re-failed every hour for as long as it stayed listed. For a public contract that is **up to two weeks**.
- Meanwhile the corpus decays to empty: ingested contracts expire out under the read-time `date_expired > now()` filter, nothing replaces them, and no watermark advances so bought contracts linger as dead listings.
- Nobody finds out. `/ready` reports `last_ingest_outcome: "failure"` and `data_stale: true` after 2h but **deliberately returns 200** (observability-spec §2.5), no alert rule exists in the repo, and the frontend has no staleness surface at all.

## The policy

| Field | ESI | Column | Malformed → |
|---|---|---|---|
| `date_issued` | required | NOT NULL | **skip the contract**, counted + named |
| `date_expired` | required | NOT NULL, and the liveness predicate + default sort | **skip the contract**, counted + named |
| `date_completed` | optional | nullable, never sent on the public route | **NULL** — costs the contract nothing |

There is no honest value to substitute for a required date, and a NULL/sentinel expiry would be worse than skipping: the contract would be filtered out forever or shown forever.

## Skips are diagnosable, which the old failure was not

`MalformedContractDate` carries the contract id and the field, so the warning names both. A bare `ValueError` rendered only the offending *string* — leaving an operator unable to aim the one workaround available to them (dropping the region from `AGGREGATION_REGION_IDS`), because nothing in it named a region or a contract.

## Skips are countable

`hangar_bay_ingest_contracts_skipped_total`, **labelled by reason from the start** — a Prometheus label set cannot be widened later without breaking every recorded series. A skip that only logs is silent data loss with extra steps.

## Verification

- **TDD**: six tests written first and watched **RED**, then the implementation.
- **Five mutants killed**, each isolated to its own test: the skip removed (batch aborts again), the optional date treated as required, the counter never incremented, the counter incremented per *contract* rather than per *skip*, and the warning stripped of its id and field.
- backend `pytest`: **775 passed**; `pdm run lint`: clean. Frontend untouched.
- Lint caught a real defect during the work — `B042`: the exception must pass all args to `super().__init__()` to survive pickle/copy. Fixed properly (readable form moved to `__str__`), not suppressed.

## One test removed, deliberately

`test_a_malformed_esi_date_takes_the_whole_batch_down_with_it` characterized the behavior this change replaces. It is **removed, not repaired** — and its inverse is covered: a batch that still aborted would fail the sibling assertions in the new skip tests, which seed a healthy contract both **before and after** the malformed one.

## Two things I did NOT do — flagging rather than deciding

1. **A run that skipped contracts is still recorded `success`.** Arguably a run that dropped listings is not fully successful, but changing the outcome taxonomy is beyond this decision and would move the readiness signal. The counter is the signal today.
2. **No alert rule.** The metric now exists and the gauge already did; whether to alert on either lives in Grafana Cloud, outside this repo. This remains the gap that made the original failure silent — the parsing fix bounds the damage, it does not make anyone aware of it.

## Merge classification

`Review — data-integrity path`. This changes what the ingestion writer persists and introduces a path where a real listing is deliberately not stored. Held for Sam; not agent-merged.


---

# Adversarial review: 10 rounds, 14 findings, all real — **CONVERGED**

Backend **775 → 798**. Findings per round: **3, 2, 2, 1, 1, 2, 1, 1, 1, 0**. Round 10 returned an explicit `CONVERGED` verdict against a scope bounded to the three authorized sentences.

## The two that were production defects, not test gaps

1. **My fix reintroduced the blast radius through the FK.** I filtered the skipped contract out of `contract_values`, but `_process_contracts` passed the *unfiltered* payload list to item enrichment — so children were inserted for a parent that was never written, PostgreSQL aborted, and healthy siblings rolled back. Same outage, worse error. Invisible to my tests because the shared fixture leaves `get_contract_items` returning `[]`. Fixed by deriving survivors from what actually persisted.

2. **I made the modal failure silent.** The realistic causes of an unreadable date — an ESI format change, a compatibility-date bump — are *global*: they corrupt every contract at once. Skipping per contract meant that case recorded **success** while writing nothing, advancing `last_ingest_success_timestamp` and resetting the staleness clock over an empty write. A loud total outage became a silent one in exactly the likeliest scenario. Now a run that fetched contracts and stored none records failure — but *not* a run that merely skipped some, which would paint the freshness signal permanently red.

## The most instructive test gaps

- **Testing the insert path is not testing the path production uses.** Every optional-date test inserted a fresh contract; production only re-sights, and the `ON CONFLICT` arm is different SQL. Under the `preserve_on_null | {"date_completed"}` mutant the full suite reported **2 failed, 796 passed** — only the new cases caught it.
- **One behavior, two control-flow routes.** An unreadable date *raises*; an explicit `null` parses cleanly and is rejected by a later guard. Instrumentation hung on the parser's `except` arm — the obvious place — counted and logged one and silently dropped the other.
- **A labelled Counter read through one label series is a projection.** A mutant incrementing a *different* `reason` raises the total dashboards query while a `reason="malformed_date"` delta stays flat. Now summed across `collect()`, plus an assertion on the label set.
- **Asserting an outcome doesn't constrain the mechanism.** A prefilter before `_build_contract_rows` skips the contract identically while bypassing the counter and warning entirely — the site loses a listing and nothing says so.
- **A fix can reintroduce what it fixed.** Counting once per contract invites an aggregate warning naming no field, reopening the diagnosis gap the policy exists to close.

## Process notes worth carrying

- A test asserting `run_aggregation`'s outcome must bind `AsyncSessionLocal` to the test database **and** request `db_session` (which creates the schema). Without both, the run dies on `relation "contracts" does not exist` and records a failure — so an outcome-is-failure assertion passes for an unrelated reason. Mine did, until it was checked.
- A mutation harness whose snapshot path fails to resolve **leaves the mutant on disk** when the restore raises. One did; only an immediate grep caught it. Snapshot beside the file being mutated, and assert the snapshot exists before mutating anything.
- `git checkout -- <file>` restores from HEAD and discards uncommitted work. TEST-12 says this in writing; I did it anyway and lost three fixes. Tests-first is what made the loss loud instead of silent.

## Final state

- backend `pytest`: **798 passed**; `pdm run lint`: clean; frontend untouched.
- Every new test mutation-verified, restores in `finally`, tree checked clean after each run.

## Merge classification

`Review — data-integrity path`. **Held for Sam. Not agent-merged.**
